### PR TITLE
fix: expose pagination for fizzy_get_cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fizzy-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fizzy-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fizzy-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP Server for Fizzy - A project management tool by Basecamp",
   "type": "module",
   "main": "dist/index.js",

--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -26,7 +26,8 @@ import type {
   UpdateUserRequest,
   CreateStepRequest,
   UpdateStepRequest,
-  CardFilterOptions,
+  CardListOptions,
+  CardsPage,
 } from "./types.js";
 import {
   createAPIError,
@@ -165,6 +166,20 @@ export class FizzyClient {
     path: string,
     body?: unknown
   ): Promise<T> {
+    const { data } = await this.requestWithMeta<T>(method, path, body);
+    return data;
+  }
+
+  /**
+   * Same as `request`, but also returns metadata derived from the response by
+   * `extractMeta` (e.g. pagination headers). Shares the retry/backoff loop.
+   */
+  private async requestWithMeta<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    extractMeta?: (response: Response) => unknown
+  ): Promise<{ data: T; meta: unknown }> {
     const url = `${this.baseUrl}${path}`;
     const requestId = this.generateRequestId();
     let lastError: Error | undefined;
@@ -173,7 +188,13 @@ export class FizzyClient {
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
       try {
-        const result = await this.executeRequest<T>(method, url, body, requestId);
+        const result = await this.executeRequestWithMeta<T>(
+          method,
+          url,
+          body,
+          requestId,
+          extractMeta
+        );
         this.log.debug(`[${requestId}] Request completed successfully`);
         return result;
       } catch (error) {
@@ -213,14 +234,20 @@ export class FizzyClient {
   }
 
   /**
-   * Execute a single HTTP request with timeout and ETag caching
+   * Execute a single HTTP request with timeout and ETag caching.
+   *
+   * `extractMeta` runs on exactly two paths: a fresh response whose JSON body
+   * parsed successfully, and a 304. It never runs on 204, on the 201-Location
+   * fallback, or on any error path (those throw first) — which is what keeps it
+   * away from the error bodies of attempts that are about to be retried.
    */
-  private async executeRequest<T>(
+  private async executeRequestWithMeta<T>(
     method: string,
     url: string,
     body?: unknown,
-    requestId?: string
-  ): Promise<T> {
+    requestId?: string,
+    extractMeta?: (response: Response) => unknown
+  ): Promise<{ data: T; meta: unknown }> {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.accessToken}`,
       Accept: "application/json",
@@ -267,10 +294,16 @@ export class FizzyClient {
 
       // Handle 304 Not Modified - return cached data
       if (response.status === 304 && this.cache) {
-        const cachedData = this.cache.get(url);
-        if (cachedData !== undefined) {
+        const cachedEntry = this.cache.getEntry(url);
+        if (cachedEntry) {
           this.log.debug(`${logPrefix}Cache hit (304 Not Modified): ${url}`);
-          return cachedData as T;
+          // Rails still runs the action on a conditional GET, so a 304 carries
+          // fresh response headers (only the body is stripped). Prefer those;
+          // fall back to the meta captured when the body was cached.
+          return {
+            data: cachedEntry.data as T,
+            meta: extractMeta?.(response) ?? cachedEntry.meta,
+          };
         }
         // Cache miss despite 304 - shouldn't happen, but fetch fresh data
         this.log.warn(`${logPrefix}304 received but no cached data for: ${url}`);
@@ -294,7 +327,7 @@ export class FizzyClient {
         if (!isGetRequest && this.cache) {
           this.invalidateCacheForMutation(url);
         }
-        return undefined as T;
+        return { data: undefined as T, meta: undefined };
       }
 
       // Parse JSON response
@@ -315,9 +348,9 @@ export class FizzyClient {
             if (this.cache) {
               this.invalidateCacheForMutation(url);
             }
-            return { id, url: location } as T;
+            return { data: { id, url: location } as T, meta: undefined };
           }
-          return undefined as T;
+          return { data: undefined as T, meta: undefined };
         }
         throw new FizzyParseError(
           "Failed to parse API response as JSON",
@@ -325,11 +358,15 @@ export class FizzyClient {
         );
       }
 
+      // Single extraction path for response metadata: computed here, once, from a
+      // fresh response with a parsed body, then stored alongside it in the cache.
+      const meta = extractMeta?.(response);
+
       // Cache the response if ETag is present (for GET requests)
       if (isGetRequest && this.cache && response.headers) {
         const etag = response.headers.get("ETag");
         if (etag) {
-          this.cache.set(url, etag, data);
+          this.cache.set(url, etag, data, meta);
           this.log.debug(`${logPrefix}Cached response with ETag: ${etag}`);
         }
       }
@@ -339,7 +376,7 @@ export class FizzyClient {
         this.invalidateCacheForMutation(url);
       }
 
-      return data;
+      return { data, meta };
     } catch (error) {
       clearTimeout(timeoutId);
 
@@ -382,6 +419,34 @@ export class FizzyClient {
 
     const queryString = searchParams.toString();
     return queryString ? `?${queryString}` : "";
+  }
+
+  /**
+   * Read geared_pagination metadata off a list response.
+   *
+   * Returns undefined when neither header is present, which is the signal the
+   * 304 path uses to fall back to the metadata cached with the body.
+   */
+  private parsePaginationMeta(
+    response: Response
+  ): { totalCount: number | null; hasMore: boolean } | undefined {
+    // Defensive header access: mocked/partial responses may omit `headers` entirely.
+    const totalCountHeader = response.headers?.get?.("X-Total-Count") ?? null;
+    const linkHeader = response.headers?.get?.("Link") ?? null;
+
+    if (totalCountHeader === null && linkHeader === null) {
+      return undefined;
+    }
+
+    const parsedTotal = totalCountHeader === null ? NaN : parseInt(totalCountHeader, 10);
+    const totalCount = Number.isFinite(parsedTotal) ? parsedTotal : null;
+
+    // Upstream emits rel="next" on every page but the last. Test the whole header
+    // so multi-link values need no splitting, and allow an unquoted rel (RFC 8288).
+    const hasMore =
+      linkHeader !== null && /<[^>]*>\s*;[^,]*?rel\s*=\s*"?next"?/i.test(linkHeader);
+
+    return { totalCount, hasMore };
   }
 
   // ============ Identity ============
@@ -474,20 +539,44 @@ export class FizzyClient {
   // ============ Cards ============
 
   /**
-   * Get all cards in an account with optional filters
+   * Get one page of cards in an account with optional filters.
+   *
+   * This endpoint is paginated with a server-controlled, variable page size, so
+   * the result is a page envelope ({@link CardsPage}) rather than a bare array.
+   * Pass `options.page` to walk further pages; nothing is aggregated here.
    * @endpoint GET /:account_slug/cards
    * @see https://github.com/basecamp/fizzy/blob/main/docs/API.md#get-account_slugcards
    */
   async getCards(
     accountSlug: string,
-    filters?: CardFilterOptions
-  ): Promise<FizzyCard[]> {
+    options?: CardListOptions
+  ): Promise<CardsPage> {
     const slug = this.normalizeSlug(accountSlug);
-    const queryString = filters ? this.buildQueryString(filters) : "";
-    return this.request<FizzyCard[]>(
+    const queryString = options ? this.buildQueryString(options) : "";
+    const requestedPage = options?.page ?? 1;
+
+    const { data, meta } = await this.requestWithMeta<FizzyCard[]>(
       "GET",
-      `/${slug}/cards${queryString}`
+      `/${slug}/cards${queryString}`,
+      undefined,
+      (response) => this.parsePaginationMeta(response)
     );
+
+    // With no pagination headers to go on we report has_more: false /
+    // total_count: null rather than fabricating values.
+    const pagination = meta as { totalCount: number | null; hasMore: boolean } | undefined;
+    const hasMore = pagination?.hasMore ?? false;
+
+    return {
+      cards: data ?? [],
+      page: requestedPage,
+      total_count: pagination?.totalCount ?? null,
+      has_more: hasMore,
+      // Derived, not parsed out of the Link URL: offset portioning guarantees
+      // sequential integer pages, so parsing would only add failure modes that
+      // silently truncate iteration.
+      next_page: hasMore ? requestedPage + 1 : null,
+    };
   }
 
 

--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -438,15 +438,36 @@ export class FizzyClient {
       return undefined;
     }
 
-    const parsedTotal = totalCountHeader === null ? NaN : parseInt(totalCountHeader, 10);
-    const totalCount = Number.isFinite(parsedTotal) ? parsedTotal : null;
+    const trimmedTotal = totalCountHeader === null ? null : totalCountHeader.trim();
+    const totalCount =
+      trimmedTotal !== null && /^[0-9]+$/.test(trimmedTotal) && Number.isSafeInteger(Number(trimmedTotal))
+        ? Number(trimmedTotal)
+        : null;
 
-    // Upstream emits rel="next" on every page but the last. Test the whole header
-    // so multi-link values need no splitting, and allow an unquoted rel (RFC 8288).
-    const hasMore =
-      linkHeader !== null && /<[^>]*>\s*;[^,]*?rel\s*=\s*"?next"?/i.test(linkHeader);
+    // Upstream emits rel="next" on every page but the last.
+    const hasMore = linkHeader !== null && this.linkHeaderHasNextRel(linkHeader);
 
     return { totalCount, hasMore };
+  }
+
+  /**
+   * True when an RFC 8288 Link header contains a link with relation type "next".
+   * A comma only separates link-values when followed by a new <URL>, so commas
+   * inside quoted params don't split; rel values may be quoted token lists.
+   */
+  private linkHeaderHasNextRel(linkHeader: string): boolean {
+    for (const part of linkHeader.split(/,(?=\s*<)/)) {
+      const paramsStart = part.indexOf(">");
+      if (paramsStart === -1) continue;
+      for (const param of part.slice(paramsStart + 1).split(";")) {
+        const eq = param.indexOf("=");
+        if (eq === -1) continue;
+        if (param.slice(0, eq).trim().toLowerCase() !== "rel") continue;
+        const value = param.slice(eq + 1).trim().replace(/^"(.*)"$/, "$1");
+        if (value.toLowerCase().split(/\s+/).includes("next")) return true;
+      }
+    }
+    return false;
   }
 
   // ============ Identity ============
@@ -554,6 +575,11 @@ export class FizzyClient {
     const slug = this.normalizeSlug(accountSlug);
     const queryString = options ? this.buildQueryString(options) : "";
     const requestedPage = options?.page ?? 1;
+
+    // The tool layer validates `page` separately; this defends direct client callers.
+    if (!Number.isSafeInteger(requestedPage) || requestedPage < 1) {
+      throw new Error("page must be a positive integer (1-based)");
+    }
 
     const { data, meta } = await this.requestWithMeta<FizzyCard[]>(
       "GET",

--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -451,20 +451,66 @@ export class FizzyClient {
   }
 
   /**
+   * Split on a separator that only counts at top level — i.e. outside RFC 8288
+   * quoted-strings (which may contain the separator, with \-escapes) and outside
+   * <URL> brackets.
+   */
+  private static splitTopLevel(input: string, separator: string): string[] {
+    const parts: string[] = [];
+    let current = "";
+    let inQuotes = false;
+    let inAngle = false;
+    for (let i = 0; i < input.length; i++) {
+      const ch = input[i];
+      if (inQuotes) {
+        if (ch === "\\" && i + 1 < input.length) {
+          current += ch + input[i + 1];
+          i++;
+          continue;
+        }
+        if (ch === '"') inQuotes = false;
+        current += ch;
+      } else if (ch === '"') {
+        inQuotes = true;
+        current += ch;
+      } else if (ch === "<" && !inAngle) {
+        inAngle = true;
+        current += ch;
+      } else if (ch === ">" && inAngle) {
+        inAngle = false;
+        current += ch;
+      } else if (ch === separator && !inAngle) {
+        parts.push(current);
+        current = "";
+      } else {
+        current += ch;
+      }
+    }
+    parts.push(current);
+    return parts;
+  }
+
+  /**
    * True when an RFC 8288 Link header contains a link with relation type "next".
-   * A comma only separates link-values when followed by a new <URL>, so commas
-   * inside quoted params don't split; rel values may be quoted token lists.
+   * Quoted strings never split link-values or params, and per RFC 8288 only the
+   * FIRST rel param of a link-value counts.
    */
   private linkHeaderHasNextRel(linkHeader: string): boolean {
-    for (const part of linkHeader.split(/,(?=\s*<)/)) {
-      const paramsStart = part.indexOf(">");
-      if (paramsStart === -1) continue;
-      for (const param of part.slice(paramsStart + 1).split(";")) {
+    for (const linkValue of FizzyClient.splitTopLevel(linkHeader, ",")) {
+      const urlEnd = linkValue.indexOf(">");
+      if (!linkValue.trimStart().startsWith("<") || urlEnd === -1) continue;
+      for (const param of FizzyClient.splitTopLevel(linkValue.slice(urlEnd + 1), ";")) {
         const eq = param.indexOf("=");
         if (eq === -1) continue;
         if (param.slice(0, eq).trim().toLowerCase() !== "rel") continue;
-        const value = param.slice(eq + 1).trim().replace(/^"(.*)"$/, "$1");
-        if (value.toLowerCase().split(/\s+/).includes("next")) return true;
+        // First rel wins (RFC 8288 §3.3); later rel params must be ignored.
+        let value = param.slice(eq + 1).trim();
+        if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
+          value = value.slice(1, -1).replace(/\\(.)/g, "$1");
+        }
+        const isNext = value.toLowerCase().split(/\s+/).includes("next");
+        if (isNext) return true;
+        break;
       }
     }
     return false;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -198,12 +198,6 @@ export const COLUMN_COLORS = {
 
 export type ColumnColor = keyof typeof COLUMN_COLORS;
 
-// API Response types
-export interface PaginatedResponse<T> {
-  data: T[];
-  nextPageUrl?: string;
-}
-
 // Identity - Response from GET /my/identity
 // Note: User info is embedded in accounts[].user, not at the top level
 export interface FizzyIdentity {
@@ -225,3 +219,17 @@ export type CardFilterOptions = {
   assignee_ids?: string[];
   tag_ids?: string[];
 };
+
+// Options accepted by getCards: the filters above plus `page`, which is a
+// pagination param (1-based), not a filter.
+export type CardListOptions = CardFilterOptions & { page?: number };
+
+// One page of GET /:account_slug/cards. The endpoint is paginated upstream
+// (geared_pagination in offset mode) with a server-controlled, variable page size.
+export interface CardsPage {
+  cards: FizzyCard[];
+  page: number;               // the page that was fetched (1-based)
+  total_count: number | null; // X-Total-Count: total cards matching the filters (advisory; null if header absent)
+  has_more: boolean;          // Link header contained rel="next"
+  next_page: number | null;   // page + 1 when has_more, else null
+}

--- a/src/cloudflare/types.ts
+++ b/src/cloudflare/types.ts
@@ -163,7 +163,7 @@ export interface HealthResponse {
  */
 export const MCP_PROTOCOL_VERSION = "2024-11-05";
 export const SERVER_NAME = "fizzy-mcp";
-export const SERVER_VERSION = "1.0.0";
+export const SERVER_VERSION = "1.1.0";
 
 /**
  * Re-export Cloudflare types for convenience

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,7 @@ function formatMcpResponse(result: unknown): {
 export function createFizzyServer(client: FizzyClient): McpServer {
   const server = new McpServer({
     name: "fizzy-mcp",
-    version: "1.0.0",
+    version: "1.1.0",
   });
 
   // Register all tools using shared handlers

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -128,9 +128,16 @@ export const TOOL_DEFINITIONS = {
       name: "fizzy_get_cards",
       title: "List Cards",
       description:
-        "Get all cards in an account with optional filtering by board, indexed_by (e.g., 'golden' for priority cards), " +
+        "Get a page of cards in an account with optional filtering by board, indexed_by (e.g., 'golden' for priority cards), " +
         "column, assignees, tags, or search terms. " +
-        "Use board_id to scope results to a specific board and column_id to scope to a workflow column.",
+        "Use board_id to scope results to a specific board and column_id to scope to a workflow column. " +
+        "Results are PAGINATED with a server-controlled, variable page size, so never compute a page count " +
+        "from the length of one page. " +
+        "Returns an object {cards, page, total_count, has_more, next_page}, where total_count is the total number " +
+        "of cards matching the filters (NOT the length of this page). " +
+        "To enumerate every match, call repeatedly with page = next_page until has_more is false OR cards comes back " +
+        "empty — an out-of-range page returns empty cards but may still report has_more true. " +
+        "A board's cards_count from fizzy_get_boards can exceed a single page of results; that is expected, not a discrepancy.",
       schema: schemas.getCardsSchema,
       annotations: {
         readOnlyHint: true,

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -9,7 +9,7 @@
  */
 
 import type { FizzyClient } from "../client/fizzy-client.js";
-import { COLUMN_COLORS, type ColumnColor, type CardFilterOptions } from "../client/types.js";
+import { COLUMN_COLORS, type ColumnColor, type CardListOptions } from "../client/types.js";
 import { resolveCardNumber } from "../utils/card-resolver.js";
 
 /**
@@ -31,6 +31,26 @@ export type ToolHandler = (
 function getColumnColorValue(color?: string): string | undefined {
   if (!color) return undefined;
   return COLUMN_COLORS[color as ColumnColor];
+}
+
+/**
+ * Validate the optional 1-based `page` argument of fizzy_get_cards.
+ *
+ * Like the unsupported-filter guard below, this has to run here because the
+ * Cloudflare transport executes raw args without zod. Digit strings are accepted
+ * because LLM clients routinely send "2"; the stdio path rejects those upstream,
+ * and being lenient here costs nothing.
+ */
+function parseCardsPage(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "number" && Number.isInteger(value) && value >= 1) {
+    return value;
+  }
+  if (typeof value === "string" && /^[0-9]+$/.test(value)) {
+    const parsed = parseInt(value, 10);
+    if (parsed >= 1) return parsed;
+  }
+  throw new Error("page must be a positive integer (1-based), e.g. 2");
 }
 
 /**
@@ -90,15 +110,16 @@ export const toolHandlers: Record<string, ToolHandler> = {
         `Card listings always contain published cards; use indexed_by="closed" for closed cards.`
       );
     }
-    const filters: CardFilterOptions = {
+    const options: CardListOptions = {
       board_ids: args.board_id ? [args.board_id as string] : undefined,
       column_ids: args.column_id ? [args.column_id as string] : undefined,
       terms: args.search ? [args.search as string] : undefined,
-      indexed_by: args.indexed_by as CardFilterOptions["indexed_by"],
+      indexed_by: args.indexed_by as CardListOptions["indexed_by"],
       assignee_ids: args.assignee_ids as string[] | undefined,
       tag_ids: args.tag_ids as string[] | undefined,
+      page: parseCardsPage(args.page),
     };
-    return client.getCards(args.account_slug as string, filters);
+    return client.getCards(args.account_slug as string, options);
   },
 
   fizzy_get_card: async (client, args) => {

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -43,12 +43,12 @@ function getColumnColorValue(color?: string): string | undefined {
  */
 function parseCardsPage(value: unknown): number | undefined {
   if (value === undefined) return undefined;
-  if (typeof value === "number" && Number.isInteger(value) && value >= 1) {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 1) {
     return value;
   }
   if (typeof value === "string" && /^[0-9]+$/.test(value)) {
     const parsed = parseInt(value, 10);
-    if (parsed >= 1) return parsed;
+    if (Number.isSafeInteger(parsed) && parsed >= 1) return parsed;
   }
   throw new Error("page must be a positive integer (1-based), e.g. 2");
 }

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -155,7 +155,7 @@ export const getCardsSchema = z.object({
     "Text search to filter cards by content. Multi-word input is matched as a single search term. " +
     "Omit to return all cards (subject to other filters)."
   ),
-  page: z.number().int().positive().optional().describe(
+  page: z.number().int().positive().max(Number.MAX_SAFE_INTEGER).optional().describe(
     "Page number to fetch (1-based). Card listings are paginated with a server-controlled, variable page size " +
     "(early pages are small, e.g. 15 cards; later pages are larger). Omit for the first page; " +
     "pass the next_page value from the previous response to fetch subsequent pages."

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -155,6 +155,11 @@ export const getCardsSchema = z.object({
     "Text search to filter cards by content. Multi-word input is matched as a single search term. " +
     "Omit to return all cards (subject to other filters)."
   ),
+  page: z.number().int().positive().optional().describe(
+    "Page number to fetch (1-based). Card listings are paginated with a server-controlled, variable page size " +
+    "(early pages are small, e.g. 15 cards; later pages are larger). Omit for the first page; " +
+    "pass the next_page value from the previous response to fetch subsequent pages."
+  ),
 });
 
 

--- a/src/utils/etag-cache.ts
+++ b/src/utils/etag-cache.ts
@@ -16,6 +16,11 @@ export interface CacheEntry<T> {
   data: T;
   cachedAt: number;
   url: string;
+  /**
+   * Opaque, endpoint-specific metadata captured alongside the body (e.g. the
+   * pagination headers of a list response) so a later 304 can still report it.
+   */
+  meta?: unknown;
 }
 
 export interface ETagCacheOptions {
@@ -65,9 +70,25 @@ export class ETagCache<T = unknown> {
   }
 
   /**
-   * Store response data with its ETag
+   * Get cached data together with its stored metadata, if available and not expired
    */
-  set(url: string, etag: string, data: T): void {
+  getEntry(url: string): { data: T; meta: unknown } | undefined {
+    const entry = this.cache.get(url);
+    if (entry && !this.isExpired(entry)) {
+      this.log.debug(`Cache hit: ${url}`);
+      return { data: entry.data, meta: entry.meta };
+    }
+    if (entry) {
+      // Expired, remove it
+      this.cache.delete(url);
+    }
+    return undefined;
+  }
+
+  /**
+   * Store response data with its ETag, plus optional endpoint-specific metadata
+   */
+  set(url: string, etag: string, data: T, meta?: unknown): void {
     // Enforce max entries (LRU-style: remove oldest if at limit)
     if (this.cache.size >= this.maxEntries) {
       const oldestKey = this.cache.keys().next().value;
@@ -82,6 +103,7 @@ export class ETagCache<T = unknown> {
       data,
       cachedAt: Date.now(),
       url,
+      meta,
     });
 
     this.log.debug(`Cache stored: ${url}`, { etag });

--- a/tests/client/fizzy-client.test.ts
+++ b/tests/client/fizzy-client.test.ts
@@ -653,6 +653,98 @@ describe("FizzyClient", () => {
       expect(result.total_count).toBeNull();
     });
 
+    it("reports total_count null for a header with trailing junk", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({ "X-Total-Count": "12junk" }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.total_count).toBeNull();
+    });
+
+    it("reports total_count null for a negative header value", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({ "X-Total-Count": "-5" }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.total_count).toBeNull();
+    });
+
+    it("does not treat rel=\"xrel\" as a next link (false positive guard)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          Link: '<https://app.fizzy.do/123/cards?page=2>; xrel="next"',
+        }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.has_more).toBe(false);
+      expect(result.next_page).toBeNull();
+    });
+
+    it("does not treat rel=\"next-page\" as a next link (false positive guard)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          Link: '<https://app.fizzy.do/123/cards?page=2>; rel="next-page"',
+        }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.has_more).toBe(false);
+      expect(result.next_page).toBeNull();
+    });
+
+    it("treats a quoted rel token list containing next as a next link", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          Link: '<https://app.fizzy.do/123/cards?page=2>; rel="prev next"',
+        }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.has_more).toBe(true);
+      expect(result.next_page).toBe(2);
+    });
+
+    it("finds rel=next among multiple links in the same header", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          Link:
+            '<https://app.fizzy.do/123/cards?page=1>; rel="prev", ' +
+            '<https://app.fizzy.do/123/cards?page=3>; rel="next"',
+        }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123", { page: 2 });
+
+      expect(result.has_more).toBe(true);
+      expect(result.next_page).toBe(3);
+    });
+
     it("returns an empty cards array when the requested page is past the end", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -750,12 +842,16 @@ describe("FizzyClient", () => {
         retryBaseDelay: 10,
       });
       const mockCards = [{ id: "card1", title: "Card 1" }];
+      const failedHeadersGet = vi.fn(() => {
+        throw new Error("must not read headers of a failed response");
+      });
 
       mockFetch
         .mockResolvedValueOnce({
           ok: false,
           status: 500,
           statusText: "Internal Server Error",
+          headers: { get: failedHeadersGet },
           text: async () => "Error",
         })
         .mockResolvedValueOnce({
@@ -771,6 +867,7 @@ describe("FizzyClient", () => {
       const result = await clientWithRetry.getCards("123");
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(failedHeadersGet).not.toHaveBeenCalled();
       expect(result).toEqual({
         cards: mockCards,
         page: 1,

--- a/tests/client/fizzy-client.test.ts
+++ b/tests/client/fizzy-client.test.ts
@@ -745,6 +745,81 @@ describe("FizzyClient", () => {
       expect(result.next_page).toBe(3);
     });
 
+    it("does not let a quoted title fabricate a rel=next param (false positive guard)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          Link: '<https://example/cards>; title="literal; rel=next; suffix"; rel="prev"',
+        }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.has_more).toBe(false);
+    });
+
+    it("does not let a quoted comma fabricate a link-value (false positive guard)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          Link: '<https://x/a>; title="see also, <https://x/b>; rel=next"; rel="prev"',
+        }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.has_more).toBe(false);
+    });
+
+    it("finds a real rel=next after a quoted param containing a semicolon", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          Link: '<https://x/a>; title="x; y"; rel="next"',
+        }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.has_more).toBe(true);
+    });
+
+    it("honors only the first rel param on a link-value (RFC 8288)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          Link: '<https://x/a>; rel="prev"; rel="next"',
+        }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.has_more).toBe(false);
+    });
+
+    it("does not let an escaped quote inside a quoted string fabricate rel=next", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          Link: '<https://x/a>; title="say \\" ; rel=next"; rel="prev"',
+        }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.has_more).toBe(false);
+    });
+
     it("returns an empty cards array when the requested page is past the end", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/tests/client/fizzy-client.test.ts
+++ b/tests/client/fizzy-client.test.ts
@@ -436,7 +436,14 @@ describe("FizzyClient", () => {
         expect.stringContaining("terms%5B%5D=urgent+task"),
         expect.any(Object)
       );
-      expect(result).toEqual(mockCards);
+      // No pagination headers on this mock: report what we know, invent nothing.
+      expect(result).toEqual({
+        cards: mockCards,
+        page: 1,
+        total_count: null,
+        has_more: false,
+        next_page: null,
+      });
     });
 
     // Expected URL: GET /:account_slug/cards/:card_id
@@ -514,6 +521,263 @@ describe("FizzyClient", () => {
           method: "DELETE",
         })
       );
+    });
+  });
+
+  /**
+   * Cards pagination
+   * GET /:account_slug/cards is paginated upstream (geared_pagination, offset mode).
+   * Every page but the last carries `Link: <...?page=N+1>; rel="next"`, and every
+   * page carries `X-Total-Count` with the total number of FILTERED cards.
+   */
+  describe("Cards pagination", () => {
+    const paginationHeaders = (values: Record<string, string>) => {
+      const headers = new Headers();
+      for (const [name, value] of Object.entries(values)) {
+        headers.set(name, value);
+      }
+      return headers;
+    };
+
+    it("reports total_count, has_more and next_page from the response headers", async () => {
+      const mockCards = [{ id: "card1", title: "Card 1" }];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          "X-Total-Count": "238",
+          Link: '<https://app.fizzy.do/123/cards?page=2>; rel="next"',
+        }),
+        json: async () => mockCards,
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result).toEqual({
+        cards: mockCards,
+        page: 1,
+        total_count: 238,
+        has_more: true,
+        next_page: 2,
+      });
+    });
+
+    it("sends ?page= only when a page is requested", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({ "X-Total-Count": "238" }),
+        json: async () => [],
+      });
+
+      const result = await client.getCards("123", { page: 2 });
+
+      expect(mockFetch.mock.calls[0][0] as string).toContain("page=2");
+      expect(result.page).toBe(2);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({ "X-Total-Count": "238" }),
+        json: async () => [],
+      });
+
+      await client.getCards("123", { indexed_by: "closed" });
+
+      expect(mockFetch.mock.calls[1][0] as string).not.toContain("page=");
+    });
+
+    it("derives next_page from the requested page, not from the Link URL", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          "X-Total-Count": "238",
+          // Deliberately inconsistent page number in the URL - it must be ignored.
+          Link: '<https://app.fizzy.do/123/cards?page=99>; rel="next"',
+        }),
+        json: async () => [{ id: "card16" }],
+      });
+
+      const result = await client.getCards("123", { page: 2 });
+
+      expect(result.page).toBe(2);
+      expect(result.next_page).toBe(3);
+    });
+
+    it("treats a Link header without rel=next as the last page", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          "X-Total-Count": "43",
+          Link: '<https://app.fizzy.do/123/cards?page=4>; rel="prev"',
+        }),
+        json: async () => [{ id: "card43" }],
+      });
+
+      const result = await client.getCards("123", { page: 5 });
+
+      expect(result.has_more).toBe(false);
+      expect(result.next_page).toBeNull();
+      expect(result.total_count).toBe(43);
+    });
+
+    it("accepts an unquoted rel=next (RFC 8288)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          Link: "<https://app.fizzy.do/123/cards?page=2>; rel=next",
+        }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.has_more).toBe(true);
+      expect(result.next_page).toBe(2);
+    });
+
+    it("reports total_count null when X-Total-Count is not a number", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({ "X-Total-Count": "abc" }),
+        json: async () => [{ id: "card1" }],
+      });
+
+      const result = await client.getCards("123");
+
+      expect(result.total_count).toBeNull();
+    });
+
+    it("returns an empty cards array when the requested page is past the end", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          "X-Total-Count": "43",
+          // Upstream keeps advertising a next page past the end, hence the
+          // documented "stop on has_more false OR empty cards" rule.
+          Link: '<https://app.fizzy.do/123/cards?page=1000>; rel="next"',
+        }),
+        json: async () => [],
+      });
+
+      const result = await client.getCards("123", { page: 999 });
+
+      expect(result.cards).toEqual([]);
+      expect(result.has_more).toBe(true);
+    });
+
+    it("reuses cached pagination metadata on a 304 that omits the headers", async () => {
+      const mockCards = [{ id: "card1", title: "Card 1" }];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          ETag: 'W/"cards1"',
+          "X-Total-Count": "238",
+          Link: '<https://app.fizzy.do/123/cards?page=2>; rel="next"',
+        }),
+        json: async () => mockCards,
+      });
+
+      const first = await client.getCards("123");
+      expect(first.total_count).toBe(238);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 304,
+        headers: paginationHeaders({ ETag: 'W/"cards1"' }),
+      });
+
+      const second = await client.getCards("123");
+
+      expect(mockFetch.mock.calls[1][1].headers["If-None-Match"]).toBe('W/"cards1"');
+      expect(second).toEqual({
+        cards: mockCards,
+        page: 1,
+        total_count: 238,
+        has_more: true,
+        next_page: 2,
+      });
+    });
+
+    it("prefers pagination headers carried by the 304 itself over cached metadata", async () => {
+      const mockCards = [{ id: "card1", title: "Card 1" }];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: paginationHeaders({
+          ETag: 'W/"cards1"',
+          "X-Total-Count": "238",
+          Link: '<https://app.fizzy.do/123/cards?page=2>; rel="next"',
+        }),
+        json: async () => mockCards,
+      });
+
+      await client.getCards("123");
+
+      // Rails runs the action for conditional GETs, so a 304 still carries fresh
+      // counts - here the total changed and the next-page link is gone.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 304,
+        headers: paginationHeaders({ ETag: 'W/"cards1"', "X-Total-Count": "240" }),
+      });
+
+      const second = await client.getCards("123");
+
+      expect(second).toEqual({
+        cards: mockCards,
+        page: 1,
+        total_count: 240,
+        has_more: false,
+        next_page: null,
+      });
+    });
+
+    it("builds the envelope from the successful attempt after a retry", async () => {
+      const clientWithRetry = new FizzyClient({
+        accessToken: "test-token",
+        baseUrl: "https://app.fizzy.do",
+        maxRetries: 2,
+        retryBaseDelay: 10,
+      });
+      const mockCards = [{ id: "card1", title: "Card 1" }];
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          text: async () => "Error",
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: paginationHeaders({
+            "X-Total-Count": "238",
+            Link: '<https://app.fizzy.do/123/cards?page=2>; rel="next"',
+          }),
+          json: async () => mockCards,
+        });
+
+      const result = await clientWithRetry.getCards("123");
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({
+        cards: mockCards,
+        page: 1,
+        total_count: 238,
+        has_more: true,
+        next_page: 2,
+      });
     });
   });
 

--- a/tests/integration/api.integration.test.ts
+++ b/tests/integration/api.integration.test.ts
@@ -91,14 +91,19 @@ describe.skipIf(!shouldRun)("Fizzy API Integration Tests", () => {
     });
 
     it("GET /:account_slug/cards - discovers existing cards", async () => {
-      const cards = await client!.getCards(testData.accountSlug);
+      const page = await client!.getCards(testData.accountSlug);
 
-      expect(cards).toBeDefined();
+      expect(page).toBeDefined();
+      expect(Array.isArray(page.cards)).toBe(true);
 
-      if (cards.length > 0) {
-        const card = cards[0] as { number: number };
+      if (page.cards.length > 0) {
+        const card = page.cards[0] as { number: number };
         testData.existingCardNumber = card.number.toString();
-        console.log(`✓ Setup: Found ${cards.length} cards, using #${testData.existingCardNumber}`);
+        console.log(
+          `✓ Setup: Found ${page.cards.length} cards on page ${page.page} ` +
+          `(total_count ${page.total_count}, has_more ${page.has_more}), ` +
+          `using #${testData.existingCardNumber}`
+        );
       } else {
         console.log("✓ Setup: No existing cards found");
       }

--- a/tests/tools/schemas.test.ts
+++ b/tests/tools/schemas.test.ts
@@ -102,6 +102,17 @@ describe("Tool Schemas", () => {
       ).toBe(true);
     });
 
+    it("getCardsSchema should accept a positive integer page", () => {
+      expect(getCardsSchema.safeParse({ account_slug: "123", page: 2 }).success).toBe(true);
+    });
+
+    it("getCardsSchema should reject non-positive, fractional, or string pages", () => {
+      expect(getCardsSchema.safeParse({ account_slug: "123", page: 0 }).success).toBe(false);
+      expect(getCardsSchema.safeParse({ account_slug: "123", page: 1.5 }).success).toBe(false);
+      // Strict on purpose: the MCP SDK advertises and validates an integer here.
+      expect(getCardsSchema.safeParse({ account_slug: "123", page: "2" }).success).toBe(false);
+    });
+
     it("getCardSchema should require account_slug and card_id", () => {
       expect(
         getCardSchema.safeParse({ account_slug: "123", card_id: "card1" }).success

--- a/tests/tools/schemas.test.ts
+++ b/tests/tools/schemas.test.ts
@@ -113,6 +113,11 @@ describe("Tool Schemas", () => {
       expect(getCardsSchema.safeParse({ account_slug: "123", page: "2" }).success).toBe(false);
     });
 
+    it("getCardsSchema should reject a page beyond MAX_SAFE_INTEGER", () => {
+      // Number.isInteger(1e100) is true, so this only fails once .max() is checked.
+      expect(getCardsSchema.safeParse({ account_slug: "123", page: 1e100 }).success).toBe(false);
+    });
+
     it("getCardSchema should require account_slug and card_id", () => {
       expect(
         getCardSchema.safeParse({ account_slug: "123", card_id: "card1" }).success

--- a/tests/tools/tool-execution.test.ts
+++ b/tests/tools/tool-execution.test.ts
@@ -667,6 +667,30 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
       expect(mockClient.getCards).not.toHaveBeenCalled();
     });
 
+    it("rejects a page number too large to be a safe integer", async () => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue({ cards: [] }) };
+
+      await expect(
+        toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          page: 1e100,
+        })
+      ).rejects.toThrow("page must be a positive integer (1-based), e.g. 2");
+      expect(mockClient.getCards).not.toHaveBeenCalled();
+    });
+
+    it("rejects an oversized digit-string page", async () => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue({ cards: [] }) };
+
+      await expect(
+        toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          page: "9".repeat(400),
+        })
+      ).rejects.toThrow("page must be a positive integer (1-based), e.g. 2");
+      expect(mockClient.getCards).not.toHaveBeenCalled();
+    });
+
     it("returns the page envelope from the client unchanged", async () => {
       const envelope = {
         cards: [{ id: "card1" }],

--- a/tests/tools/tool-execution.test.ts
+++ b/tests/tools/tool-execution.test.ts
@@ -214,7 +214,15 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
         terms: ["test"],
       });
 
-      expect(result).toEqual(mockCards);
+      // Paginated endpoint: the client returns a page envelope, and this mock
+      // response carries no pagination headers.
+      expect(result).toEqual({
+        cards: mockCards,
+        page: 1,
+        total_count: null,
+        has_more: false,
+        next_page: null,
+      });
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("board_ids%5B%5D=board1"),
         expect.any(Object)
@@ -613,6 +621,68 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
         assignee_ids: ["u1"],
         tag_ids: ["t1"],
       });
