### PR TITLE
fix: use board_id query param instead of nonexistent board cards endpoint

### DIFF
--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -490,23 +490,7 @@ export class FizzyClient {
     );
   }
 
-  /**
-   * Get all cards on a specific board with optional filters
-   * @endpoint GET /:account_slug/boards/:board_id/cards
-   * @see https://github.com/basecamp/fizzy/blob/main/docs/API.md#get-account_slugboardsboard_idcards
-   */
-  async getBoardCards(
-    accountSlug: string,
-    boardId: string,
-    filters?: CardFilterOptions
-  ): Promise<FizzyCard[]> {
-    const slug = this.normalizeSlug(accountSlug);
-    const queryString = filters ? this.buildQueryString(filters) : "";
-    return this.request<FizzyCard[]>(
-      "GET",
-      `/${slug}/boards/${boardId}/cards${queryString}`
-    );
-  }
+
 
   /**
    * Get a specific card

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -213,6 +213,7 @@ export interface FizzyIdentity {
 // Card filtering options
 export interface CardFilterOptions {
   [key: string]: string | string[] | undefined;
+  board_id?: string;
   indexed_by?: "all" | "closed" | "not_now" | "stalled" | "postponing_soon" | "golden";
   status?: "draft" | "published" | "archived";
   column_id?: string;

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -76,6 +76,7 @@ export const toolHandlers: Record<string, ToolHandler> = {
   // ============ Card Tools ============
   fizzy_get_cards: async (client, args) => {
     const filters = {
+      board_id: args.board_id as string,
       indexed_by: args.indexed_by as "all" | "closed" | "not_now" | "stalled" | "postponing_soon" | "golden" | undefined,
       status: args.status as "draft" | "published" | "archived" | undefined,
       column_id: args.column_id as string,
@@ -85,9 +86,6 @@ export const toolHandlers: Record<string, ToolHandler> = {
       due_after: args.due_after as string,
       search: args.search as string,
     };
-    if (args.board_id) {
-      return client.getBoardCards(args.account_slug as string, args.board_id as string, filters);
-    }
     return client.getCards(args.account_slug as string, filters);
   },
 


### PR DESCRIPTION
## Summary
- The `GET /:account_slug/boards/:board_id/cards` endpoint doesn't exist in the Fizzy API, causing 404 errors when `board_id` was passed to `fizzy_get_cards`
- Changed to pass `board_id` as a query parameter on `GET /:account_slug/cards?board_id=...`, which is the correct API behavior
- Removed the dead `getBoardCards` client method and added `board_id` to `CardFilterOptions`

## Test plan
- [x] Verified `GET /boards/:id/cards` returns 404 against live API
- [x] Verified `GET /cards?board_id=...` returns 200 with correct filtered results
- [x] All 124 existing tests pass (`tests/tools`, `tests/client`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)