### PR TITLE
fix: get_cards filters silently ignored — send plural board_ids[]/column_ids[]/terms[] params

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ npx fizzy-mcp --transport http --port 3000
 ### Cards (6)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_cards` | List cards with optional filters (status, column, assignees, tags, search) |
+| `fizzy_get_cards` | List cards with optional filters (board, indexed_by, column, assignees, tags, search) |
 | `fizzy_get_card` | Get card details including description, assignees, tags |
 | `fizzy_create_card` | Create a new card with title, description, status, column, assignees, tags, due date |
 | `fizzy_update_card` | Update any card property |

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -210,16 +210,18 @@ export interface FizzyIdentity {
   accounts: FizzyAccount[];
 }
 
-// Card filtering options
-export interface CardFilterOptions {
-  [key: string]: string | string[] | undefined;
-  board_id?: string;
+// Card filtering options — GET /:account_slug/cards
+// The filter params this client currently exposes. Array-valued filters use the
+// API's plural form (Rails strong params silently drop singular keys like
+// board_id/column_id).
+// The upstream API also accepts other params (card_ids, creator_ids, closer_ids,
+// assignment_status, sorted_by, creation, closure) not yet exposed here.
+// See https://github.com/basecamp/fizzy/blob/main/docs/api/sections/cards.md
+export type CardFilterOptions = {
+  board_ids?: string[];
+  column_ids?: string[];
+  terms?: string[];
   indexed_by?: "all" | "closed" | "not_now" | "stalled" | "postponing_soon" | "golden";
-  status?: "draft" | "published" | "archived";
-  column_id?: string;
   assignee_ids?: string[];
   tag_ids?: string[];
-  due_before?: string;
-  due_after?: string;
-  search?: string;
-}
+};

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -129,9 +129,8 @@ export const TOOL_DEFINITIONS = {
       title: "List Cards",
       description:
         "Get all cards in an account with optional filtering by board, indexed_by (e.g., 'golden' for priority cards), " +
-        "status, column, assignees, tags, due dates, or search query. " +
-        "Use board_id to scope results to a specific board. " +
-        "Use due_before/due_after for deadline-based filtering (e.g., overdue cards, upcoming due dates).",
+        "column, assignees, tags, or search terms. " +
+        "Use board_id to scope results to a specific board and column_id to scope to a workflow column.",
       schema: schemas.getCardsSchema,
       annotations: {
         readOnlyHint: true,

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -9,7 +9,7 @@
  */
 
 import type { FizzyClient } from "../client/fizzy-client.js";
-import { COLUMN_COLORS, type ColumnColor } from "../client/types.js";
+import { COLUMN_COLORS, type ColumnColor, type CardFilterOptions } from "../client/types.js";
 import { resolveCardNumber } from "../utils/card-resolver.js";
 
 /**
@@ -75,16 +75,28 @@ export const toolHandlers: Record<string, ToolHandler> = {
 
   // ============ Card Tools ============
   fizzy_get_cards: async (client, args) => {
-    const filters = {
-      board_id: args.board_id as string,
-      indexed_by: args.indexed_by as "all" | "closed" | "not_now" | "stalled" | "postponing_soon" | "golden" | undefined,
-      status: args.status as "draft" | "published" | "archived" | undefined,
-      column_id: args.column_id as string,
-      assignee_ids: args.assignee_ids as string[],
-      tag_ids: args.tag_ids as string[],
-      due_before: args.due_before as string,
-      due_after: args.due_after as string,
-      search: args.search as string,
+    // The Cloudflare transport executes raw args without zod validation, so stale
+    // clients sending these removed fields must get a visible error here rather
+    // than a silently unfiltered payload. The stdio/Node MCP SDK path strips
+    // unknown keys before the handler runs, so this only fires there if a
+    // pre-validation bug ever reintroduces one of these fields.
+    const unsupported = ["status", "due_before", "due_after"].filter(
+      (key) => args[key] !== undefined
+    );
+    if (unsupported.length > 0) {
+      throw new Error(
+        `Unsupported filter(s): ${unsupported.join(", ")}. ` +
+        `The Fizzy cards API cannot filter by status or due date. ` +
+        `Card listings always contain published cards; use indexed_by="closed" for closed cards.`
+      );
+    }
+    const filters: CardFilterOptions = {
+      board_ids: args.board_id ? [args.board_id as string] : undefined,
+      column_ids: args.column_id ? [args.column_id as string] : undefined,
+      terms: args.search ? [args.search as string] : undefined,
+      indexed_by: args.indexed_by as CardFilterOptions["indexed_by"],
+      assignee_ids: args.assignee_ids as string[] | undefined,
+      tag_ids: args.tag_ids as string[] | undefined,
     };
     return client.getCards(args.account_slug as string, filters);
   },

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -72,15 +72,6 @@ export const cardStatusSchema = z
     "'archived' = completed/closed (hidden from active view)"
   );
 
-export const cardStatusFilterSchema = z
-  .enum(["draft", "published", "archived"])
-  .optional()
-  .describe(
-    "Optional filter to limit results by card status. " +
-    "Omit to include all statuses. " +
-    "'draft' = unpublished cards, 'published' = active cards, 'archived' = closed cards"
-  );
-
 // Indexed by schema for special card filters
 export const indexedBySchema = z
   .enum(["all", "closed", "not_now", "stalled", "postponing_soon", "golden"])
@@ -91,7 +82,7 @@ export const indexedBySchema = z
     "'closed' = only closed/archived cards, " +
     "'not_now' = cards in Not Now triage, " +
     "'stalled' = cards with no recent activity, " +
-    "'postponing_soon' = cards with upcoming due dates, " +
+    "'postponing_soon' = cards nearing their board's auto-postpone period (about to move to Not Now), " +
     "'golden' = priority/important cards marked as golden"
   );
 
@@ -146,7 +137,6 @@ export const getCardsSchema = z.object({
     "Omit to include cards from all boards."
   ),
   indexed_by: indexedBySchema,
-  status: cardStatusFilterSchema,
   column_id: z.string().optional().describe(
     "Filter cards by workflow column. Only returns cards in the specified column. " +
     "Omit to include cards from all columns and triage."
@@ -161,19 +151,8 @@ export const getCardsSchema = z.object({
     "Only returns cards that have ANY of the specified tags (OR logic). " +
     "Omit to include cards regardless of tags."
   ),
-  due_before: z.string().optional().describe(
-    "Filter cards with due dates on or before this date (ISO 8601 format, e.g., '2026-04-10'). " +
-    "Useful for finding cards due soon or overdue. " +
-    "Omit to ignore due date upper bound."
-  ),
-  due_after: z.string().optional().describe(
-    "Filter cards with due dates on or after this date (ISO 8601 format, e.g., '2026-04-01'). " +
-    "Useful for scoping to a date range when combined with due_before. " +
-    "Omit to ignore due date lower bound."
-  ),
   search: z.string().optional().describe(
-    "Full-text search query to filter cards by title or description content. " +
-    "Performs fuzzy matching across card text. " +
+    "Text search to filter cards by content. Multi-word input is matched as a single search term. " +
     "Omit to return all cards (subject to other filters)."
   ),
 });

--- a/tests/client/fizzy-client.test.ts
+++ b/tests/client/fizzy-client.test.ts
@@ -18,7 +18,7 @@
  *   DELETE /:account_slug/boards/:board_id        - Delete board
  * 
  * CARDS
- *   GET    /:account_slug/cards                   - List cards (supports ?status, ?column_id, ?assignee_ids[], ?tag_ids[] filters)
+ *   GET    /:account_slug/cards                   - List cards (supports ?board_ids[], ?column_ids[], ?terms[], ?assignee_ids[], ?tag_ids[] filters)
  *   GET    /:account_slug/boards/:board_id/cards  - List cards on a specific board
  *   GET    /:account_slug/cards/:card_id          - Get specific card
  *   POST   /:account_slug/boards/:board_id/cards  - Create card on board
@@ -394,7 +394,7 @@ describe("FizzyClient", () => {
 
   /**
    * Cards API
-   * GET  /:account_slug/cards                     - List cards (with optional ?status, ?column_id, ?assignee_ids[], ?tag_ids[] filters)
+   * GET  /:account_slug/cards                     - List cards (with optional ?board_ids[], ?column_ids[], ?terms[], ?assignee_ids[], ?tag_ids[] filters)
    * GET  /:account_slug/boards/:board_id/cards    - List cards on a specific board
    * GET  /:account_slug/cards/:card_id            - Get specific card
    * POST /:account_slug/boards/:board_id/cards    - Create card on board (NOTE: uses boards path!)
@@ -402,7 +402,9 @@ describe("FizzyClient", () => {
    * DELETE /:account_slug/cards/:card_id          - Delete card
    */
   describe("Cards", () => {
-    // Expected URL: GET /:account_slug/cards?status=...&column_id=...
+    // Expected URL: GET /:account_slug/cards?board_ids[]=...&column_ids[]=...&terms[]=...
+    // The Fizzy API only accepts these plural array params (Rails strong params drop
+    // singular keys like status/column_id/search).
     it("should get all cards with filters", async () => {
       const mockCards = [{ id: "card1", title: "Card 1" }];
 
@@ -413,8 +415,9 @@ describe("FizzyClient", () => {
       });
 
       const result = await client.getCards("123", {
-        status: "published",
-        column_id: "col1",
+        board_ids: ["board1"],
+        column_ids: ["col1"],
+        terms: ["urgent task"],
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
@@ -422,7 +425,15 @@ describe("FizzyClient", () => {
         expect.any(Object)
       );
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("status=published"),
+        expect.stringContaining("board_ids%5B%5D=board1"),
+        expect.any(Object)
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("column_ids%5B%5D=col1"),
+        expect.any(Object)
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("terms%5B%5D=urgent+task"),
         expect.any(Object)
       );
       expect(result).toEqual(mockCards);

--- a/tests/tools/schemas.test.ts
+++ b/tests/tools/schemas.test.ts
@@ -93,27 +93,12 @@ describe("Tool Schemas", () => {
       expect(
         getCardsSchema.safeParse({
           account_slug: "123",
-          status: "published",
+          board_id: "board1",
           column_id: "col1",
           assignee_ids: ["user1"],
           tag_ids: ["tag1"],
           search: "test",
         }).success
-      ).toBe(true);
-    });
-
-    it("getCardsSchema should validate status enum", () => {
-      expect(
-        getCardsSchema.safeParse({ account_slug: "123", status: "invalid" }).success
-      ).toBe(false);
-      expect(
-        getCardsSchema.safeParse({ account_slug: "123", status: "draft" }).success
-      ).toBe(true);
-      expect(
-        getCardsSchema.safeParse({ account_slug: "123", status: "published" }).success
-      ).toBe(true);
-      expect(
-        getCardsSchema.safeParse({ account_slug: "123", status: "archived" }).success
       ).toBe(true);
     });
 

--- a/tests/tools/tool-execution.test.ts
+++ b/tests/tools/tool-execution.test.ts
@@ -40,6 +40,7 @@ import {
   FizzyAuthError,
   FizzyValidationError,
 } from "../../src/utils/errors.js";
+import { toolHandlers } from "../../src/tools/handlers.js";
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -208,22 +209,22 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
       mockFetch.mockResolvedValueOnce(mockResponse(mockCards));
 
       const result = await client.getCards("123", {
-        status: "published",
-        column_id: "col1",
-        search: "test",
+        board_ids: ["board1"],
+        column_ids: ["col1"],
+        terms: ["test"],
       });
 
       expect(result).toEqual(mockCards);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("status=published"),
+        expect.stringContaining("board_ids%5B%5D=board1"),
         expect.any(Object)
       );
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("column_id=col1"),
+        expect.stringContaining("column_ids%5B%5D=col1"),
         expect.any(Object)
       );
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("search=test"),
+        expect.stringContaining("terms%5B%5D=test"),
         expect.any(Object)
       );
     });
@@ -578,15 +579,78 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
       mockFetch.mockResolvedValueOnce(mockResponse([]));
 
       await client.getCards("123", {
-        status: "published",
-        column_id: undefined,
-        search: undefined,
+        indexed_by: "closed",
+        column_ids: undefined,
+        terms: undefined,
       });
 
       const url = mockFetch.mock.calls[0][0] as string;
-      expect(url).toContain("status=published");
-      expect(url).not.toContain("column_id");
-      expect(url).not.toContain("search");
+      expect(url).toContain("indexed_by=closed");
+      expect(url).not.toContain("column_ids");
+      expect(url).not.toContain("terms");
+    });
+  });
+
+  describe("fizzy_get_cards handler (maps external filter names to API params)", () => {
+    it("maps board_id/column_id/search to plural array params and passes through the rest", async () => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue([]) };
+
+      await toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+        board_id: "b1",
+        column_id: "c1",
+        search: "urgent task",
+        indexed_by: "golden",
+        assignee_ids: ["u1"],
+        tag_ids: ["t1"],
+      });
+
+      expect(mockClient.getCards).toHaveBeenCalledWith("123", {
+        board_ids: ["b1"],
+        column_ids: ["c1"],
+        terms: ["urgent task"],
+        indexed_by: "golden",
+        assignee_ids: ["u1"],
+        tag_ids: ["t1"],
+      });
+    });
+
+    it("leaves board_ids/column_ids/terms undefined when no filters are given", async () => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue([]) };
+
+      await toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+      });
+
+      const filters = mockClient.getCards.mock.calls[0][1];
+      expect(filters.board_ids).toBeUndefined();
+      expect(filters.column_ids).toBeUndefined();
+      expect(filters.terms).toBeUndefined();
+    });
+
+    it("rejects a status filter with an 'Unsupported filter' error", async () => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue([]) };
+
+      await expect(
+        toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          status: "draft",
+        })
+      ).rejects.toThrow(/Unsupported filter/);
+      expect(mockClient.getCards).not.toHaveBeenCalled();
+    });
+
+    it("rejects due_before/due_after filters with an 'Unsupported filter' error", async () => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue([]) };
+
+      await expect(
+        toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          due_before: "2026-04-10",
+          due_after: "2026-04-01",
+        })
+      ).rejects.toThrow(/Unsupported filter/);
+      expect(mockClient.getCards).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #16. `fizzy_get_cards` sent singular `board_id`/`column_id`/`search` query params, but the Fizzy cards index only permits the plural array forms (`board_ids[]`, `column_ids[]`, `terms[]`) — Rails strong params (`Filter::PERMITTED_PARAMS`) silently dropped ours, so every "filtered" call returned the full unfiltered card list (~530KB per call in the reported case).

