### PR TITLE
fix: update tool definitions to use JSON Schema draft 2020-12 compliance

### DIFF
--- a/src/cloudflare/mcp-session.ts
+++ b/src/cloudflare/mcp-session.ts
@@ -15,7 +15,6 @@
  */
 
 import { DurableObject } from "cloudflare:workers";
-import { zodToJsonSchema } from "zod-to-json-schema";
 import { FizzyClient } from "../client/fizzy-client.js";
 import type {
   Env,
@@ -37,7 +36,10 @@ import {
   type CloudflareAnalytics,
   type LogLevel,
 } from "./utils/index.js";
-import { ALL_TOOLS } from "../tools/definitions.js";
+import {
+  buildMcpToolDefinitions,
+  type McpToolDefinition,
+} from "../tools/json-schema.js";
 import { executeToolHandler } from "../tools/handlers.js";
 
 /**
@@ -285,45 +287,12 @@ export class McpSessionDO extends DurableObject<Env> {
 
   /**
    * Get tool definitions
-   * 
+   *
    * Uses centralized tool definitions from tools/definitions.ts and converts
    * Zod schemas to JSON Schema for MCP protocol compatibility.
    */
-  private getToolDefinitions(): Array<{
-    name: string;
-    title?: string;
-    description: string;
-    inputSchema: Record<string, unknown>;
-    annotations?: {
-      readOnlyHint?: boolean;
-      destructiveHint?: boolean;
-    };
-  }> {
-    return ALL_TOOLS.map((toolDef) => {
-      // Convert Zod schema to JSON Schema
-      const jsonSchema = zodToJsonSchema(toolDef.schema, {
-        target: "jsonSchema2019-09",
-        $refStrategy: "none",
-      }) as Record<string, unknown>;
-
-      // Remove $schema field (MCP defaults to 2020-12)
-      if ("$schema" in jsonSchema) {
-        delete jsonSchema.$schema;
-      }
-
-      // Add strict mode (additionalProperties: false)
-      if (jsonSchema.type === "object") {
-        jsonSchema.additionalProperties = false;
-      }
-
-      return {
-        name: toolDef.name,
-        title: toolDef.title,
-        description: toolDef.description,
-        inputSchema: jsonSchema,
-        annotations: toolDef.annotations,
-      };
-    });
+  private getToolDefinitions(): McpToolDefinition[] {
+    return buildMcpToolDefinitions();
   }
 
   /**

--- a/src/tools/json-schema.ts
+++ b/src/tools/json-schema.ts
@@ -1,0 +1,74 @@
+/**
+ * Zod → JSON Schema conversion for MCP tool definitions
+ *
+ * MCP declares tool `inputSchema` to be JSON Schema draft 2020-12. Strict clients
+ * validate it — the Anthropic Messages API rejects the *entire* request with
+ * `tools.N.custom.input_schema: JSON schema is invalid` when any single tool schema
+ * carries a legacy draft-04 keyword. One bad schema therefore takes down every tool
+ * in the list, so the conversion lives here behind a regression test rather than
+ * being inlined per transport.
+ *
+ * @see tests/tools/json-schema.test.ts
+ */
+
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { ALL_TOOLS, type ToolDefinition } from "./definitions.js";
+
+/**
+ * A tool as served over the wire by `tools/list`.
+ */
+export interface McpToolDefinition {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+  };
+}
+
+/**
+ * Convert a tool's Zod schema into the JSON Schema published to clients.
+ *
+ * `target: "jsonSchema7"` is deliberate and load-bearing. It is the only target for
+ * which zod-to-json-schema emits *numeric* `exclusiveMinimum` / `exclusiveMaximum`;
+ * every other target — including "jsonSchema2019-09" — falls back to the draft-04
+ * boolean flag (`exclusiveMinimum: true`), which is invalid under draft 2020-12.
+ * The two drafts agree on everything else this codebase emits, and `$refStrategy:
+ * "none"` inlines all definitions so the `definitions` / `$defs` naming difference
+ * never surfaces.
+ */
+export function toolInputJsonSchema(
+  schema: ToolDefinition["schema"]
+): Record<string, unknown> {
+  const jsonSchema = zodToJsonSchema(schema, {
+    target: "jsonSchema7",
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+
+  // Remove $schema field (MCP defaults to 2020-12)
+  if ("$schema" in jsonSchema) {
+    delete jsonSchema.$schema;
+  }
+
+  // Add strict mode (additionalProperties: false)
+  if (jsonSchema.type === "object") {
+    jsonSchema.additionalProperties = false;
+  }
+
+  return jsonSchema;
+}
+
+/**
+ * Build the full tool list served by `tools/list`.
+ */
+export function buildMcpToolDefinitions(): McpToolDefinition[] {
+  return ALL_TOOLS.map((toolDef) => ({
+    name: toolDef.name,
+    title: toolDef.title,
+    description: toolDef.description,
+    inputSchema: toolInputJsonSchema(toolDef.schema),
+    annotations: toolDef.annotations,
+  }));
+}

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -155,7 +155,11 @@ export const getCardsSchema = z.object({
     "Text search to filter cards by content. Multi-word input is matched as a single search term. " +
     "Omit to return all cards (subject to other filters)."
   ),
-  page: z.number().int().positive().max(Number.MAX_SAFE_INTEGER).optional().describe(
+  // Use .min(1) rather than .positive(): both mean "page >= 1" for an integer, but
+  // .positive() is an *exclusive* bound, which zod-to-json-schema renders as the
+  // draft-04 `exclusiveMinimum: true` flag. Draft 2020-12 requires a numeric bound,
+  // so the exclusive form makes the whole tool list unusable for strict clients.
+  page: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER).optional().describe(
     "Page number to fetch (1-based). Card listings are paginated with a server-controlled, variable page size " +
     "(early pages are small, e.g. 15 cards; later pages are larger). Omit for the first page; " +
     "pass the next_page value from the previous response to fetch subsequent pages."

--- a/tests/tools/json-schema.test.ts
+++ b/tests/tools/json-schema.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tool JSON Schema Tests
+ *
+ * MCP publishes tool `inputSchema` as JSON Schema draft 2020-12, and strict clients
+ * validate it. The Anthropic Messages API rejects the *whole* request — every tool,
+ * not just the offending one — with `tools.N.custom.input_schema: JSON schema is
+ * invalid` when a schema carries a pre-2019 keyword. A single bad Zod modifier is
+ * therefore a total outage for that client, so every tool is swept here.
+ *
+ * Regression: `page: z.number().int().positive()` on fizzy_get_cards rendered as the
+ * draft-04 `exclusiveMinimum: true`, which broke tools/list for Claude clients.
+ */
+
+import { describe, it, expect } from "vitest";
+import { ALL_TOOLS } from "../../src/tools/definitions.js";
+import {
+  buildMcpToolDefinitions,
+  toolInputJsonSchema,
+} from "../../src/tools/json-schema.js";
+
+const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+
+const VALID_TYPES = new Set([
+  "object",
+  "array",
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "null",
+]);
+
+/** Keywords that a draft 2020-12 validator rejects or silently ignores. */
+function findLegacyKeywords(node: unknown, path: string): string[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((item, i) => findLegacyKeywords(item, `${path}[${i}]`));
+  }
+  if (node === null || typeof node !== "object") {
+    return [];
+  }
+
+  const schema = node as Record<string, unknown>;
+  const problems: string[] = [];
+  const at = path || "<root>";
+
+  for (const keyword of ["exclusiveMinimum", "exclusiveMaximum"]) {
+    if (typeof schema[keyword] === "boolean") {
+      problems.push(
+        `${at}: "${keyword}" is a boolean (draft-04); draft 2020-12 requires a number`
+      );
+    }
+  }
+  if (Array.isArray(schema.items)) {
+    problems.push(`${at}: "items" is a tuple (draft-07); use "prefixItems"`);
+  }
+  if ("additionalItems" in schema) {
+    problems.push(`${at}: "additionalItems" was removed in draft 2020-12`);
+  }
+  if ("definitions" in schema) {
+    problems.push(`${at}: "definitions" is draft-07; draft 2020-12 uses "$defs"`);
+  }
+  if ("dependencies" in schema) {
+    problems.push(
+      `${at}: "dependencies" was split into "dependentSchemas"/"dependentRequired"`
+    );
+  }
+  if (typeof schema.$schema === "string" && schema.$schema !== DRAFT_2020_12) {
+    problems.push(`${at}: "$schema" declares ${schema.$schema}`);
+  }
+  if (typeof schema.required === "boolean") {
+    problems.push(`${at}: "required" is a boolean (draft-03)`);
+  }
+
+  const declaredType = schema.type;
+  const types =
+    typeof declaredType === "string"
+      ? [declaredType]
+      : Array.isArray(declaredType)
+        ? declaredType
+        : [];
+  for (const type of types) {
+    if (typeof type !== "string" || !VALID_TYPES.has(type)) {
+      problems.push(`${at}: invalid type ${JSON.stringify(type)}`);
+    }
+  }
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (
+      (key === "properties" || key === "$defs" || key === "patternProperties") &&
+      value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value)
+    ) {
+      for (const [child, childSchema] of Object.entries(
+        value as Record<string, unknown>
+      )) {
+        problems.push(...findLegacyKeywords(childSchema, `${at}.${key}.${child}`));
+      }
+    } else if (value !== null && typeof value === "object") {
+      problems.push(...findLegacyKeywords(value, `${at}.${key}`));
+    }
+  }
+
+  return problems;
+}
+
+describe("Tool JSON Schema — draft 2020-12 compliance", () => {
+  const tools = buildMcpToolDefinitions();
+
+  it("publishes one schema per registered tool", () => {
+    expect(tools).toHaveLength(ALL_TOOLS.length);
+    expect(tools.length).toBeGreaterThan(0);
+  });
+
+  it("emits no pre-2019 JSON Schema keywords in any tool", () => {
+    const problems = tools.flatMap((tool) =>
+      findLegacyKeywords(tool.inputSchema, "").map(
+        (problem) => `${tool.name} ${problem}`
+      )
+    );
+
+    expect(problems).toEqual([]);
+  });
+
+  it.each(ALL_TOOLS.map((tool) => tool.name))(
+    "%s publishes a strict object schema",
+    (name) => {
+      const tool = tools.find((candidate) => candidate.name === name);
+
+      expect(tool).toBeDefined();
+      expect(tool!.inputSchema.type).toBe("object");
+      expect(tool!.inputSchema.additionalProperties).toBe(false);
+      expect(tool!.inputSchema.$schema).toBeUndefined();
+    }
+  );
+});
+
+describe("Tool JSON Schema — fizzy_get_cards pagination", () => {
+  const pageSchema = () => {
+    const tool = buildMcpToolDefinitions().find(
+      (candidate) => candidate.name === "fizzy_get_cards"
+    );
+    const properties = tool!.inputSchema.properties as Record<string, unknown>;
+    return properties.page as Record<string, unknown>;
+  };
+
+  it("bounds page with an inclusive numeric minimum", () => {
+    const page = pageSchema();
+
+    expect(page.type).toBe("integer");
+    expect(page.minimum).toBe(1);
+    expect(page).not.toHaveProperty("exclusiveMinimum");
+  });
+
+  it("keeps the upper bound inclusive and numeric", () => {
+    const page = pageSchema();
+
+    expect(page.maximum).toBe(Number.MAX_SAFE_INTEGER);
+    expect(page).not.toHaveProperty("exclusiveMaximum");
+  });
+
+  it("still rejects page 0 and accepts page 1 at the Zod layer", () => {
+    const schema = ALL_TOOLS.find(
+      (tool) => tool.name === "fizzy_get_cards"
+    )!.schema;
+
+    expect(
+      schema.safeParse({ account_slug: "6117483", page: 0 }).success
+    ).toBe(false);
+    expect(
+      schema.safeParse({ account_slug: "6117483", page: 1 }).success
+    ).toBe(true);
+  });
+});
+
+describe("toolInputJsonSchema", () => {
+  it("strips $schema and enforces additionalProperties on every tool", () => {
+    for (const tool of ALL_TOOLS) {
+      const schema = toolInputJsonSchema(tool.schema);
+
+      expect(schema).not.toHaveProperty("$schema");
+      expect(schema.additionalProperties).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`fizzy_get_cards` currently publishes an input schema that strict MCP clients reject:

```json
"page": { "type": "integer", "exclusiveMinimum": true, "minimum": 0, "maximum": 9007199254740991 }
```

The boolean `exclusiveMinimum` is draft-04. MCP declares `inputSchema` as JSON Schema draft 2020-12, where the bound must be numeric, so the Anthropic Messages API rejects the request with `400 tools.N.custom.input_schema: JSON schema is invalid`. Tool definitions are validated as a set, so this disables **all 49 tools**, not just `fizzy_get_cards` — and once the tool enters a client's tool list, every subsequent message in that session fails, including ones that call no tools. Introduced in #27, which added the first numeric field in the codebase.

Two independent causes, both addressed:

- `src/tools/schemas.ts` — `page` used `.positive()`, an exclusive bound. Now `.min(1)`, which is equivalent for a 1-based integer page and renders as a plain `minimum`.
- `src/cloudflare/mcp-session.ts` — conversion ran with `target: "jsonSchema2019-09"`. `jsonSchema7` is the only zod-to-json-schema target that emits numeric `exclusiveMinimum`/`exclusiveMaximum`; every other target falls back to the draft-04 flag. Switching it prevents the next `.positive()` / `.gt()` / `.lt()` from reintroducing the same outage.

The conversion moved out of `McpSessionDO` into `src/tools/json-schema.ts` (body unchanged apart from the target) so it can be covered by a test. `getToolDefinitions()` was a private method on a Durable Object that imports `cloudflare:workers`, so the real conversion was unreachable from the test suite — which is why the regression shipped uncaught.

Wire-format impact is limited to the one field: 48 of 49 published schemas are byte-identical to what production serves today.

## Test plan

- `npm run typecheck`, `npm run typecheck:cf`, `npm run build` — clean
- `npm test` — 464 tests, including 55 new in `tests/tools/json-schema.test.ts`
- `npm run test:cloudflare` — 98 passed
- Generated tool list diffed field-by-field against the schemas served by production: only `fizzy_get_cards.page` differs (`exclusiveMinimum: true, minimum: 0` → `minimum: 1`); the other 48 schemas are unchanged.

The new test sweeps every registered tool for pre-2019 keywords (boolean exclusive bounds, tuple `items`, `additionalItems`, `definitions`, `dependencies`, boolean `required`, foreign `$schema`) and asserts each tool publishes a strict object schema. It fails on `main` as it stands.

Unrelated pre-existing flake, present on `main` without these changes (~4 failures in 5 full-suite runs, passes in isolation): `tests/transports/http-multi-user.test.ts > should reject request with mismatched token for existing session`, `expected 200 to be 403`. Not addressed here.

## Declarations

- [ ] This PR adds or changes dependencies (`package.json` / `package-lock.json`)
- [ ] This PR changes build or deploy configuration (`tsconfig*.json`, `wrangler.jsonc`, `.github/`)
- [ ] This PR adds npm lifecycle scripts (preinstall/postinstall/prepare)

None checked — no dependency, build, deploy, or lifecycle-script changes.

Worth a follow-up, out of scope here: `zod-to-json-schema` is imported directly but is not declared in `package.json`; it resolves transitively through `@modelcontextprotocol/sdk`. Since schema validity now depends on that library's target behaviour, an SDK bump could change published output with nothing visible in the diff.
