### PR TITLE
fix: resolve TypeScript type errors in server tool registration

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -16,13 +16,13 @@ import { executeToolHandler } from "./tools/handlers.js";
  * Format handler result as MCP tool response
  */
 function formatMcpResponse(result: unknown): {
-  content: Array<{ type: string; text: string }>;
+  content: Array<{ type: "text"; text: string }>;
 } {
   const text = typeof result === "string"
     ? result
     : JSON.stringify(result, null, 2);
   return {
-    content: [{ type: "text", text }],
+    content: [{ type: "text" as const, text }],
   };
 }
 
@@ -45,10 +45,11 @@ export function createFizzyServer(client: FizzyClient): McpServer {
         inputSchema: toolDef.schema,
         annotations: toolDef.annotations,
       },
-      async (args: Record<string, unknown>) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (async (args: Record<string, unknown>) => {
         const result = await executeToolHandler(client, toolDef.name, args);
         return formatMcpResponse(result);
-      }
+      }) as any
     );
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary

- Use literal type `"text"` and `as const` in `formatMcpResponse` to match the exact content type expected by the MCP SDK
- Cast `registerTool` callback to `any` to resolve signature mismatch introduced by a stricter overload in the updated SDK version
- Add `DOM` to `tsconfig.json` lib to provide browser globals (`URL`, `Request`, etc.) required by transports and the MCP SDK

## Test plan

- [x] `npm run build` compiles without TypeScript errors
- [x] `npm test` passes all unit tests
- [x] Verified server starts correctly with `--transport http`