## Changes

- **`src/tools/handlers.ts`** — maps the tool's scalar args to the API's plural arrays (`board_id` → `board_ids: [x]`, `column_id` → `column_ids: [x]`, `search` → `terms: [x]`). External MCP tool arg names are unchanged.
- **Removed dead filters** — `status`, `due_before`, `due_after` can never work: the index hardcodes published cards, and there is no due-date param or payload field upstream. Removed from the tool schema/description (a silently-ignored filter misleads LLM callers), and rejected with a clear error in the handler for stale clients on the Cloudflare path, which executes args without zod validation (#17).
- **`src/client/types.ts`** — `CardFilterOptions` now matches the real API contract and drops the `[key: string]` index signature that defeated excess-property checking.
- **Docs** — fixed false descriptions (`postponing_soon` ≠ "upcoming due dates"; search is not "fuzzy matching"); README table updated.
- **Tests** — handler-level mapping tests added (previously nothing exercised the handler, only `FizzyClient` directly); the old test asserting the broken singular URL rewritten; multi-word search locked in as a single `terms[]` element.

## Testing

- Unit: 127/127 on touched files, full suite 370/375 (5 failures are pre-existing port-3100 transport flakes, identical on clean main), Cloudflare suite 98/98. `typecheck`/`build` failures are pre-existing on main (#21).
- **Live smoke test already performed** against the real API with a read-only token (since revocable): column filters returned only member cards (7/2/15 per column vs the previous full dump), a foreign-board filter returned 0 instead of the unfiltered page, gibberish `terms[]` returned 0, and a raw-HTTP control reproduced the original bug — singular `?column_id=` byte-identical to unfiltered (597,983 chars) while plural `?column_ids[]=` returned 312,947 chars.

Follow-ups filed during this work: #17 (Cloudflare arg validation), #18 (`due_on` no-op), #19 (`indexed_by` missing `maybe`), #20 (pagination truncation), #21 (tsc error on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)