+    });
+
+    it("passes a requested page through to the client", async () => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue({ cards: [] }) };
+
+      await toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+        page: 3,
+      });
+
+      expect(mockClient.getCards.mock.calls[0][1].page).toBe(3);
+    });
+
+    it("leaves page undefined when it is not given", async () => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue({ cards: [] }) };
+
+      await toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+      });
+
+      expect(mockClient.getCards.mock.calls[0][1].page).toBeUndefined();
+    });
+
+    it("coerces a digit-string page (LLM clients on the raw-args transport send \"2\")", async () => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue({ cards: [] }) };
+
+      await toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+        page: "2",
+      });
+
+      expect(mockClient.getCards.mock.calls[0][1].page).toBe(2);
+    });
+
+    it.each([0, -1, 1.5, "abc"])("rejects page %p", async (page) => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue({ cards: [] }) };
+
+      await expect(
+        toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          page,
+        })
+      ).rejects.toThrow("page must be a positive integer (1-based), e.g. 2");
+      expect(mockClient.getCards).not.toHaveBeenCalled();
+    });
+
+    it("returns the page envelope from the client unchanged", async () => {
+      const envelope = {
+        cards: [{ id: "card1" }],
+        page: 2,
+        total_count: 238,
+        has_more: true,
+        next_page: 3,
+      };
+      const mockClient = { getCards: vi.fn().mockResolvedValue(envelope) };
+
+      const result = await toolHandlers.fizzy_get_cards(
+        mockClient as unknown as FizzyClient,
+        { account_slug: "123", page: 2 }
+      );
+
+      expect(result).toEqual(envelope);
     });
 
     it("leaves board_ids/column_ids/terms undefined when no filters are given", async () => {


### PR DESCRIPTION
## Problem

`GET /:account_slug/cards` is paginated upstream (geared_pagination in offset mode, server-controlled variable page size: 15, 30, 60+ per page). `FizzyClient.getCards` issued a single GET and returned that page's bare array, discarding the `X-Total-Count` and `Link` headers — so `fizzy_get_cards` silently returned ~15 cards with no signal that (in the reported case) 238 exist.

## Fix — option 2 from the issue: surface pagination, don't aggregate

- `fizzy_get_cards` gains an optional 1-based `page` argument and now returns `{cards, page, total_count, has_more, next_page}` instead of a bare array.
- `has_more` derives solely from the `Link: rel="next"` header (never count arithmetic — page size varies), parsed with a quote-aware RFC 8288 parser (first `rel` per link-value wins). `next_page` is derived as `page + 1`: offset portioning guarantees sequential integer pages, and parsing the Link URL would only add failure modes that silently truncate iteration.
- ETag caching stays correct: pagination metadata is stored as an opaque `meta` field alongside cached bodies (`ETagCache.set/getEntry`), and on a `304` the fresh response headers win (Rails still runs the action on a conditional GET — verified live), with cached meta as fallback.
- `page` is validated at every entry point: strict zod integer (stdio path), manual safe-integer validation with digit-string leniency in the shared handler (the Cloudflare transport executes raw args without zod), and a defensive guard in the client. Values like `1e100`, where `page + 1 === page`, are rejected everywhere.
- The tool description documents the iteration contract: **continue with `page = next_page` until `has_more` is false OR `cards` comes back empty.** The second clause matters: a past-the-end page returns `200` + empty array but still emits a `Link` header (upstream quirk, verified live).
- Version bumped to 1.1.0 — the tool's response shape changed (array → envelope). LLM callers re-read the tool description each session, so this is soft-breaking by design; total_count/has_more is the entire point of the fix.

Auto-aggregation of all pages was deliberately not implemented (rejected in the issue — a full sweep of the reported board is ~9 MB of card payloads).

## Live verification against app.fizzy.do

- Page 1: 15 cards, `x-total-count: 238`, `link: <…?page=2>; rel="next"`. Last page (5, 43 cards — size varies): **no** Link header. `?page=999`: `200` + `[]` + Link still present.
- `If-None-Match` request: `304` carrying fresh `x-total-count` and `link` headers.

## Tests

~35 new/updated tests: header parsing (absent headers, non-numeric/negative `X-Total-Count`, unquoted `rel=next`, `rel="prev next"` token lists, quoted-string edge cases incl. `title="literal; rel=next; suffix"`, first-rel-wins), ETag 304 cached-meta reuse and fresh-header precedence, retry-path pinning (headers of failed responses are never read), page validation on all three layers, past-the-end pages, and `?page=` presence/absence in request URLs.

Full verification: `typecheck`, `typecheck:cf`, `build` clean; `test:cloudflare` 98/98; `npm test` 404 passed with only the 5 pre-existing port-bind environment failures (identical on main).

Fixes #20

## Pre-merge smoke test (~2 min)

The mocked-fetch tests cannot cover real header behavior end-to-end, and a regression here is silent (page 1 still "works").

1. With a real token, call `fizzy_get_cards` (no filters) against an account with >15 cards → expect a JSON **object** with `cards` (~15 items), `total_count` equal to the account's real card count, `has_more: true`, `next_page: 2`. Then call with `page: 2` → different card IDs and `"page": 2` echoed in the response.
2. *(Optional)* Call with `page` well past the end → `cards: []` (confirms the documented stop-on-empty contract).
