### PR TITLE
ci: add typecheck/build/test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ">=18.0.0"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      # NOTE: Cloudflare-targeted checks (`npm run typecheck:cf`,
+      # `npm run test:cloudflare`) are intentionally excluded here. main
+      # currently fails `tsc --noEmit -p tsconfig.cloudflare.json` with
+      # pre-existing type errors at src/cloudflare/mcp-session.ts:315-316.
+      # Re-enable once those are fixed.
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ">=18.0.0"
+          node-version: "22"
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
- Adds a single GitHub Actions workflow that runs `npm ci`, `npm run typecheck`, `npm run build`, and `npm test` on every pull request targeting main and on pushes to main.
- Excludes the Cloudflare-targeted checks (`npm run typecheck:cf`, `npm run test:cloudflare`) because main currently fails `tsc --noEmit -p tsconfig.cloudflare.json` with pre-existing type errors at `src/cloudflare/mcp-session.ts:315-316`; the workflow file has a comment noting this and can be re-enabled once those are fixed.
- This PR's own workflow run is a live test of the pipeline end to end.