### PR TITLE
fix: resolve Cloudflare typecheck errors and gate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,14 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Typecheck (Cloudflare)
+        run: npm run typecheck:cf
+
       - name: Build
         run: npm run build
 
-      # NOTE: Cloudflare-targeted checks (`npm run typecheck:cf`,
-      # `npm run test:cloudflare`) are intentionally excluded here. main
-      # currently fails `tsc --noEmit -p tsconfig.cloudflare.json` with
-      # pre-existing type errors at src/cloudflare/mcp-session.ts:315-316.
-      # Re-enable once those are fixed.
       - name: Test
         run: npm test
+
+      - name: Test (Cloudflare)
+        run: npm run test:cloudflare

--- a/src/cloudflare/mcp-session.ts
+++ b/src/cloudflare/mcp-session.ts
@@ -304,7 +304,7 @@ export class McpSessionDO extends DurableObject<Env> {
       const jsonSchema = zodToJsonSchema(toolDef.schema, {
         target: "jsonSchema2019-09",
         $refStrategy: "none",
-      });
+      }) as Record<string, unknown>;
 
       // Remove $schema field (MCP defaults to 2020-12)
       if ("$schema" in jsonSchema) {
@@ -320,7 +320,7 @@ export class McpSessionDO extends DurableObject<Env> {
         name: toolDef.name,
         title: toolDef.title,
         description: toolDef.description,
-        inputSchema: jsonSchema as Record<string, unknown>,
+        inputSchema: jsonSchema,
         annotations: toolDef.annotations,
       };
     });


### PR DESCRIPTION
## Summary
- `zodToJsonSchema()`'s return type is a narrow intersection that doesn't expose arbitrary JSON Schema keys, so accessing `.type` / `.additionalProperties` on it failed under `tsconfig.cloudflare.json`. Fixed by casting once at the conversion site (`as Record<string, unknown>`) instead of at the return; this is a type-level-only change, no emitted JS differs.
- With `npm run typecheck:cf` now passing, added a `Typecheck (Cloudflare)` step to CI right after the existing Typecheck step, and removed the stale NOTE comment explaining the prior exclusion.
- `npm run test:cloudflare` passes locally (98/98 tests), so a `Test (Cloudflare)` step was also added to CI, right after the existing Test step.

## Verification
- `npm run typecheck:cf` -> exit 0
- `npm run typecheck` -> exit 0
- `npm run build` -> exit 0
- `npm test` -> 370/375 passing; the 5 failures are the known local EADDRINUSE flakes on ports 3100/3001 (pass on CI runners)
- `npm run test:cloudflare` -> 98/98 passing