### PR TITLE
Remove phantom tag tools that lack API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This MCP server allows AI assistants like Claude, Cursor, and GitHub Copilot to 
 
 ## Features
 
-- **Full Fizzy API Coverage**: 47 tools covering Boards, Cards, Card Actions, Comments, Reactions, Steps, Columns, Tags, Users, and Notifications
+- **Full Fizzy API Coverage**: 44 tools covering Boards, Cards, Card Actions, Comments, Reactions, Steps, Columns, Tags, Users, and Notifications
 - **Multiple Transport Protocols**: Stdio (CLI/IDE), HTTP (Streamable), and SSE (deprecated)
 - **Multi-User Support**: HTTP and SSE transports support multiple users with per-user authentication
 - **Flexible Deployment**: Run locally (Node.js) or deploy globally (Cloudflare Workers)
@@ -578,13 +578,10 @@ npx fizzy-mcp --transport http --port 3000
 | `fizzy_update_column` | Update column name/color |
 | `fizzy_delete_column` | Delete a column |
 
-### Tags (4)
+### Tags (1)
 | Tool | Description |
 |------|-------------|
 | `fizzy_get_tags` | List all tags in an account |
-| `fizzy_get_board_tags` | List tags used on a board |
-| `fizzy_create_tag` | Create a new tag |
-| `fizzy_delete_tag` | Delete a tag |
 
 ### Users (4)
 | Tool | Description |

--- a/src/cloudflare/mcp-session.ts
+++ b/src/cloudflare/mcp-session.ts
@@ -288,9 +288,6 @@ export class McpSessionDO extends DurableObject<Env> {
       
       // Tag Tools
       { name: "fizzy_get_tags", description: "Get all tags in an account", inputSchema: { type: "object", properties: { account_slug: { type: "string" } }, required: ["account_slug"] } },
-      { name: "fizzy_get_board_tags", description: "Get all tags used on a specific board", inputSchema: { type: "object", properties: { account_slug: { type: "string" }, board_id: { type: "string" } }, required: ["account_slug", "board_id"] } },
-      { name: "fizzy_create_tag", description: "Create a new tag in an account", inputSchema: { type: "object", properties: { account_slug: { type: "string" }, title: { type: "string" } }, required: ["account_slug", "title"] } },
-      { name: "fizzy_delete_tag", description: "Delete a tag from an account", inputSchema: { type: "object", properties: { account_slug: { type: "string" }, tag_id: { type: "string" } }, required: ["account_slug", "tag_id"] } },
       
       // User Tools
       { name: "fizzy_get_users", description: "Get all active users in an account", inputSchema: { type: "object", properties: { account_slug: { type: "string" } }, required: ["account_slug"] } },


### PR DESCRIPTION
## Summary

Remove three tools from Cloudflare `mcp-session.ts` that were declared but never implemented, as the official Fizzy API doesn't support them:

- `fizzy_get_board_tags`: No endpoint exists to get tags per board
- `fizzy_create_tag`: POST /tags returns 404 (tags are created implicitly via `toggle_card_tag`)
- `fizzy_delete_tag`: DELETE /tags returns 404 (no tag deletion API)

## Problem

These tools were listed in `getAvailableTools()` but would throw 'Unknown tool' errors when invoked since `executeToolCall()` had no handlers for them.

## Changes

- Removed the 3 phantom tool definitions from `src/cloudflare/mcp-session.ts`
- Updated `README.md` to reflect the correct tool count (44 instead of 47)
- Updated Tags section heading from "Tags (4)" to "Tags (1)"

## Testing

All 357 tests pass.