### PR TITLE
chore: narrow tsconfig lib to ES2022 and drop stale eslint-disable

### DIFF
--- a/src/ambient/headers-init.d.ts
+++ b/src/ambient/headers-init.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @types/node does not declare HeadersInit globally (it lives in undici-types),
+ * but @modelcontextprotocol/sdk declaration files reference the global name.
+ * Without this alias, skipLibCheck silently types it as `any`.
+ * The Cloudflare build must NOT include this file: @cloudflare/workers-types
+ * already declares a global HeadersInit.
+ */
+type HeadersInit = NonNullable<RequestInit["headers"]>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,7 +45,6 @@ export function createFizzyServer(client: FizzyClient): McpServer {
         inputSchema: toolDef.schema,
         annotations: toolDef.annotations,
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (async (args: Record<string, unknown>) => {
         const result = await executeToolHandler(client, toolDef.name, args);
         return formatMcpResponse(result);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary
- Narrowed `tsconfig.json` `lib` from `["ES2022", "DOM"]` back to `["ES2022"]`. `@types/node` ^22 (already a devDependency) supplies the `URL`, `URLSearchParams`, `fetch`, `Request`, `Response`, and `Headers` globals the MCP SDK needs, so the full DOM lib added in #14 was unnecessary and risked masking Node-vs-Cloudflare-Workers type mismatches repo-wide.
- Removed the stale `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comment in `src/server.ts`. Verified eslint is not a devDependency and no `.eslintrc*`/`eslint.config.*` file exists in the repo, so the comment silenced a linter that isn't installed (and was misplaced regardless — the actual `as any` cast is on the closing `}) as any` line, not the line below the comment).
- Added `src/ambient/headers-init.d.ts` declaring a global `HeadersInit` type alias for the Node build. The MCP SDK's declaration files (`@modelcontextprotocol/sdk/dist/esm/shared/transport.d.ts`) reference the DOM-global `HeadersInit`, which `@types/node` only ships as a module export (via `undici-types`), not a global — with `skipLibCheck: true` this was silently degrading to `any` once the DOM lib was removed above. The file is excluded from `tsconfig.cloudflare.json`'s include list since `@cloudflare/workers-types` already declares `HeadersInit` globally and a duplicate would break the Cloudflare typecheck.

## Verification
- `npm run typecheck` — passes (exit 0) with the narrowed lib.
- `npm run build` — passes (exit 0).
- `npm test` — 370 passed, 5 failed. All 5 failures are `EADDRINUSE` errors in `tests/transports/sse-multi-user.test.ts` (hardcoded port 3100) and `tests/transports/security-warnings.test.ts` (hardcoded port 3001); confirmed both ports are occupied by unrelated processes already running on this machine, and reproduced the identical failures by running the same two test files against unmodified `main` — pre-existing environmental flake, unrelated to this diff.
