### PR TITLE
fix: rename step field from description to content to match Fizzy API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ temp/
 # Cloudflare Wrangler local development files
 .dev.vars
 .wrangler/
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+@AGENTS.local.md
+# AGENTS.md
+
+## Project Overview
+
+fizzy-mcp is an MCP (Model Context Protocol) server for the Fizzy project management tool. It exposes 40+ tools for managing boards, cards, columns, steps, comments, reactions, tags, and notifications.
+
+## Tech Stack
+
+- **Language:** TypeScript 5.7 (ES2022, ESM modules)
+- **Runtime:** Node.js 18+ (standard), Cloudflare Workers (production)
+- **MCP SDK:** @modelcontextprotocol/sdk
+- **Validation:** Zod
+- **Testing:** Vitest
+- **Build:** tsc (compile), tsx (dev)
+
+## Architecture
+
+```
+src/
+├── index.ts              # CLI entry point, transport selection
+├── server.ts             # MCP server setup, tool registration
+├── client/
+│   ├── fizzy-client.ts   # HTTP client with retry, ETag caching
+│   └── types.ts          # API request/response interfaces
+├── tools/
+│   ├── definitions.ts    # Tool metadata (name, description, annotations)
+│   ├── schemas.ts        # Zod input schemas
+│   └── handlers.ts       # Tool execution logic
+├── transports/
+│   ├── stdio.ts          # IDE integrations (Cursor, VS Code)
+│   ├── sse.ts            # Server-Sent Events (multi-user)
+│   └── http.ts           # Streamable HTTP (multi-user)
+├── utils/
+│   ├── errors.ts         # Typed error classes (FizzyAPIError, etc.)
+│   ├── logger.ts         # Structured stderr logging
+│   ├── security.ts       # CORS, auth, localhost binding
+│   ├── session-manager.ts
+│   └── etag-cache.ts
+└── cloudflare/           # Workers deployment (Durable Objects)
+```
+
+### Key flow
+
+1. `server.ts` registers tools from `tools/definitions.ts`
+2. Each tool call dispatches through `executeToolHandler()` in `tools/handlers.ts`
+3. Handlers call `FizzyClient` methods which make HTTP requests to the Fizzy API
+4. Responses are formatted as MCP text content
+
+### Tool system
+
+Tools are defined across three files that must stay in sync:
+- **`definitions.ts`** — tool name, title, description, schema reference, annotations
+- **`schemas.ts`** — Zod schema for input validation (field names here are what MCP clients send)
+- **`handlers.ts`** — flat `Record<toolName, handler>` mapping; maps MCP args to client method calls
+
+When adding or modifying a tool, update all three files.
+
+### Types
+
+- Request types (`Create*Request`, `Update*Request`) in `types.ts` must match the Fizzy API field names exactly — these are serialized directly into the HTTP request body
+- Response types (`Fizzy*`) must match the API's JSON response fields
+- Zod schemas in `schemas.ts` define the MCP-facing field names
+
+## Commands
+
+```shell
+npm test              # Unit tests (excludes integration/cloudflare)
+npm run test:all      # All tests
+npm run build         # TypeScript compile
+npm run dev           # Dev server with tsx watch
+npm run start:stdio   # stdio transport
+npm run start:sse     # SSE transport (port 3000)
+npm run start:http    # Streamable HTTP transport (port 3000)
+```
+
+## Environment Variables
+
+- `FIZZY_ACCESS_TOKEN` — required for stdio transport
+- `FIZZY_BASE_URL` — API base URL (default: `https://app.fizzy.do`)
+- `MCP_TRANSPORT` — default transport (default: `stdio`)
+- `MCP_ALLOWED_ORIGINS` — CORS origins (default: `*`)
+- `MCP_AUTH_TOKEN` — optional client bearer token
+- `LOG_LEVEL` — `debug`/`info`/`warn`/`error` (default: `info`)
+
+## Code Conventions
+
+- Type-only imports/exports must use `export type` / `import type` — tsx strips value exports of interfaces at runtime
+- Logging goes to stderr (never stdout — it interferes with stdio transport)
+- `FizzyClient` is passed into handlers via dependency injection, not imported as a global
+- Security: localhost binding by default, origin validation, per-user token isolation for HTTP/SSE transports
+- Error classes in `utils/errors.ts` carry status codes and support retry detection
+
+## Testing
+
+Tests live in `/tests` mirroring the `src/` structure. Use `vitest` globals (no imports needed for `describe`/`it`/`expect`). Integration tests in `tests/integration/` hit the real API and are excluded from the default test run.

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,8 +219,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251210.0.tgz",
       "integrity": "sha512-EGf2lWqeVO48LjDYFl1peSbi/AvQFDJ1vj+etwRAGqLjGWgq+R1fwFfLCjXr7tMsX8aHykE17XpCAVuroKpZoQ==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1549,7 +1548,6 @@
       "integrity": "sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2213,7 +2211,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2336,7 +2333,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3963,7 +3959,6 @@
       "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "exsolve": "^1.0.1",
@@ -4003,7 +3998,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4517,7 +4511,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -4617,7 +4610,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -5232,7 +5224,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -96,7 +96,7 @@ export interface FizzyReaction {
 
 export interface FizzyStep {
   id: string;
-  description: string;
+  content: string;
   completed: boolean;
   completed_at?: string;
   creator: FizzyUser;
@@ -155,11 +155,11 @@ export interface CreateTagRequest {
 }
 
 export interface CreateStepRequest {
-  description: string;
+  content: string;
 }
 
 export interface UpdateStepRequest {
-  description?: string;
+  content?: string;
   completed?: boolean;
 }
 

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -280,7 +280,7 @@ export const toolHandlers: Record<string, ToolHandler> = {
 
   fizzy_create_step: async (client, args) => {
     return client.createStep(args.account_slug as string, args.card_number as string, {
-      description: (args.content || args.description) as string,
+      content: args.content as string,
     });
   },
 
@@ -290,7 +290,7 @@ export const toolHandlers: Record<string, ToolHandler> = {
       args.card_number as string,
       args.step_id as string,
       {
-        description: (args.content || args.description) as string,
+        content: args.content as string,
         completed: args.completed as boolean,
       }
     );

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -7,5 +7,5 @@ export * from "./sse.js";
 export * from "./http.js";
 
 // Re-export security types for consumers
-export { SecurityOptions } from "../utils/security.js";
+export type { SecurityOptions } from "../utils/security.js";
 


### PR DESCRIPTION
## Summary

- Renames `description` to `content` in `CreateStepRequest`, `UpdateStepRequest`, and `FizzyStep` response type to match the official Fizzy API field name
- Updates `fizzy_create_step` and `fizzy_update_step` handlers to pass `content` instead of `description`
- Fixes type-only re-export of `SecurityOptions` in transports index (`export type` instead of `export`) that prevented `tsx` from running the server locally

## Test plan

- [x] Verified `fizzy_create_step` no longer returns 400 Bad Request via MCP Inspector
- [x] Verified `fizzy_update_step` sends correct field name
- [ ] Run full test suite

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)