### PR TITLE
feat(tools): add fizzy_upload_file for rich-text attachments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,12 @@ src/
 │   ├── logger.ts         # Structured stderr logging
 │   ├── security.ts       # CORS, auth, localhost binding
 │   ├── session-manager.ts
-│   └── etag-cache.ts
+│   ├── etag-cache.ts
+│   ├── card-resolver.ts  # card_id → card_number
+│   ├── attachments.ts    # Upload input resolution + ActionText markup
+│   ├── file-source.ts    # Injected local-file capability (stdio only)
+│   ├── md5.ts            # Runtime-independent MD5 (upload checksums)
+│   └── base64.ts         # btoa/atob helpers that also work on Workers
 └── cloudflare/           # Workers deployment (Durable Objects)
 ```
 
@@ -89,6 +94,8 @@ npm run start:http    # Streamable HTTP transport (port 3000)
 - Logging goes to stderr (never stdout — it interferes with stdio transport)
 - `FizzyClient` is passed into handlers via dependency injection, not imported as a global
 - Security: localhost binding by default, origin validation, per-user token isolation for HTTP/SSE transports
+- **Never import `node:fs` (or any filesystem API) into `client/`, `tools/` or `utils/`.** That code is shared with the Cloudflare Worker, which has no filesystem, and with the HTTP/SSE transports, which serve *remote* callers — reading a caller-supplied path there would let a client exfiltrate the server's disk. Local file access is a capability injected at startup via `utils/file-source.ts`, and only `startStdioTransport` in `index.ts` installs it. Leave the default (no reader) alone; it is what keeps every other transport closed
+- Anything reached from `client/`, `tools/` or `utils/` must also run on Workers: no `Buffer`, no `node:crypto`, no reliance on the `nodejs_compat` flag. New files there must be added to `tsconfig.cloudflare.json`'s `include`, or CI's Cloudflare typecheck will not cover them
 - Error classes in `utils/errors.ts` carry status codes and support retry detection
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ npx fizzy-mcp --transport http --port 3000
 
 ---
 
-## Available Tools (47 total)
+## Available Tools (50 total)
 
 ### Identity & Accounts (3)
 | Tool | Description |
@@ -599,6 +599,58 @@ npx fizzy-mcp --transport http --port 3000
 | `fizzy_mark_notification_unread` | Mark notification as unread |
 | `fizzy_mark_all_notifications_read` | Mark all notifications as read |
 
+### Attachments (1)
+| Tool | Description |
+|------|-------------|
+| `fizzy_upload_file` | Upload a file and get back HTML that embeds it in rich text |
+
+#### Attaching a file to a card or comment
+
+`fizzy_upload_file` uploads the file and returns an `attachment_html` snippet. It
+does not attach anything by itself — every rich-text field already accepts HTML,
+so you include the snippet wherever you want the file to appear:
+
+```jsonc
+// 1. Upload. Use file_path locally, or base64_data anywhere.
+{ "name": "fizzy_upload_file",
+  "arguments": { "account_slug": "123456", "file_path": "/tmp/screenshot.png" } }
+
+// Returns:
+// {
+//   "attachable_sgid": "eyJfcmFpbHMi...",
+//   "filename": "screenshot.png",
+//   "content_type": "image/png",
+//   "byte_size": 8124,
+//   "attachment_html": "<action-text-attachment sgid=\"eyJfcmFpbHMi...\"></action-text-attachment>"
+// }
+
+// 2. Reference it in any rich-text field — a comment body here, but a card
+//    description works the same way.
+{ "name": "fizzy_create_comment",
+  "arguments": {
+    "account_slug": "123456",
+    "card_number": "42",
+    "body": "<p>Steps to reproduce:</p><action-text-attachment sgid=\"eyJfcmFpbHMi...\"></action-text-attachment>"
+  } }
+```
+
+Use `attachment_html` verbatim. It carries the blob's `attachable_sgid`, which is
+the only token ActionText resolves; a hand-built tag using some other signed id
+will save without error and then render as a broken-attachment placeholder.
+
+**File input:** provide exactly one of `file_path` or `base64_data`.
+
+| Input | stdio | HTTP / SSE | Cloudflare Workers |
+|-------|-------|-----------|--------------------|
+| `base64_data` (+ `filename`) | ✅ | ✅ | ✅ |
+| `file_path` | ✅ | ❌ rejected | ❌ rejected |
+
+`file_path` is accepted only on stdio, where the MCP client and the server are
+the same user, so the server reads nothing that user could not already read. The
+HTTP and SSE transports serve remote callers — honouring a path there would let a
+client read the *server's* disk — and Workers have no filesystem. Uploads are
+capped at 10 MB on both paths.
+
 ---
 
 ## Example Prompts
@@ -611,6 +663,7 @@ Once configured, you can ask your AI assistant things like:
 - "What cards are assigned to me?"
 - "Move the 'Design review' card to the 'Done' column"
 - "Add a comment to the authentication card saying 'Ready for review'"
+- "Attach this screenshot to card 42 as evidence"
 - "Show me my unread notifications"
 - "List all users in my account"
 - "Create a new column called 'In Review' with blue color on the Engineering board"

--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -28,6 +28,9 @@ import type {
   UpdateStepRequest,
   CardListOptions,
   CardsPage,
+  DirectUploadBlobRequest,
+  FizzyDirectUpload,
+  FileUpload,
 } from "./types.js";
 import {
   createAPIError,
@@ -39,6 +42,7 @@ import {
 } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { ETagCache } from "../utils/etag-cache.js";
+import { md5Base64 } from "../utils/md5.js";
 
 export interface FizzyClientConfig {
   accessToken: string;
@@ -1270,5 +1274,107 @@ export class FizzyClient {
       "POST",
       `/${slug}/notifications/bulk_reading`
     );
+  }
+
+  // ============ Attachments (ActionText direct upload) ============
+
+  /**
+   * Step 1: register a blob and get back its signed ids plus where to put the bytes.
+   * @endpoint POST /:account_slug/rails/active_storage/direct_uploads
+   * @see https://github.com/basecamp/fizzy/blob/main/docs/api/sections/rich_text.md
+   */
+  async createDirectUpload(
+    accountSlug: string,
+    blob: DirectUploadBlobRequest
+  ): Promise<FizzyDirectUpload> {
+    const slug = this.normalizeSlug(accountSlug);
+    return this.request<FizzyDirectUpload>(
+      "POST",
+      `/${slug}/rails/active_storage/direct_uploads`,
+      { blob }
+    );
+  }
+
+  /**
+   * Step 2: PUT the bytes to the signed storage URL from step 1.
+   *
+   * Deliberately not routed through `request()`, for two reasons. That path
+   * prefixes `baseUrl`, and this URL is absolute and on a storage host; and it
+   * attaches the Fizzy bearer token, which must never be sent to a third party.
+   * Only the headers step 1 handed back are sent — the URL signature covers
+   * exactly those, and storage rejects any mismatch with an error that does not
+   * mention headers.
+   *
+   * No retry: a failure here is worth surfacing rather than replaying against a
+   * signed URL that may since have expired, which would turn one clear error
+   * into a slower and less obvious one. Callers retry the whole upload, which
+   * mints a fresh URL.
+   */
+  private async putBlobToStorage(
+    url: string,
+    headers: Record<string, string>,
+    bytes: Uint8Array
+  ): Promise<void> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(url, {
+        method: "PUT",
+        headers,
+        body: bytes,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw createAPIError(response.status, response.statusText, errorText);
+      }
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new FizzyTimeoutError(
+          `Upload timed out after ${this.timeout}ms`,
+          this.timeout
+        );
+      }
+      if (error instanceof TypeError && error.message.includes("fetch")) {
+        throw new FizzyNetworkError(`Network error during upload: ${error.message}`, error);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Run both steps of the ActionText direct-upload flow and return the blob
+   * record.
+   *
+   * To reference the result in a rich-text field, use the record's
+   * `attachable_sgid` — not its `signed_id`. See {@link FizzyDirectUpload}.
+   */
+  async uploadFile(
+    accountSlug: string,
+    file: FileUpload
+  ): Promise<FizzyDirectUpload> {
+    const upload = await this.createDirectUpload(accountSlug, {
+      filename: file.filename,
+      byte_size: file.bytes.length,
+      checksum: md5Base64(file.bytes),
+      content_type: file.contentType,
+    });
+
+    this.log.debug("Direct upload registered", {
+      filename: upload.filename,
+      byteSize: upload.byte_size,
+    });
+
+    await this.putBlobToStorage(
+      upload.direct_upload.url,
+      upload.direct_upload.headers,
+      file.bytes
+    );
+
+    return upload;
   }
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -233,3 +233,49 @@ export interface CardsPage {
   has_more: boolean;          // Link header contained rel="next"
   next_page: number | null;   // page + 1 when has_more, else null
 }
+
+// ActionText direct uploads — POST /:account_slug/rails/active_storage/direct_uploads
+// See https://github.com/basecamp/fizzy/blob/main/docs/api/sections/rich_text.md
+
+// Serialized directly as the `blob` request body, so these names are the API's.
+export interface DirectUploadBlobRequest {
+  filename: string;
+  byte_size: number;
+  /** Base64-encoded MD5 of the file. Hex is rejected, with an error that does not say so. */
+  checksum: string;
+  content_type: string;
+}
+
+export interface FizzyDirectUpload {
+  id: string;
+  key: string;
+  filename: string;
+  content_type: string;
+  byte_size: number;
+  checksum: string;
+  /**
+   * The signed global id that `<action-text-attachment sgid="…">` requires —
+   * purpose "attachable", wrapping `gid://fizzy/ActiveStorage::Blob/…`.
+   *
+   * Not to be confused with `signed_id` below. Fizzy's rich-text documentation
+   * says to use `signed_id` here; doing so is accepted by the API and then
+   * renders as an unresolved-attachment placeholder, because that token is
+   * scoped to purpose "blob_id" instead. This is the field that works.
+   */
+  attachable_sgid: string;
+  /** Purpose "blob_id" — identifies the blob to ActiveStorage, not to ActionText. */
+  signed_id: string;
+  direct_upload: {
+    /** Storage endpoint, on a different host to the API. */
+    url: string;
+    /** Must be echoed back verbatim on the upload PUT — the signature covers them. */
+    headers: Record<string, string>;
+  };
+}
+
+/** A file to upload, already resolved to bytes by the caller. */
+export interface FileUpload {
+  bytes: Uint8Array;
+  filename: string;
+  contentType: string;
+}

--- a/src/cloudflare/utils/logger.ts
+++ b/src/cloudflare/utils/logger.ts
@@ -275,7 +275,17 @@ export class CloudflareLogger {
     const sanitized: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(args)) {
-      if (sensitiveKeys.some(k => key.toLowerCase().includes(k))) {
+      const lowerKey = key.toLowerCase();
+
+      if (lowerKey === "base64_data") {
+        // The attachment upload's file bytes. Never log any of it — even a
+        // truncated prefix is content, not metadata — but the length is safe
+        // and useful for debugging.
+        sanitized[key] = typeof value === "string" ? `[redacted: ${value.length} chars]` : "[REDACTED]";
+      } else if (lowerKey === "file_path") {
+        // A local filesystem path is sensitive metadata about the caller's machine.
+        sanitized[key] = "[REDACTED]";
+      } else if (sensitiveKeys.some(k => lowerKey.includes(k))) {
         sanitized[key] = "[REDACTED]";
       } else if (typeof value === "string" && value.length > 500) {
         sanitized[key] = value.slice(0, 500) + "...[truncated]";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,11 @@
  * - Configure via environment variables: MCP_ALLOWED_ORIGINS, MCP_AUTH_TOKEN
  */
 
+import { readFile } from "node:fs/promises";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { FizzyClient } from "./client/fizzy-client.js";
 import { createFizzyServer } from "./server.js";
+import { setLocalFileReader } from "./utils/file-source.js";
 import { 
   startHTTPTransport as startSecureHTTPTransport,
   startSSETransport as startSecureSSETransport,
@@ -113,6 +115,12 @@ function createClient(): FizzyClient {
 
 // Start stdio transport - for IDE integrations like Cursor, VS Code, Claude Desktop
 async function startStdioTransport(): Promise<void> {
+  // Only stdio may read local files for fizzy_upload_file: here the MCP client is
+  // the same user who owns this process, so reading their disk grants nothing they
+  // could not already do. The HTTP/SSE transports below serve remote callers and
+  // deliberately never install a reader.
+  setLocalFileReader(async (path) => new Uint8Array(await readFile(path)));
+
   const client = createClient();
   const server = createFizzyServer(client);
   const transport = new StdioServerTransport();

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -670,6 +670,27 @@ export const TOOL_DEFINITIONS = {
       },
     },
   ] as ToolDefinition[],
+
+  // ============ Attachment Tools ============
+  attachments: [
+    {
+      name: "fizzy_upload_file",
+      title: "Upload File",
+      description:
+        "Upload a file (screenshot, image, PDF, log) to Fizzy and get back the HTML needed to embed it. " +
+        "This does not attach the file on its own — it returns an 'attachment_html' snippet that you then " +
+        "include in any rich-text field: pass it in 'body' to fizzy_create_comment or fizzy_update_comment, " +
+        "or in 'description' to fizzy_create_card or fizzy_update_card. Combine it with your own HTML, " +
+        "e.g. body: \"<p>Steps to reproduce:</p>\" + attachment_html. " +
+        "Provide the file as 'file_path' (a local path — stdio transport only) or as 'base64_data' with " +
+        "'filename' (works everywhere).",
+      schema: schemas.uploadFileSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
+    },
+  ] as ToolDefinition[],
 } as const;
 
 /**

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -11,6 +11,7 @@
 import type { FizzyClient } from "../client/fizzy-client.js";
 import { COLUMN_COLORS, type ColumnColor, type CardListOptions } from "../client/types.js";
 import { resolveCardNumber } from "../utils/card-resolver.js";
+import { attachmentHtml, resolveAttachment } from "../utils/attachments.js";
 
 /**
  * Tool handler result - either data to serialize or a success message
@@ -431,6 +432,25 @@ export const toolHandlers: Record<string, ToolHandler> = {
   fizzy_mark_all_notifications_read: async (client, args) => {
     await client.markAllNotificationsAsRead(args.account_slug as string);
     return "All notifications marked as read";
+  },
+
+  // ============ Attachment Tools ============
+  fizzy_upload_file: async (client, args) => {
+    const file = await resolveAttachment(args);
+    const upload = await client.uploadFile(args.account_slug as string, file);
+
+    return {
+      // attachable_sgid, not signed_id — see FizzyDirectUpload for why they differ.
+      attachable_sgid: upload.attachable_sgid,
+      filename: upload.filename,
+      content_type: upload.content_type,
+      byte_size: upload.byte_size,
+      attachment_html: attachmentHtml(upload.attachable_sgid),
+      next_step:
+        "Include attachment_html verbatim in a rich-text field to attach the file — for " +
+        "example as the 'body' of fizzy_create_comment, or the 'description' of " +
+        "fizzy_update_card. Do not rebuild the tag by hand.",
+    };
   },
 };
 

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -508,3 +508,49 @@ export const ungildCardSchema = z.object({
   account_slug: accountSlugSchema,
   card_number: cardNumberSchema,
 });
+
+// ============ Attachment schemas ============
+
+// Deliberately a plain object with no .refine(): McpServer.registerTool reads its
+// fields off the schema's shape, and a refined schema is a ZodEffects wrapper with
+// no shape to read — so refining this would publish `properties: {}` to stdio
+// clients and leave the model unable to see any argument. (Two existing tools are
+// refined and already serve empty schemas over stdio for exactly this reason.)
+// The either/or rules below are enforced at runtime by resolveAttachment, which
+// has to own them regardless: the Cloudflare transport dispatches raw arguments
+// without Zod at all.
+export const uploadFileSchema = z
+  .object({
+    account_slug: accountSlugSchema,
+    file_path: z
+      .string()
+      .optional()
+      .describe(
+        "Absolute path to a local file. Provide exactly one of file_path or base64_data. " +
+        "Only available over the stdio transport, where the caller and the server are the " +
+        "same user; hosted transports reject it. Preferred locally — it avoids inlining " +
+        "the file's bytes into the request."
+      ),
+    base64_data: z
+      .string()
+      .optional()
+      .describe(
+        "The file's bytes, Base64-encoded. Provide exactly one of file_path or base64_data. " +
+        "Works on every transport, and requires filename. Use this when file_path is " +
+        "unavailable."
+      ),
+    filename: z
+      .string()
+      .optional()
+      .describe(
+        "Name to store the file under, e.g. 'screenshot.png'. Required with base64_data; " +
+        "defaults to the basename of file_path otherwise."
+      ),
+    content_type: z
+      .string()
+      .optional()
+      .describe(
+        "MIME type, e.g. 'image/png'. Inferred from the filename extension when omitted, " +
+        "falling back to application/octet-stream."
+      ),
+  });

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -526,8 +526,7 @@ export const ungildCardSchema = z.object({
 // Deliberately a plain object with no .refine(): McpServer.registerTool reads its
 // fields off the schema's shape, and a refined schema is a ZodEffects wrapper with
 // no shape to read — so refining this would publish `properties: {}` to stdio
-// clients and leave the model unable to see any argument. (Two existing tools are
-// refined and already serve empty schemas over stdio for exactly this reason.)
+// clients and leave the model unable to see any argument.
 // The either/or rules below are enforced at runtime by resolveAttachment, which
 // has to own them regardless: the Cloudflare transport dispatches raw arguments
 // without Zod at all.

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -2,10 +2,12 @@
  * Turning a tool call's arguments into the bytes Fizzy's direct-upload flow
  * needs, plus the ActionText markup that references the result.
  *
- * Validation lives here rather than in the Zod schema because the Cloudflare
- * transport executes raw arguments without Zod — the same reason
- * `parseCardsPage` in tools/handlers.ts validates by hand. The Zod schema
- * mirrors these rules so stdio clients get them at the protocol layer too.
+ * Validation lives here rather than in the Zod schema, for two reasons: the
+ * Cloudflare transport executes raw arguments without Zod at all — the same
+ * reason `parseCardsPage` in tools/handlers.ts validates by hand — and the
+ * either/or rules cannot be expressed as Zod refinements without turning the
+ * schema into a ZodEffects, which `McpServer.registerTool` publishes to stdio
+ * clients as an empty property list. So this is the only place they live.
  */
 
 import { base64ToBytes } from "./base64.js";
@@ -51,7 +53,7 @@ export interface ResolvedAttachment {
 /** Strip any directory component, handling both POSIX and Windows separators. */
 function basename(path: string): string {
   const segments = path.split(/[/\\]/);
-  return segments[segments.length - 1] || "";
+  return segments[segments.length - 1];
 }
 
 export function contentTypeForFilename(filename: string): string {

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -129,7 +129,9 @@ export async function resolveAttachment(
     if (!explicitFilename) {
       throw new Error("filename is required when uploading with base64_data");
     }
-    bytes = base64ToBytes(base64Data);
+    // Bound passed through so the limit is enforced before the decode allocates,
+    // not after: this path is reachable by remote callers on http/sse/Workers.
+    bytes = base64ToBytes(base64Data, MAX_ATTACHMENT_BYTES);
     filename = basename(explicitFilename);
   } else {
     throw new Error(

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -123,7 +123,8 @@ export async function resolveAttachment(
       );
     }
     bytes = await readLocalFile(filePath);
-    filename = explicitFilename ?? basename(filePath);
+    // basename either way: an explicit filename is no more trustworthy than a path.
+    filename = basename(explicitFilename ?? filePath);
   } else if (base64Data) {
     if (!explicitFilename) {
       throw new Error("filename is required when uploading with base64_data");

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -10,7 +10,7 @@
  * clients as an empty property list. So this is the only place they live.
  */
 
-import { base64ToBytes } from "./base64.js";
+import { base64ToBytes, maxEncodedLength } from "./base64.js";
 import { getLocalFileReader } from "./file-source.js";
 
 /**
@@ -103,6 +103,19 @@ function optionalString(args: Record<string, unknown>, key: string): string | un
 export async function resolveAttachment(
   args: Record<string, unknown>
 ): Promise<ResolvedAttachment> {
+  // Guard on the raw value before optionalString trims it: .trim() copies the
+  // whole string, so an over-cap base64_data must be rejected before that copy,
+  // not after — the same reasoning base64ToBytes applies to its own input.
+  const rawBase64Data = args.base64_data;
+  if (
+    typeof rawBase64Data === "string" &&
+    rawBase64Data.length > maxEncodedLength(MAX_ATTACHMENT_BYTES)
+  ) {
+    throw new Error(
+      `base64_data is over the ${MAX_ATTACHMENT_BYTES}-byte upload limit`
+    );
+  }
+
   const filePath = optionalString(args, "file_path");
   const base64Data = optionalString(args, "base64_data");
   const explicitFilename = optionalString(args, "filename");

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,0 +1,156 @@
+/**
+ * Turning a tool call's arguments into the bytes Fizzy's direct-upload flow
+ * needs, plus the ActionText markup that references the result.
+ *
+ * Validation lives here rather than in the Zod schema because the Cloudflare
+ * transport executes raw arguments without Zod — the same reason
+ * `parseCardsPage` in tools/handlers.ts validates by hand. The Zod schema
+ * mirrors these rules so stdio clients get them at the protocol layer too.
+ */
+
+import { base64ToBytes } from "./base64.js";
+import { getLocalFileReader } from "./file-source.js";
+
+/**
+ * Upper bound on an attachment, applied to both input modes.
+ *
+ * Base64 inflates by ~4/3, so 10 MB of file is already a ~13.3 MB JSON-RPC
+ * message — beyond this the transport, not the storage backend, is the real
+ * limit, and a clear refusal beats a truncated frame.
+ */
+export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
+/** Extensions worth naming; anything else uploads as a generic download. */
+const CONTENT_TYPES_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  bmp: "image/bmp",
+  pdf: "application/pdf",
+  txt: "text/plain",
+  log: "text/plain",
+  md: "text/markdown",
+  csv: "text/csv",
+  json: "application/json",
+  zip: "application/zip",
+  mp4: "video/mp4",
+  mov: "video/quicktime",
+};
+
+const DEFAULT_CONTENT_TYPE = "application/octet-stream";
+
+export interface ResolvedAttachment {
+  bytes: Uint8Array;
+  filename: string;
+  contentType: string;
+}
+
+/** Strip any directory component, handling both POSIX and Windows separators. */
+function basename(path: string): string {
+  const segments = path.split(/[/\\]/);
+  return segments[segments.length - 1] || "";
+}
+
+export function contentTypeForFilename(filename: string): string {
+  const match = /\.([A-Za-z0-9]+)$/.exec(filename);
+  if (!match) return DEFAULT_CONTENT_TYPE;
+  return CONTENT_TYPES_BY_EXTENSION[match[1].toLowerCase()] ?? DEFAULT_CONTENT_TYPE;
+}
+
+/**
+ * The ActionText element that renders an uploaded blob inside a rich-text field.
+ *
+ * Takes the blob's **`attachable_sgid`**, not its `signed_id`: the two are both
+ * signed tokens for the same blob but carry different purposes, and only the
+ * attachable one resolves here. Passing `signed_id` produces a comment that
+ * saves cleanly and then displays an unresolved-attachment placeholder.
+ *
+ * The value is a Rails signed global id and so carries no markup, but it is
+ * escaped rather than trusted — it lands in an HTML attribute, where the cost
+ * of being wrong is stored XSS.
+ */
+export function attachmentHtml(attachableSgid: string): string {
+  const escaped = attachableSgid
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+  return `<action-text-attachment sgid="${escaped}"></action-text-attachment>`;
+}
+
+function optionalString(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") {
+    throw new Error(`${key} must be a string`);
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+/**
+ * Resolve `file_path` or `base64_data` into bytes plus the metadata the
+ * direct-upload request needs.
+ *
+ * @throws Error with a message naming the argument at fault — these surface
+ * verbatim to the model, so they have to say what to send instead.
+ */
+export async function resolveAttachment(
+  args: Record<string, unknown>
+): Promise<ResolvedAttachment> {
+  const filePath = optionalString(args, "file_path");
+  const base64Data = optionalString(args, "base64_data");
+  const explicitFilename = optionalString(args, "filename");
+  const explicitContentType = optionalString(args, "content_type");
+
+  if (filePath && base64Data) {
+    throw new Error("Provide either file_path or base64_data, not both");
+  }
+
+  let bytes: Uint8Array;
+  let filename: string;
+
+  if (filePath) {
+    const readLocalFile = getLocalFileReader();
+    if (!readLocalFile) {
+      throw new Error(
+        "file_path is only supported on the stdio transport, where the caller and the " +
+          "server are the same user. Read the file yourself and pass base64_data with " +
+          "filename instead."
+      );
+    }
+    bytes = await readLocalFile(filePath);
+    filename = explicitFilename ?? basename(filePath);
+  } else if (base64Data) {
+    if (!explicitFilename) {
+      throw new Error("filename is required when uploading with base64_data");
+    }
+    bytes = base64ToBytes(base64Data);
+    filename = basename(explicitFilename);
+  } else {
+    throw new Error(
+      "Provide the file to upload as either file_path (stdio transport only) or base64_data"
+    );
+  }
+
+  if (!filename) {
+    throw new Error("Could not determine a filename for the upload");
+  }
+  if (bytes.length === 0) {
+    throw new Error(`${filename} is empty — there is nothing to upload`);
+  }
+  if (bytes.length > MAX_ATTACHMENT_BYTES) {
+    throw new Error(
+      `${filename} is ${bytes.length} bytes, over the ${MAX_ATTACHMENT_BYTES}-byte upload limit`
+    );
+  }
+
+  return {
+    bytes,
+    filename,
+    contentType: explicitContentType ?? contentTypeForFilename(filename),
+  };
+}

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -17,16 +17,43 @@ export function bytesToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
+/** base64url characters mapped to their standard equivalents; whitespace drops. */
+const BASE64URL_REPLACEMENTS: Record<string, string> = { "-": "+", _: "/" };
+
+/** Bytes a normalized, unpadded base64 string decodes to: 4 characters carry 3. */
+function decodedLength(unpaddedBase64: string): number {
+  return Math.floor((unpaddedBase64.length * 3) / 4);
+}
+
 /**
  * Decode base64 to bytes, accepting the base64url alphabet and missing padding
  * as well — MCP clients produce both, and rejecting them would surface as an
  * opaque "invalid base64" for input that is perfectly recoverable.
  *
- * @throws Error when the input is not decodable as base64.
+ * `maxBytes` bounds the decode itself rather than its result. Decoding is where
+ * the memory goes — `atob` materializes a string the size of the output, and the
+ * copy below materializes it again as bytes — so a caller-supplied limit has to
+ * be checked before that work, not after it. The size is computed from the
+ * encoded length, which is exact and costs nothing.
+ *
+ * @throws Error when the input is not decodable, or would exceed `maxBytes`.
  */
-export function base64ToBytes(input: string): Uint8Array {
-  const normalized = input.replace(/\s+/g, "").replace(/-/g, "+").replace(/_/g, "/");
-  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+export function base64ToBytes(input: string, maxBytes?: number): Uint8Array {
+  // One pass: each additional pass copies the whole string, which is precisely
+  // the allocation this function is trying not to make on hostile input.
+  const normalized = input.replace(
+    /\s+|[-_]/g,
+    (match) => BASE64URL_REPLACEMENTS[match] ?? ""
+  );
+  const unpadded = normalized.replace(/=+$/, "");
+
+  if (maxBytes !== undefined && decodedLength(unpadded) > maxBytes) {
+    throw new Error(
+      `base64_data decodes to ${decodedLength(unpadded)} bytes, over the ${maxBytes}-byte upload limit`
+    );
+  }
+
+  const padded = unpadded.padEnd(Math.ceil(unpadded.length / 4) * 4, "=");
 
   let binary: string;
   try {

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -45,24 +45,54 @@ function significantLength(input: string): number {
 }
 
 /**
+ * Upper bound on the raw (undecoded) input length for a given `maxBytes`, i.e.
+ * before any padding/whitespace is stripped. `dataChars` is the base64 length
+ * of `maxBytes` worth of data; the rest is slack for padding (up to 2 chars)
+ * plus realistic line-wrapping whitespace (~6%, generous for MCP clients that
+ * wrap at 64 or 76 columns).
+ *
+ * This is a hard cap, not an estimate: legitimate input never needs more than
+ * this many characters, so anything longer is rejected on length alone.
+ */
+export function maxEncodedLength(maxBytes: number): number {
+  const dataChars = Math.ceil(maxBytes / 3) * 4;
+  return dataChars + Math.ceil(dataChars / 16) + 64;
+}
+
+/**
  * Decode base64 to bytes, accepting the base64url alphabet and missing padding
  * as well — MCP clients produce both, and rejecting them would surface as an
  * opaque "invalid base64" for input that is perfectly recoverable.
  *
- * `maxBytes` bounds the work this function does, not merely its result. Every
- * step here allocates something proportional to the input — normalization copies
- * the string, `atob` materializes the output, and the loop below materializes it
- * again as bytes — so the limit is enforced ahead of all of them. Sizes come from
- * character counts, which are exact for base64 and need no allocation.
+ * `maxBytes` bounds the work this function does, not merely its result. Whitespace
+ * and `=` are skipped, not counted, by the significant-length scan below, so raw
+ * input can be arbitrarily longer than what it decodes to — megabytes of padding
+ * or line-wrapping around a tiny payload would otherwise pass every check that
+ * only looks at decoded size. `maxEncodedLength` closes that: it is a pure length
+ * comparison against the raw string, done first, so nothing past this function's
+ * first line allocates or scans more than an input within the raw cap. Every step
+ * beyond it allocates something proportional to input length — normalization
+ * copies the string, `atob` materializes the output, and the loop below
+ * materializes it again as bytes — and all of them are now bounded by that cap.
  *
  * @throws Error when the input is not decodable, or would exceed `maxBytes`.
  */
 export function base64ToBytes(input: string, maxBytes?: number): Uint8Array {
+  // Pure length comparison: no allocation, no scan. Must run before anything
+  // else touches the string, since raw length is otherwise unbounded relative
+  // to decoded size (see the doc comment above).
+  if (maxBytes !== undefined && input.length > maxEncodedLength(maxBytes)) {
+    throw new Error(
+      `base64_data is over the ${maxBytes}-byte upload limit`
+    );
+  }
+
   // Reject before normalizing, not just before decoding: normalization copies the
   // whole input, so a check placed after it would still let a caller force an
   // allocation the size of their payload. The length comparison clears every
   // input that cannot possibly be over the limit, so only suspiciously long ones
-  // pay for the counting scan, which allocates nothing.
+  // pay for the counting scan, which allocates nothing. Bounded by the raw cap
+  // above, so this scan is now proportional to a size this function controls.
   if (maxBytes !== undefined && input.length > Math.ceil(maxBytes / 3) * 4) {
     const decoded = Math.floor((significantLength(input) * 3) / 4);
     if (decoded > maxBytes) {

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,0 +1,43 @@
+/**
+ * Base64 helpers that behave identically on Node and Cloudflare Workers.
+ *
+ * `btoa`/`atob` are the only encoders both runtimes ship natively — `Buffer`
+ * exists on Workers solely behind the `nodejs_compat` flag, and this module is
+ * reached from the shared client, so it must not depend on that flag staying on.
+ */
+
+/** Chunked to keep large inputs off the argument stack of `String.fromCharCode`. */
+const CHUNK_SIZE = 0x8000;
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK_SIZE));
+  }
+  return btoa(binary);
+}
+
+/**
+ * Decode base64 to bytes, accepting the base64url alphabet and missing padding
+ * as well — MCP clients produce both, and rejecting them would surface as an
+ * opaque "invalid base64" for input that is perfectly recoverable.
+ *
+ * @throws Error when the input is not decodable as base64.
+ */
+export function base64ToBytes(input: string): Uint8Array {
+  const normalized = input.replace(/\s+/g, "").replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+
+  let binary: string;
+  try {
+    binary = atob(padded);
+  } catch {
+    throw new Error("base64_data is not valid base64");
+  }
+
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -20,9 +20,28 @@ export function bytesToBase64(bytes: Uint8Array): string {
 /** base64url characters mapped to their standard equivalents; whitespace drops. */
 const BASE64URL_REPLACEMENTS: Record<string, string> = { "-": "+", _: "/" };
 
+/** Stateless (no /g), so `.test` does not carry lastIndex between calls. */
+const WHITESPACE = /\s/;
+
 /** Bytes a normalized, unpadded base64 string decodes to: 4 characters carry 3. */
 function decodedLength(unpaddedBase64: string): number {
   return Math.floor((unpaddedBase64.length * 3) / 4);
+}
+
+/**
+ * How many characters actually encode data, counted without building a copy of
+ * the input: whitespace is dropped by normalization, `=` is padding, and the
+ * base64url swaps are one-for-one. Excluding `=` matters — counting it would
+ * overestimate by up to two bytes and reject a payload sitting exactly on the
+ * limit.
+ */
+function significantLength(input: string): number {
+  let count = 0;
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+    if (char !== "=" && !WHITESPACE.test(char)) count++;
+  }
+  return count;
 }
 
 /**
@@ -30,15 +49,29 @@ function decodedLength(unpaddedBase64: string): number {
  * as well — MCP clients produce both, and rejecting them would surface as an
  * opaque "invalid base64" for input that is perfectly recoverable.
  *
- * `maxBytes` bounds the decode itself rather than its result. Decoding is where
- * the memory goes — `atob` materializes a string the size of the output, and the
- * copy below materializes it again as bytes — so a caller-supplied limit has to
- * be checked before that work, not after it. The size is computed from the
- * encoded length, which is exact and costs nothing.
+ * `maxBytes` bounds the work this function does, not merely its result. Every
+ * step here allocates something proportional to the input — normalization copies
+ * the string, `atob` materializes the output, and the loop below materializes it
+ * again as bytes — so the limit is enforced ahead of all of them. Sizes come from
+ * character counts, which are exact for base64 and need no allocation.
  *
  * @throws Error when the input is not decodable, or would exceed `maxBytes`.
  */
 export function base64ToBytes(input: string, maxBytes?: number): Uint8Array {
+  // Reject before normalizing, not just before decoding: normalization copies the
+  // whole input, so a check placed after it would still let a caller force an
+  // allocation the size of their payload. The length comparison clears every
+  // input that cannot possibly be over the limit, so only suspiciously long ones
+  // pay for the counting scan, which allocates nothing.
+  if (maxBytes !== undefined && input.length > Math.ceil(maxBytes / 3) * 4) {
+    const decoded = Math.floor((significantLength(input) * 3) / 4);
+    if (decoded > maxBytes) {
+      throw new Error(
+        `base64_data decodes to ${decoded} bytes, over the ${maxBytes}-byte upload limit`
+      );
+    }
+  }
+
   // One pass: each additional pass copies the whole string, which is precisely
   // the allocation this function is trying not to make on hostile input.
   const normalized = input.replace(

--- a/src/utils/file-source.ts
+++ b/src/utils/file-source.ts
@@ -1,0 +1,34 @@
+/**
+ * The single seam through which a local filesystem may enter the tool layer.
+ *
+ * `fizzy_upload_file` accepts a `file_path` because attaching a local screenshot
+ * is the common case and base64-inlining one costs the caller ~1.37x the file
+ * size in tokens. But reading local files is only safe where the caller and the
+ * server process belong to the same person, which is true of stdio and of
+ * nothing else this server ships:
+ *
+ * - **stdio** — the client is the local user, who can already read their own
+ *   disk. Honouring `file_path` grants no capability they lack.
+ * - **http / sse** — the client is remote. Reading server-side paths on its
+ *   behalf would let it exfiltrate the host's files into Fizzy.
+ * - **Cloudflare Workers** — there is no filesystem at all.
+ *
+ * So the capability is injected rather than imported: the stdio entry point
+ * installs a reader, every other transport leaves it unset, and the handler
+ * refuses `file_path` when none is installed. A missing reader is the safe
+ * default, which means a new transport is closed until it deliberately opts in.
+ */
+
+export type LocalFileReader = (path: string) => Promise<Uint8Array>;
+
+let localFileReader: LocalFileReader | null = null;
+
+/** Install (or with `null`, remove) the reader. Called once, at startup. */
+export function setLocalFileReader(reader: LocalFileReader | null): void {
+  localFileReader = reader;
+}
+
+/** The installed reader, or `null` where local file access is not permitted. */
+export function getLocalFileReader(): LocalFileReader | null {
+  return localFileReader;
+}

--- a/src/utils/md5.ts
+++ b/src/utils/md5.ts
@@ -51,7 +51,13 @@ const K = [
   0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
 ];
 
-/** Raw 16-byte MD5 digest. */
+/**
+ * Raw 16-byte MD5 digest.
+ *
+ * The padded-length arithmetic below is 32-bit, so inputs at or beyond 4 GiB
+ * would wrap. Callers here are bounded far below that by MAX_ATTACHMENT_BYTES;
+ * anything streaming larger input would need a chunked digest anyway.
+ */
 export function md5(input: Uint8Array): Uint8Array {
   // Message + a mandatory 0x80 byte + zero padding to 56 mod 64 + an 8-byte length.
   const paddedLength = (((input.length + 8) >>> 6) + 1) << 6;

--- a/src/utils/md5.ts
+++ b/src/utils/md5.ts
@@ -1,0 +1,136 @@
+/**
+ * MD5, implemented here rather than taken from a runtime.
+ *
+ * Fizzy's direct-upload endpoint requires a Base64-encoded MD5 of the file as
+ * its `checksum`. WebCrypto offers only SHA-family digests, so the alternative
+ * would be `node:crypto` — which ties this shared code path to the
+ * `nodejs_compat` flag staying enabled and to workerd implementing MD5, neither
+ * of which is verifiable from the Node test suite. A self-contained
+ * implementation produces identical bytes in every runtime with no branch to get
+ * wrong, and its correctness is pinned by the RFC 1321 test vectors plus a
+ * differential test against `node:crypto` over block-boundary lengths.
+ *
+ * This is an upload integrity checksum, never a security primitive.
+ *
+ * @see https://www.ietf.org/rfc/rfc1321.txt
+ * @see tests/utils/md5.test.ts
+ */
+
+import { bytesToBase64 } from "./base64.js";
+
+/** Per-round left-rotation amounts (RFC 1321 §3.4). */
+const SHIFTS = [
+  7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+  5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
+  4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+  6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+];
+
+/**
+ * Round constants, `floor(2^32 * abs(sin(i + 1)))`, written out rather than
+ * derived: ECMAScript does not require `Math.sin` to be correctly rounded, so
+ * deriving them could in principle differ by one ulp between engines and flip a
+ * `floor`.
+ */
+const K = [
+  0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee,
+  0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+  0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be,
+  0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+  0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa,
+  0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+  0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed,
+  0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+  0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c,
+  0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+  0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05,
+  0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+  0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039,
+  0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+  0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1,
+  0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
+];
+
+/** Raw 16-byte MD5 digest. */
+export function md5(input: Uint8Array): Uint8Array {
+  // Message + a mandatory 0x80 byte + zero padding to 56 mod 64 + an 8-byte length.
+  const paddedLength = (((input.length + 8) >>> 6) + 1) << 6;
+  const block = new Uint8Array(paddedLength);
+  block.set(input);
+  block[input.length] = 0x80;
+
+  const view = new DataView(block.buffer);
+
+  // Length in bits, little-endian across two 32-bit words. `Math.floor(bits /
+  // 2^32)` stays exact because a byte length large enough to overflow it would
+  // long since have exhausted memory.
+  const bitLength = input.length * 8;
+  view.setUint32(paddedLength - 8, bitLength >>> 0, true);
+  view.setUint32(paddedLength - 4, Math.floor(bitLength / 0x100000000), true);
+
+  let a0 = 0x67452301;
+  let b0 = 0xefcdab89;
+  let c0 = 0x98badcfe;
+  let d0 = 0x10325476;
+
+  const words = new Int32Array(16);
+
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    for (let i = 0; i < 16; i++) {
+      words[i] = view.getInt32(offset + i * 4, true);
+    }
+
+    let a = a0;
+    let b = b0;
+    let c = c0;
+    let d = d0;
+
+    for (let i = 0; i < 64; i++) {
+      let f: number;
+      let g: number;
+
+      if (i < 16) {
+        f = (b & c) | (~b & d);
+        g = i;
+      } else if (i < 32) {
+        f = (d & b) | (~d & c);
+        g = (5 * i + 1) % 16;
+      } else if (i < 48) {
+        f = b ^ c ^ d;
+        g = (3 * i + 5) % 16;
+      } else {
+        f = c ^ (b | ~d);
+        g = (7 * i) % 16;
+      }
+
+      const rotated = (f + a + K[i] + words[g]) | 0;
+      const shift = SHIFTS[i];
+
+      a = d;
+      d = c;
+      c = b;
+      b = (b + (((rotated << shift) | (rotated >>> (32 - shift))) | 0)) | 0;
+    }
+
+    a0 = (a0 + a) | 0;
+    b0 = (b0 + b) | 0;
+    c0 = (c0 + c) | 0;
+    d0 = (d0 + d) | 0;
+  }
+
+  const digest = new Uint8Array(16);
+  const digestView = new DataView(digest.buffer);
+  digestView.setInt32(0, a0, true);
+  digestView.setInt32(4, b0, true);
+  digestView.setInt32(8, c0, true);
+  digestView.setInt32(12, d0, true);
+  return digest;
+}
+
+/**
+ * MD5 digest as Base64 — the encoding Fizzy's direct-upload `checksum` expects.
+ * A hex digest is rejected there with an error that does not say why.
+ */
+export function md5Base64(input: Uint8Array): string {
+  return bytesToBase64(md5(input));
+}

--- a/tests/client/direct-upload.test.ts
+++ b/tests/client/direct-upload.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createHash } from "node:crypto";
 import { FizzyClient } from "../../src/client/fizzy-client.js";
 
-const ACCOUNT = "/6117483";
+const ACCOUNT = "/123456";
 const STORAGE_URL = "https://storage.example.com/upload/abc?signature=xyz";
 const ATTACHABLE_SGID = "eyJfcmFpbHMiOnsiZGF0YSI6ImdpZDovL2Zpenp5In19--attachable";
 const BLOB_SIGNED_ID = "eyJfcmFpbHMiOnsiZGF0YSI6IjAzZ2wifX0=--blob-id";
@@ -97,7 +97,7 @@ describe("createDirectUpload", () => {
     expect(calls).toHaveLength(1);
     // The leading slash on the account slug must be normalized away, as elsewhere.
     expect(calls[0].url).toBe(
-      "https://app.fizzy.do/6117483/rails/active_storage/direct_uploads"
+      "https://app.fizzy.do/123456/rails/active_storage/direct_uploads"
     );
     expect(calls[0].method).toBe("POST");
     expect(JSON.parse(calls[0].body as string)).toEqual({

--- a/tests/client/direct-upload.test.ts
+++ b/tests/client/direct-upload.test.ts
@@ -1,0 +1,223 @@
+/**
+ * The two-step ActionText direct-upload flow, exercised against a stubbed
+ * `fetch`. The three assertions that matter are the ones whose failures the
+ * real API reports unhelpfully: a hex checksum, headers that differ from the
+ * ones storage signed, and — the one no API error would ever reveal — the Fizzy
+ * bearer token being sent to a third-party storage host.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHash } from "node:crypto";
+import { FizzyClient } from "../../src/client/fizzy-client.js";
+
+const ACCOUNT = "/6117483";
+const STORAGE_URL = "https://storage.example.com/upload/abc?signature=xyz";
+const ATTACHABLE_SGID = "eyJfcmFpbHMiOnsiZGF0YSI6ImdpZDovL2Zpenp5In19--attachable";
+const BLOB_SIGNED_ID = "eyJfcmFpbHMiOnsiZGF0YSI6IjAzZ2wifX0=--blob-id";
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+let calls: RecordedCall[];
+const originalFetch = globalThis.fetch;
+
+function directUploadResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "abc123",
+    key: "abc123def456",
+    filename: "screenshot.png",
+    content_type: "image/png",
+    byte_size: 5,
+    checksum: "ignored-by-client",
+    attachable_sgid: ATTACHABLE_SGID,
+    signed_id: BLOB_SIGNED_ID,
+    direct_upload: {
+      url: STORAGE_URL,
+      headers: {
+        // Three headers, not two: the real API also returns Content-Disposition,
+        // which is why they are echoed wholesale rather than picked out by name.
+        "Content-Type": "image/png",
+        "Content-MD5": "GQ5SqLsM7ylnji0Wgd9wNA==",
+        "Content-Disposition": 'inline; filename="screenshot.png"',
+      },
+    },
+    ...overrides,
+  };
+}
+
+function stubFetch(handler: (call: RecordedCall) => Response) {
+  globalThis.fetch = vi.fn(async (url: unknown, init: Record<string, unknown> = {}) => {
+    const call: RecordedCall = {
+      url: String(url),
+      method: (init.method as string) ?? "GET",
+      headers: (init.headers as Record<string, string>) ?? {},
+      body: init.body,
+    };
+    calls.push(call);
+    return handler(call);
+  }) as unknown as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function client(): FizzyClient {
+  // Retries off: a retrying client would mask which request actually failed.
+  return new FizzyClient({ accessToken: "test-token", maxRetries: 0 });
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("createDirectUpload", () => {
+  it("posts the blob envelope to the account-scoped direct_uploads endpoint", async () => {
+    stubFetch(() => jsonResponse(directUploadResponse()));
+
+    await client().createDirectUpload(ACCOUNT, {
+      filename: "screenshot.png",
+      byte_size: 5,
+      checksum: "GQ5SqLsM7ylnji0Wgd9wNA==",
+      content_type: "image/png",
+    });
+
+    expect(calls).toHaveLength(1);
+    // The leading slash on the account slug must be normalized away, as elsewhere.
+    expect(calls[0].url).toBe(
+      "https://app.fizzy.do/6117483/rails/active_storage/direct_uploads"
+    );
+    expect(calls[0].method).toBe("POST");
+    expect(JSON.parse(calls[0].body as string)).toEqual({
+      blob: {
+        filename: "screenshot.png",
+        byte_size: 5,
+        checksum: "GQ5SqLsM7ylnji0Wgd9wNA==",
+        content_type: "image/png",
+      },
+    });
+  });
+});
+
+describe("uploadFile", () => {
+  const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+
+  function stubHappyPath() {
+    stubFetch((call) =>
+      call.method === "POST" ? jsonResponse(directUploadResponse()) : new Response(null, { status: 204 })
+    );
+  }
+
+  it("sends a Base64-encoded MD5 as the checksum, not hex", async () => {
+    stubHappyPath();
+
+    await client().uploadFile(ACCOUNT, {
+      bytes,
+      filename: "screenshot.png",
+      contentType: "image/png",
+    });
+
+    const blob = JSON.parse(calls[0].body as string).blob;
+    expect(blob.checksum).toBe(createHash("md5").update(bytes).digest("base64"));
+    expect(blob.checksum).not.toBe(createHash("md5").update(bytes).digest("hex"));
+    expect(blob.byte_size).toBe(5);
+  });
+
+  it("PUTs the bytes to the storage URL from step 1", async () => {
+    stubHappyPath();
+
+    await client().uploadFile(ACCOUNT, {
+      bytes,
+      filename: "screenshot.png",
+      contentType: "image/png",
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].url).toBe(STORAGE_URL);
+    expect(calls[1].method).toBe("PUT");
+    expect(Array.from(calls[1].body as Uint8Array)).toEqual(Array.from(bytes));
+  });
+
+  it("echoes step 1's headers back verbatim, adding nothing", async () => {
+    stubHappyPath();
+
+    await client().uploadFile(ACCOUNT, {
+      bytes,
+      filename: "screenshot.png",
+      contentType: "image/png",
+    });
+
+    // Signed storage URLs verify the signature against exactly these headers and
+    // reject any deviation with an error that never mentions headers. Asserting
+    // equality (not containment) is the point: an extra header breaks it too.
+    expect(calls[1].headers).toEqual({
+      "Content-Type": "image/png",
+      "Content-MD5": "GQ5SqLsM7ylnji0Wgd9wNA==",
+      "Content-Disposition": 'inline; filename="screenshot.png"',
+    });
+  });
+
+  it("never sends the Fizzy access token to the storage host", async () => {
+    stubHappyPath();
+
+    await client().uploadFile(ACCOUNT, {
+      bytes,
+      filename: "screenshot.png",
+      contentType: "image/png",
+    });
+
+    const storageHeaderValues = Object.values(calls[1].headers).join(" ");
+    expect(Object.keys(calls[1].headers)).not.toContain("Authorization");
+    expect(storageHeaderValues).not.toContain("test-token");
+    // The API call, by contrast, must still be authenticated.
+    expect(calls[0].headers.Authorization).toBe("Bearer test-token");
+  });
+
+  it("returns both signed tokens, which are distinct and not interchangeable", async () => {
+    stubHappyPath();
+
+    const upload = await client().uploadFile(ACCOUNT, {
+      bytes,
+      filename: "screenshot.png",
+      contentType: "image/png",
+    });
+
+    expect(upload.attachable_sgid).toBe(ATTACHABLE_SGID);
+    expect(upload.signed_id).toBe(BLOB_SIGNED_ID);
+    expect(upload.filename).toBe("screenshot.png");
+  });
+
+  it("surfaces a storage rejection instead of reporting success", async () => {
+    stubFetch((call) =>
+      call.method === "POST"
+        ? jsonResponse(directUploadResponse())
+        : new Response("SignatureDoesNotMatch", { status: 403 })
+    );
+
+    await expect(
+      client().uploadFile(ACCOUNT, { bytes, filename: "a.png", contentType: "image/png" })
+    ).rejects.toThrow();
+  });
+
+  it("does not attempt the upload when step 1 fails", async () => {
+    stubFetch(() => jsonResponse({ error: "unprocessable" }, 422));
+
+    await expect(
+      client().uploadFile(ACCOUNT, { bytes, filename: "a.png", contentType: "image/png" })
+    ).rejects.toThrow();
+
+    expect(calls.filter((call) => call.method === "PUT")).toHaveLength(0);
+  });
+});

--- a/tests/cloudflare/logger.test.ts
+++ b/tests/cloudflare/logger.test.ts
@@ -1,0 +1,94 @@
+/**
+ * CloudflareLogger Tests
+ *
+ * Tests for the structured audit logger, focused on argument sanitization —
+ * `logToolInvocation` is the audit trail that lands in Workers console logs
+ * and, optionally, R2, so a leak here is a leak into persistent storage.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createLogger } from "../../src/cloudflare/utils/logger.js";
+
+describe("CloudflareLogger.logToolInvocation sanitization", () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  function loggedArgs(args: Record<string, unknown>): Record<string, unknown> {
+    const logger = createLogger({ consoleOutput: true });
+    logger.logToolInvocation("fizzy_upload_file", "acme", args, {
+      success: true,
+      durationMs: 12,
+    });
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const [line] = infoSpy.mock.calls[0] as [string];
+    return JSON.parse(line).args;
+  }
+
+  it("never logs base64_data content, but reports its length", () => {
+    const base64Data = "A".repeat(1234);
+    const sanitized = loggedArgs({ base64_data: base64Data, filename: "a.png" });
+
+    expect(JSON.stringify(sanitized)).not.toContain(base64Data);
+    expect(sanitized.base64_data).toBe("[redacted: 1234 chars]");
+  });
+
+  it("redacts base64_data as [REDACTED] when it is not a string", () => {
+    const sanitized = loggedArgs({ base64_data: 12345 });
+    expect(sanitized.base64_data).toBe("[REDACTED]");
+  });
+
+  it("redacts file_path outright", () => {
+    const sanitized = loggedArgs({ file_path: "/Users/alice/secret-plans.pdf" });
+    expect(sanitized.file_path).toBe("[REDACTED]");
+  });
+
+  it("redacts base64_data and file_path regardless of key casing", () => {
+    // The Cloudflare transport logs raw, unvalidated arguments — including on
+    // failed calls — so a differently-cased key must not fall through to the
+    // generic 500-char truncation and leak content.
+    const base64Data = "B".repeat(999);
+    const sanitized = loggedArgs({ Base64_Data: base64Data, FILE_PATH: "/etc/passwd" });
+
+    expect(JSON.stringify(sanitized)).not.toContain(base64Data);
+    expect(sanitized.Base64_Data).toBe("[redacted: 999 chars]");
+    expect(sanitized.FILE_PATH).toBe("[REDACTED]");
+  });
+
+  it("still redacts existing sensitive keys", () => {
+    const sanitized = loggedArgs({
+      password: "hunter2",
+      api_token: "abc123",
+      client_secret: "shh",
+      api_key: "xyz",
+      Authorization: "Bearer abc",
+    });
+
+    expect(sanitized.password).toBe("[REDACTED]");
+    expect(sanitized.api_token).toBe("[REDACTED]");
+    expect(sanitized.client_secret).toBe("[REDACTED]");
+    expect(sanitized.api_key).toBe("[REDACTED]");
+    expect(sanitized.Authorization).toBe("[REDACTED]");
+  });
+
+  it("still truncates other long strings at 500 chars", () => {
+    const longValue = "x".repeat(600);
+    const sanitized = loggedArgs({ description: longValue });
+
+    expect(sanitized.description).toBe("x".repeat(500) + "...[truncated]");
+  });
+
+  it("passes other args through unchanged", () => {
+    const sanitized = loggedArgs({ account_slug: "acme", card_number: 7 });
+
+    expect(sanitized.account_slug).toBe("acme");
+    expect(sanitized.card_number).toBe(7);
+  });
+});

--- a/tests/integration/api.integration.test.ts
+++ b/tests/integration/api.integration.test.ts
@@ -30,6 +30,7 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import { FizzyClient } from "../../src/client/fizzy-client.js";
+import { attachmentHtml } from "../../src/utils/attachments.js";
 
 const FIZZY_ACCESS_TOKEN = process.env.FIZZY_ACCESS_TOKEN;
 const shouldRun = !!FIZZY_ACCESS_TOKEN;
@@ -384,6 +385,82 @@ describe.skipIf(!shouldRun)("Fizzy API Integration Tests", () => {
   // ==========================================
   // PHASE 4: DELETE - Delete all created resources (clean slate)
   // ==========================================
+  // ==========================================
+  // PHASE 3.5: ATTACHMENTS - Real upload, real render
+  // ==========================================
+  // Unit tests cannot prove this flow works: they stub the network, and both ways
+  // it fails upstream — a hex checksum, and the wrong signed id in the sgid
+  // attribute — are accepted by a stub while the real service rejects one and
+  // silently renders the other broken. So the round trip is exercised here
+  // against the live API, gated on a token exactly like the rest of this file.
+  describe("Phase 3.5: ATTACHMENTS - Upload and render", () => {
+    beforeAll(() => {
+      console.log("\n📎 Phase 3.5: Uploading a real file and attaching it...\n");
+    });
+
+    // A real 16x8 PNG. Small enough to inline, structured enough that the server
+    // reports its dimensions back, which is what proves the bytes arrived intact.
+    const PNG_BASE64 =
+      "iVBORw0KGgoAAAANSUhEUgAAABAAAAAICAIAAAB/FOjAAAAAHUlEQVR42mPYKSPDX5ZHPMlAkuqdMjIMozYQQQIAumx5AQMTQzEAAAAASUVORK5CYII=";
+    const pngBytes = Uint8Array.from(atob(PNG_BASE64), (c) => c.charCodeAt(0));
+
+    let attachableSgid = "";
+
+    it("POST /:account_slug/rails/active_storage/direct_uploads - uploads a real file", async () => {
+      const upload = await client!.uploadFile(testData.accountSlug, {
+        bytes: pngBytes,
+        filename: "integration-attachment.png",
+        contentType: "image/png",
+      });
+
+      // Reaching here at all means the Base64-encoded MD5 matched the bytes: the
+      // direct-upload endpoint rejects a mismatched checksum.
+      expect(upload.attachable_sgid).toBeTruthy();
+      expect(upload.byte_size).toBe(pngBytes.length);
+      expect(upload.filename).toBe("integration-attachment.png");
+
+      // The trap: both are signed tokens for this same blob, and only the
+      // attachable one resolves in rich text. They must not be conflated.
+      expect(upload.signed_id).toBeTruthy();
+      expect(upload.attachable_sgid).not.toBe(upload.signed_id);
+
+      attachableSgid = upload.attachable_sgid;
+      console.log(`✓ Uploaded: ${upload.byte_size} bytes, blob ${upload.id}`);
+    });
+
+    it("attaches the upload to a comment and the server resolves it", async () => {
+      expect(attachableSgid).toBeTruthy();
+
+      const comment = await client!.createCardComment(
+        testData.accountSlug,
+        testData.createdCardNumber,
+        { body: `<p>Integration attachment:</p>${attachmentHtml(attachableSgid)}` }
+      );
+
+      const fetched = await client!.getComment(
+        testData.accountSlug,
+        testData.createdCardNumber,
+        comment.id
+      );
+
+      // Rich text comes back as { plain_text, html }, despite the declared type.
+      const body = fetched.body as unknown as { html?: string } | string;
+      const html = typeof body === "string" ? body : body?.html ?? "";
+
+      expect(html).toContain("action-text-attachment");
+      // A <figure> means the server resolved the blob. The placeholder glyph means
+      // it accepted the tag and could not resolve it — the silent failure mode.
+      expect(html).toContain("<figure");
+      expect(html).not.toContain(">☒<");
+      // Dimensions come from the server analysing the stored bytes, so they match
+      // only if the right file actually reached storage.
+      expect(html).toContain('width="16"');
+      expect(html).toContain('height="8"');
+
+      console.log("✓ Attachment rendered and resolved by the server");
+    });
+  });
+
   describe("Phase 4: DELETE - Clean Up (Clean Slate)", () => {
     beforeAll(() => {
       console.log("\n🧹 Phase 4: Deleting test resources (clean slate)...\n");

--- a/tests/integration/api.integration.test.ts
+++ b/tests/integration/api.integration.test.ts
@@ -465,9 +465,7 @@ describe.skipIf(!shouldRun)("Fizzy API Integration Tests", () => {
         comment.id
       );
 
-      // Rich text comes back as { plain_text, html }, despite the declared type.
-      const body = fetched.body as unknown as { html?: string } | string;
-      const html = typeof body === "string" ? body : body?.html ?? "";
+      const html = fetched.body.html;
 
       expect(html).toContain("action-text-attachment");
       // A <figure> means the server resolved the blob. The placeholder glyph means

--- a/tests/tools/upload-file.test.ts
+++ b/tests/tools/upload-file.test.ts
@@ -73,7 +73,7 @@ describe("fizzy_upload_file schema", () => {
   it("accepts base64_data with a filename", () => {
     expect(
       uploadFileSchema.safeParse({
-        account_slug: "6117483",
+        account_slug: "123456",
         base64_data: base64("x"),
         filename: "a.txt",
       }).success
@@ -105,7 +105,7 @@ describe("fizzy_upload_file schema", () => {
 describe("fizzy_upload_file handler", () => {
   it("builds the HTML from attachable_sgid, not signed_id", async () => {
     const result = (await executeToolHandler(clientStub(), "fizzy_upload_file", {
-      account_slug: "6117483",
+      account_slug: "123456",
       base64_data: base64("hello"),
       filename: "screenshot.png",
     })) as Record<string, unknown>;
@@ -127,14 +127,14 @@ describe("fizzy_upload_file handler", () => {
 
     await expect(
       executeToolHandler(client, "fizzy_upload_file", {
-        account_slug: "6117483",
+        account_slug: "123456",
         base64_data: base64("x"),
       })
     ).rejects.toThrow(/filename is required/);
 
     await expect(
       executeToolHandler(client, "fizzy_upload_file", {
-        account_slug: "6117483",
+        account_slug: "123456",
         file_path: "a.png",
         base64_data: base64("x"),
         filename: "a.png",
@@ -142,19 +142,19 @@ describe("fizzy_upload_file handler", () => {
     ).rejects.toThrow(/not both/);
 
     await expect(
-      executeToolHandler(client, "fizzy_upload_file", { account_slug: "6117483" })
+      executeToolHandler(client, "fizzy_upload_file", { account_slug: "123456" })
     ).rejects.toThrow(/either file_path .* or base64_data/);
   });
 
   it("passes the decoded bytes and resolved metadata to the client", async () => {
     let seen: { slug: string; file: any } | undefined;
     await executeToolHandler(clientStub((slug, file) => (seen = { slug, file: file as any })), "fizzy_upload_file", {
-      account_slug: "/6117483",
+      account_slug: "/123456",
       base64_data: base64("hello"),
       filename: "screenshot.png",
     });
 
-    expect(seen?.slug).toBe("/6117483");
+    expect(seen?.slug).toBe("/123456");
     expect(new TextDecoder().decode(seen?.file.bytes)).toBe("hello");
     expect(seen?.file.filename).toBe("screenshot.png");
     expect(seen?.file.contentType).toBe("image/png");
@@ -168,7 +168,7 @@ describe("fizzy_upload_file handler", () => {
 
     await expect(
       executeToolHandler(client, "fizzy_upload_file", {
-        account_slug: "6117483",
+        account_slug: "123456",
         file_path: "/etc/passwd",
       })
     ).rejects.toThrow(/only supported on the stdio transport/);
@@ -180,7 +180,7 @@ describe("fizzy_upload_file handler", () => {
     setLocalFileReader(async () => new Uint8Array([1, 2, 3, 4, 5]));
 
     const result = (await executeToolHandler(clientStub(), "fizzy_upload_file", {
-      account_slug: "6117483",
+      account_slug: "123456",
       file_path: "C:/shots/screenshot.png",
     })) as Record<string, unknown>;
 

--- a/tests/tools/upload-file.test.ts
+++ b/tests/tools/upload-file.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tool-layer wiring for fizzy_upload_file, including the contract the model
+ * depends on: the returned `attachment_html` is what gets pasted into a
+ * rich-text field, so it has to reference the signed id the upload produced.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { executeToolHandler } from "../../src/tools/handlers.js";
+import { getToolDefinition } from "../../src/tools/definitions.js";
+import { toolInputJsonSchema } from "../../src/tools/json-schema.js";
+import { uploadFileSchema } from "../../src/tools/schemas.js";
+import { setLocalFileReader } from "../../src/utils/file-source.js";
+import type { FizzyClient } from "../../src/client/fizzy-client.js";
+
+// The two tokens the API returns for one blob. Only the attachable one renders.
+const ATTACHABLE_SGID = "eyJfcmFpbHMiOnsiZGF0YSI6ImdpZDovL2Zpenp5In19--attachable-sig";
+const BLOB_SIGNED_ID = "eyJfcmFpbHMiOnsiZGF0YSI6IjAzZ2wifX0=--blob-id-sig";
+
+const base64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
+
+function clientStub(record?: (slug: string, file: unknown) => void): FizzyClient {
+  return {
+    uploadFile: async (slug: string, file: unknown) => {
+      record?.(slug, file);
+      return {
+        id: "abc",
+        key: "abc123",
+        filename: "screenshot.png",
+        content_type: "image/png",
+        byte_size: 5,
+        checksum: "kAFQmDzST7DWlj99KOF/cg==",
+        attachable_sgid: ATTACHABLE_SGID,
+        signed_id: BLOB_SIGNED_ID,
+        direct_upload: { url: "https://storage.example.com/x", headers: {} },
+      };
+    },
+  } as unknown as FizzyClient;
+}
+
+afterEach(() => {
+  setLocalFileReader(null);
+});
+
+describe("fizzy_upload_file definition", () => {
+  it("is registered and declares itself as a non-destructive write", () => {
+    const definition = getToolDefinition("fizzy_upload_file");
+
+    expect(definition).toBeDefined();
+    expect(definition?.annotations.readOnlyHint).toBe(false);
+    expect(definition?.annotations.destructiveHint).toBe(false);
+  });
+
+  it("tells the model that the returned HTML is what attaches the file", () => {
+    const description = getToolDefinition("fizzy_upload_file")?.description ?? "";
+
+    expect(description).toContain("attachment_html");
+    expect(description).toContain("fizzy_create_comment");
+  });
+
+  it("publishes a valid JSON Schema with all four inputs", () => {
+    const schema = toolInputJsonSchema(uploadFileSchema) as {
+      properties?: Record<string, unknown>;
+    };
+    const published = JSON.stringify(schema);
+
+    for (const field of ["account_slug", "file_path", "base64_data", "filename", "content_type"]) {
+      expect(published).toContain(field);
+    }
+  });
+});
+
+describe("fizzy_upload_file schema", () => {
+  it("accepts base64_data with a filename", () => {
+    expect(
+      uploadFileSchema.safeParse({
+        account_slug: "6117483",
+        base64_data: base64("x"),
+        filename: "a.txt",
+      }).success
+    ).toBe(true);
+  });
+
+  it("still requires account_slug", () => {
+    expect(uploadFileSchema.safeParse({ base64_data: base64("x"), filename: "a.txt" }).success).toBe(
+      false
+    );
+  });
+
+  // The either/or rules are intentionally NOT Zod refinements: a refined schema is
+  // a ZodEffects with no shape for McpServer.registerTool to read, so refining
+  // would publish an empty property list to stdio clients. resolveAttachment owns
+  // these rules instead — which it must anyway, since the Cloudflare transport
+  // never runs Zod. See the handler tests below and tests/utils/attachments.test.ts.
+  it("publishes a non-empty shape, which a refined schema would not", () => {
+    expect(Object.keys(uploadFileSchema.shape)).toEqual([
+      "account_slug",
+      "file_path",
+      "base64_data",
+      "filename",
+      "content_type",
+    ]);
+  });
+});
+
+describe("fizzy_upload_file handler", () => {
+  it("builds the HTML from attachable_sgid, not signed_id", async () => {
+    const result = (await executeToolHandler(clientStub(), "fizzy_upload_file", {
+      account_slug: "6117483",
+      base64_data: base64("hello"),
+      filename: "screenshot.png",
+    })) as Record<string, unknown>;
+
+    expect(result.attachment_html).toBe(
+      `<action-text-attachment sgid="${ATTACHABLE_SGID}"></action-text-attachment>`
+    );
+    // Regression guard for the trap this cost a live round to find: signed_id is
+    // also a valid-looking token for the same blob, is what Fizzy's own docs point
+    // at, and renders as an unresolved-attachment placeholder.
+    expect(result.attachment_html).not.toContain(BLOB_SIGNED_ID);
+    expect(result.attachable_sgid).toBe(ATTACHABLE_SGID);
+    expect(result.byte_size).toBe(5);
+    expect(String(result.next_step)).toContain("fizzy_create_comment");
+  });
+
+  it("enforces the either/or rules that are not in the Zod schema", async () => {
+    const client = clientStub();
+
+    await expect(
+      executeToolHandler(client, "fizzy_upload_file", {
+        account_slug: "6117483",
+        base64_data: base64("x"),
+      })
+    ).rejects.toThrow(/filename is required/);
+
+    await expect(
+      executeToolHandler(client, "fizzy_upload_file", {
+        account_slug: "6117483",
+        file_path: "a.png",
+        base64_data: base64("x"),
+        filename: "a.png",
+      })
+    ).rejects.toThrow(/not both/);
+
+    await expect(
+      executeToolHandler(client, "fizzy_upload_file", { account_slug: "6117483" })
+    ).rejects.toThrow(/either file_path .* or base64_data/);
+  });
+
+  it("passes the decoded bytes and resolved metadata to the client", async () => {
+    let seen: { slug: string; file: any } | undefined;
+    await executeToolHandler(clientStub((slug, file) => (seen = { slug, file: file as any })), "fizzy_upload_file", {
+      account_slug: "/6117483",
+      base64_data: base64("hello"),
+      filename: "screenshot.png",
+    });
+
+    expect(seen?.slug).toBe("/6117483");
+    expect(new TextDecoder().decode(seen?.file.bytes)).toBe("hello");
+    expect(seen?.file.filename).toBe("screenshot.png");
+    expect(seen?.file.contentType).toBe("image/png");
+  });
+
+  it("refuses file_path on transports with no reader installed, without calling the client", async () => {
+    let uploadCalled = false;
+    const client = clientStub(() => {
+      uploadCalled = true;
+    });
+
+    await expect(
+      executeToolHandler(client, "fizzy_upload_file", {
+        account_slug: "6117483",
+        file_path: "/etc/passwd",
+      })
+    ).rejects.toThrow(/only supported on the stdio transport/);
+
+    expect(uploadCalled).toBe(false);
+  });
+
+  it("accepts file_path once a reader is installed, as stdio does", async () => {
+    setLocalFileReader(async () => new Uint8Array([1, 2, 3, 4, 5]));
+
+    const result = (await executeToolHandler(clientStub(), "fizzy_upload_file", {
+      account_slug: "6117483",
+      file_path: "C:/shots/screenshot.png",
+    })) as Record<string, unknown>;
+
+    expect(result.attachable_sgid).toBe(ATTACHABLE_SGID);
+  });
+});

--- a/tests/tools/upload-file.test.ts
+++ b/tests/tools/upload-file.test.ts
@@ -10,6 +10,7 @@ import { getToolDefinition } from "../../src/tools/definitions.js";
 import { toolInputJsonSchema } from "../../src/tools/json-schema.js";
 import { uploadFileSchema } from "../../src/tools/schemas.js";
 import { setLocalFileReader } from "../../src/utils/file-source.js";
+import type { ResolvedAttachment } from "../../src/utils/attachments.js";
 import type { FizzyClient } from "../../src/client/fizzy-client.js";
 
 // The two tokens the API returns for one blob. Only the attachable one renders.
@@ -57,11 +58,8 @@ describe("fizzy_upload_file definition", () => {
     expect(description).toContain("fizzy_create_comment");
   });
 
-  it("publishes a valid JSON Schema with all four inputs", () => {
-    const schema = toolInputJsonSchema(uploadFileSchema) as {
-      properties?: Record<string, unknown>;
-    };
-    const published = JSON.stringify(schema);
+  it("publishes a JSON Schema carrying every input", () => {
+    const published = JSON.stringify(toolInputJsonSchema(uploadFileSchema));
 
     for (const field of ["account_slug", "file_path", "base64_data", "filename", "content_type"]) {
       expect(published).toContain(field);
@@ -147,8 +145,12 @@ describe("fizzy_upload_file handler", () => {
   });
 
   it("passes the decoded bytes and resolved metadata to the client", async () => {
-    let seen: { slug: string; file: any } | undefined;
-    await executeToolHandler(clientStub((slug, file) => (seen = { slug, file: file as any })), "fizzy_upload_file", {
+    let seen: { slug: string; file: ResolvedAttachment } | undefined;
+    const client = clientStub((slug, file) => {
+      seen = { slug, file: file as ResolvedAttachment };
+    });
+
+    await executeToolHandler(client, "fizzy_upload_file", {
       account_slug: "/123456",
       base64_data: base64("hello"),
       filename: "screenshot.png",

--- a/tests/utils/attachments.test.ts
+++ b/tests/utils/attachments.test.ts
@@ -110,6 +110,17 @@ describe("resolveAttachment", () => {
       );
     });
 
+    it("strips directory components from an explicit filename too", async () => {
+      setLocalFileReader(async () => new Uint8Array([1]));
+
+      const resolved = await resolveAttachment({
+        file_path: "C:/shots/bug.png",
+        filename: "../../etc/renamed.png",
+      });
+
+      expect(resolved.filename).toBe("renamed.png");
+    });
+
     it("passes the path through to the reader unchanged", async () => {
       const seen: string[] = [];
       setLocalFileReader(async (path) => {

--- a/tests/utils/attachments.test.ts
+++ b/tests/utils/attachments.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  MAX_ATTACHMENT_BYTES,
+  attachmentHtml,
+  contentTypeForFilename,
+  resolveAttachment,
+} from "../../src/utils/attachments.js";
+import { setLocalFileReader } from "../../src/utils/file-source.js";
+
+const base64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
+
+afterEach(() => {
+  setLocalFileReader(null);
+});
+
+describe("attachmentHtml", () => {
+  it("emits the ActionText element with the signed id as sgid", () => {
+    expect(attachmentHtml("eyJfcmFpbHMi--abc123")).toBe(
+      '<action-text-attachment sgid="eyJfcmFpbHMi--abc123"></action-text-attachment>'
+    );
+  });
+
+  it("escapes the attribute rather than trusting the signed id", () => {
+    const html = attachmentHtml('a"><script>alert(1)</script>');
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&quot;");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("contentTypeForFilename", () => {
+  it.each([
+    ["shot.png", "image/png"],
+    ["photo.JPG", "image/jpeg"],
+    ["photo.jpeg", "image/jpeg"],
+    ["report.pdf", "application/pdf"],
+    ["notes.md", "text/markdown"],
+    ["server.log", "text/plain"],
+  ])("maps %s to %s", (filename, expected) => {
+    expect(contentTypeForFilename(filename)).toBe(expected);
+  });
+
+  it("falls back to a generic type for unknown and absent extensions", () => {
+    expect(contentTypeForFilename("archive.xyz")).toBe("application/octet-stream");
+    expect(contentTypeForFilename("Makefile")).toBe("application/octet-stream");
+  });
+});
+
+describe("resolveAttachment", () => {
+  describe("base64_data", () => {
+    it("decodes the bytes and infers the content type from the filename", async () => {
+      const resolved = await resolveAttachment({
+        base64_data: base64("hello"),
+        filename: "greeting.txt",
+      });
+
+      expect(new TextDecoder().decode(resolved.bytes)).toBe("hello");
+      expect(resolved.filename).toBe("greeting.txt");
+      expect(resolved.contentType).toBe("text/plain");
+    });
+
+    it("prefers an explicit content_type over the inferred one", async () => {
+      const resolved = await resolveAttachment({
+        base64_data: base64("x"),
+        filename: "data.txt",
+        content_type: "application/json",
+      });
+
+      expect(resolved.contentType).toBe("application/json");
+    });
+
+    it("strips any directory component from the supplied filename", async () => {
+      const resolved = await resolveAttachment({
+        base64_data: base64("x"),
+        filename: "../../etc/passwd.txt",
+      });
+
+      expect(resolved.filename).toBe("passwd.txt");
+    });
+
+    it("requires a filename, which cannot be inferred from bytes", async () => {
+      await expect(resolveAttachment({ base64_data: base64("x") })).rejects.toThrow(
+        /filename is required/
+      );
+    });
+
+    it("works with no local file reader installed", async () => {
+      // The hosted transports never install one; base64 must still work there.
+      expect(
+        (await resolveAttachment({ base64_data: base64("x"), filename: "a.txt" })).bytes.length
+      ).toBe(1);
+    });
+  });
+
+  describe("file_path", () => {
+    it("reads through the injected reader and infers name and type from the path", async () => {
+      setLocalFileReader(async () => new Uint8Array([1, 2, 3]));
+
+      const resolved = await resolveAttachment({ file_path: "C:/shots/bug.png" });
+
+      expect(Array.from(resolved.bytes)).toEqual([1, 2, 3]);
+      expect(resolved.filename).toBe("bug.png");
+      expect(resolved.contentType).toBe("image/png");
+    });
+
+    it("handles POSIX paths", async () => {
+      setLocalFileReader(async () => new Uint8Array([1]));
+      expect((await resolveAttachment({ file_path: "/tmp/a/b/report.pdf" })).filename).toBe(
+        "report.pdf"
+      );
+    });
+
+    it("passes the path through to the reader unchanged", async () => {
+      const seen: string[] = [];
+      setLocalFileReader(async (path) => {
+        seen.push(path);
+        return new Uint8Array([1]);
+      });
+
+      await resolveAttachment({ file_path: "C:/shots/bug.png" });
+
+      expect(seen).toEqual(["C:/shots/bug.png"]);
+    });
+
+    // The security boundary: without an installed reader — which is every
+    // transport except stdio — file_path must be refused, never read.
+    it("refuses file_path when no reader is installed", async () => {
+      setLocalFileReader(null);
+
+      await expect(resolveAttachment({ file_path: "/etc/passwd" })).rejects.toThrow(
+        /only supported on the stdio transport/
+      );
+    });
+
+    it("names base64_data as the alternative when refusing", async () => {
+      await expect(resolveAttachment({ file_path: "/etc/passwd" })).rejects.toThrow(
+        /base64_data/
+      );
+    });
+  });
+
+  describe("input validation", () => {
+    it("rejects both inputs at once", async () => {
+      setLocalFileReader(async () => new Uint8Array([1]));
+
+      await expect(
+        resolveAttachment({
+          file_path: "a.png",
+          base64_data: base64("x"),
+          filename: "a.png",
+        })
+      ).rejects.toThrow(/not both/);
+    });
+
+    it("rejects neither input", async () => {
+      await expect(resolveAttachment({})).rejects.toThrow(/either file_path .* or base64_data/);
+    });
+
+    it("treats blank strings as absent", async () => {
+      await expect(
+        resolveAttachment({ file_path: "   ", base64_data: "" })
+      ).rejects.toThrow(/either file_path .* or base64_data/);
+    });
+
+    it("rejects non-string arguments, which the Cloudflare path does not pre-validate", async () => {
+      await expect(resolveAttachment({ file_path: 42 })).rejects.toThrow(
+        /file_path must be a string/
+      );
+    });
+
+    it("rejects an empty file rather than uploading nothing", async () => {
+      setLocalFileReader(async () => new Uint8Array(0));
+      await expect(resolveAttachment({ file_path: "empty.png" })).rejects.toThrow(/is empty/);
+    });
+
+    it("rejects a file over the size limit, reporting both sizes", async () => {
+      setLocalFileReader(async () => new Uint8Array(MAX_ATTACHMENT_BYTES + 1));
+
+      await expect(resolveAttachment({ file_path: "huge.png" })).rejects.toThrow(
+        new RegExp(`${MAX_ATTACHMENT_BYTES + 1} bytes.*${MAX_ATTACHMENT_BYTES}-byte`)
+      );
+    });
+
+    it("accepts a file exactly at the size limit", async () => {
+      setLocalFileReader(async () => new Uint8Array(MAX_ATTACHMENT_BYTES));
+      await expect(resolveAttachment({ file_path: "big.png" })).resolves.toBeDefined();
+    });
+  });
+});

--- a/tests/utils/attachments.test.ts
+++ b/tests/utils/attachments.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   MAX_ATTACHMENT_BYTES,
   attachmentHtml,
   contentTypeForFilename,
   resolveAttachment,
 } from "../../src/utils/attachments.js";
+import { maxEncodedLength } from "../../src/utils/base64.js";
 import { setLocalFileReader } from "../../src/utils/file-source.js";
 
 const base64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
@@ -89,6 +90,24 @@ describe("resolveAttachment", () => {
       expect(
         (await resolveAttachment({ base64_data: base64("x"), filename: "a.txt" })).bytes.length
       ).toBe(1);
+    });
+
+    // The guard has to bound its own cost, not just the decode: optionalString
+    // calls .trim(), which copies the whole string, so an over-cap payload must
+    // be refused before that copy — mirroring the replace-spy assertion in
+    // base64.test.ts for base64ToBytes's own raw-length guard.
+    it("rejects an over-cap base64_data without trimming it first", async () => {
+      const oversized = "A".repeat(maxEncodedLength(MAX_ATTACHMENT_BYTES) + 1);
+      const trimSpy = vi.spyOn(String.prototype, "trim");
+
+      try {
+        await expect(
+          resolveAttachment({ base64_data: oversized, filename: "a.txt" })
+        ).rejects.toThrow(/upload limit/);
+        expect(trimSpy).not.toHaveBeenCalled();
+      } finally {
+        trimSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/utils/base64.test.ts
+++ b/tests/utils/base64.test.ts
@@ -59,10 +59,43 @@ describe("base64ToBytes", () => {
       const oversized = "A".repeat(4000); // decodes to 3000 bytes
       const atobSpy = vi.spyOn(globalThis, "atob");
 
-      expect(() => base64ToBytes(oversized, 1000)).toThrow(/over the 1000-byte upload limit/);
-      expect(atobSpy).not.toHaveBeenCalled();
+      try {
+        expect(() => base64ToBytes(oversized, 1000)).toThrow(/over the 1000-byte upload limit/);
+        expect(atobSpy).not.toHaveBeenCalled();
+      } finally {
+        // In a finally so a failing assertion above cannot leave the global spied.
+        atobSpy.mockRestore();
+      }
+    });
 
-      atobSpy.mockRestore();
+    // The guard has to bound its own cost, not just the decode: normalization
+    // copies the whole input, so an over-limit payload must be refused before it.
+    it("rejects an oversized payload without normalizing it first", () => {
+      const replaceSpy = vi.spyOn(String.prototype, "replace");
+
+      try {
+        expect(() => base64ToBytes("A".repeat(4000), 1000)).toThrow(/upload limit/);
+        expect(replaceSpy).not.toHaveBeenCalled();
+      } finally {
+        replaceSpy.mockRestore();
+      }
+    });
+
+    // Whitespace collapses away, so a long-but-mostly-blank payload is small once
+    // decoded. It must not be rejected on raw length alone.
+    it("does not reject a long payload that is mostly whitespace", () => {
+      const padded = " ".repeat(20000) + Buffer.from("hi", "utf8").toString("base64");
+
+      expect(new TextDecoder().decode(base64ToBytes(padded, 1000))).toBe("hi");
+    });
+
+    it("accepts a padded payload sitting exactly on the limit", () => {
+      // 2 bytes encodes as "aGk=" — counting the '=' would overestimate by one
+      // byte and reject this, so padding must be excluded from the estimate.
+      for (const size of [998, 999, 1000]) {
+        const bytes = new Uint8Array(randomBytes(size));
+        expect(base64ToBytes(bytesToBase64(bytes), 1000).length).toBe(size);
+      }
     });
 
     it("reports the decoded size it computed", () => {

--- a/tests/utils/base64.test.ts
+++ b/tests/utils/base64.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { randomBytes } from "node:crypto";
 import { base64ToBytes, bytesToBase64 } from "../../src/utils/base64.js";
 
@@ -49,5 +49,41 @@ describe("base64ToBytes", () => {
 
   it("rejects input that is not base64 with a message naming the argument", () => {
     expect(() => base64ToBytes("not valid base64!!")).toThrow(/base64_data is not valid base64/);
+  });
+
+  describe("maxBytes", () => {
+    // The guard exists to stop a remote caller forcing a large allocation, so it
+    // has to reject BEFORE decoding — asserting the size alone would still pass
+    // if the check were moved after atob().
+    it("rejects before decoding, not after", () => {
+      const oversized = "A".repeat(4000); // decodes to 3000 bytes
+      const atobSpy = vi.spyOn(globalThis, "atob");
+
+      expect(() => base64ToBytes(oversized, 1000)).toThrow(/over the 1000-byte upload limit/);
+      expect(atobSpy).not.toHaveBeenCalled();
+
+      atobSpy.mockRestore();
+    });
+
+    it("reports the decoded size it computed", () => {
+      expect(() => base64ToBytes("A".repeat(4000), 1000)).toThrow(/decodes to 3000 bytes/);
+    });
+
+    it("accepts input exactly at the limit", () => {
+      const bytes = new Uint8Array(randomBytes(999));
+      const encoded = bytesToBase64(bytes);
+
+      expect(base64ToBytes(encoded, 999).length).toBe(999);
+    });
+
+    it("does not count padding or whitespace toward the limit", () => {
+      // 2 bytes encodes as "aGk=" — the '=' and any wrapping must not push it over.
+      const encoded = Buffer.from("hi", "utf8").toString("base64");
+      expect(base64ToBytes(encoded.slice(0, 2) + "\n " + encoded.slice(2), 2).length).toBe(2);
+    });
+
+    it("is unbounded when no limit is given", () => {
+      expect(base64ToBytes("A".repeat(4000)).length).toBe(3000);
+    });
   });
 });

--- a/tests/utils/base64.test.ts
+++ b/tests/utils/base64.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { randomBytes } from "node:crypto";
+import { base64ToBytes, bytesToBase64 } from "../../src/utils/base64.js";
+
+const utf8 = (text: string) => new TextEncoder().encode(text);
+
+describe("bytesToBase64", () => {
+  it("matches Buffer's encoding", () => {
+    for (const length of [0, 1, 2, 3, 255, 4096]) {
+      const bytes = new Uint8Array(randomBytes(length));
+      expect(bytesToBase64(bytes)).toBe(Buffer.from(bytes).toString("base64"));
+    }
+  });
+
+  it("encodes inputs larger than the chunking threshold", () => {
+    // The chunk size is 0x8000; anything above it exercises the loop that keeps
+    // String.fromCharCode off a 100k-argument spread.
+    const bytes = new Uint8Array(randomBytes(0x8000 * 2 + 13));
+    expect(bytesToBase64(bytes)).toBe(Buffer.from(bytes).toString("base64"));
+  });
+});
+
+describe("base64ToBytes", () => {
+  it("round-trips arbitrary bytes", () => {
+    for (const length of [1, 2, 3, 17, 1024]) {
+      const bytes = new Uint8Array(randomBytes(length));
+      expect(Array.from(base64ToBytes(bytesToBase64(bytes)))).toEqual(Array.from(bytes));
+    }
+  });
+
+  it("accepts the base64url alphabet", () => {
+    const bytes = new Uint8Array([0xfb, 0xef, 0xfe]);
+    const standard = Buffer.from(bytes).toString("base64"); // "++/+"
+    const urlSafe = standard.replace(/\+/g, "-").replace(/\//g, "_");
+
+    expect(Array.from(base64ToBytes(urlSafe))).toEqual(Array.from(bytes));
+  });
+
+  it("accepts unpadded input", () => {
+    const padded = Buffer.from(utf8("hi")).toString("base64"); // "aGk="
+    expect(Array.from(base64ToBytes(padded.replace(/=+$/, "")))).toEqual([104, 105]);
+  });
+
+  it("ignores whitespace, which MCP clients introduce when wrapping long values", () => {
+    const encoded = Buffer.from(utf8("hello world")).toString("base64");
+    const wrapped = encoded.slice(0, 4) + "\n  " + encoded.slice(4);
+    expect(new TextDecoder().decode(base64ToBytes(wrapped))).toBe("hello world");
+  });
+
+  it("rejects input that is not base64 with a message naming the argument", () => {
+    expect(() => base64ToBytes("not valid base64!!")).toThrow(/base64_data is not valid base64/);
+  });
+});

--- a/tests/utils/base64.test.ts
+++ b/tests/utils/base64.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { randomBytes } from "node:crypto";
-import { base64ToBytes, bytesToBase64 } from "../../src/utils/base64.js";
+import { base64ToBytes, bytesToBase64, maxEncodedLength } from "../../src/utils/base64.js";
 
 const utf8 = (text: string) => new TextEncoder().encode(text);
 
@@ -81,12 +81,44 @@ describe("base64ToBytes", () => {
       }
     });
 
-    // Whitespace collapses away, so a long-but-mostly-blank payload is small once
-    // decoded. It must not be rejected on raw length alone.
-    it("does not reject a long payload that is mostly whitespace", () => {
-      const padded = " ".repeat(20000) + Buffer.from("hi", "utf8").toString("base64");
+    // Realistic wrapping — a client folding long values at a fixed column — must
+    // still fit comfortably inside the raw cap and decode successfully.
+    it("decodes realistic line-wrapped base64 within the raw cap", () => {
+      const bytes = new Uint8Array(randomBytes(900));
+      const encoded = bytesToBase64(bytes);
+      const wrapped = (encoded.match(/.{1,64}/g) ?? []).join("\r\n");
 
-      expect(new TextDecoder().decode(base64ToBytes(padded, 1000))).toBe("hi");
+      expect(Array.from(base64ToBytes(wrapped, 1000))).toEqual(Array.from(bytes));
+    });
+
+    // Whitespace collapses away, so a payload that is mostly blank decodes to
+    // something tiny — but the raw cap bounds the function's own cost before
+    // that collapse happens, so an input built to be far larger than any
+    // legitimate wrapping must still be rejected, without normalizing it first.
+    it("rejects a payload padded with far more whitespace than real wrapping ever needs, without normalizing it first", () => {
+      const padded = " ".repeat(100000) + Buffer.from("hi", "utf8").toString("base64");
+      const replaceSpy = vi.spyOn(String.prototype, "replace");
+
+      try {
+        expect(() => base64ToBytes(padded, 1000)).toThrow(/upload limit/);
+        expect(replaceSpy).not.toHaveBeenCalled();
+      } finally {
+        replaceSpy.mockRestore();
+      }
+    });
+
+    // '=' is padding, not data, and is skipped by the significant-length count —
+    // but the raw cap still has to catch a flood of it before any scan runs.
+    it("rejects a flood of padding characters on raw length alone", () => {
+      const flooded = "A".repeat(4) + "=".repeat(100000);
+      const replaceSpy = vi.spyOn(String.prototype, "replace");
+
+      try {
+        expect(() => base64ToBytes(flooded, 1000)).toThrow(/upload limit/);
+        expect(replaceSpy).not.toHaveBeenCalled();
+      } finally {
+        replaceSpy.mockRestore();
+      }
     });
 
     it("accepts a padded payload sitting exactly on the limit", () => {
@@ -99,7 +131,10 @@ describe("base64ToBytes", () => {
     });
 
     it("reports the decoded size it computed", () => {
-      expect(() => base64ToBytes("A".repeat(4000), 1000)).toThrow(/decodes to 3000 bytes/);
+      // Chosen to sit inside the raw cap (so the earlier length-only check does
+      // not fire first) while still decoding over the limit, so the precise,
+      // scan-computed size is what ends up in the error.
+      expect(() => base64ToBytes("A".repeat(1400), 1000)).toThrow(/decodes to 1050 bytes/);
     });
 
     it("accepts input exactly at the limit", () => {
@@ -118,5 +153,16 @@ describe("base64ToBytes", () => {
     it("is unbounded when no limit is given", () => {
       expect(base64ToBytes("A".repeat(4000)).length).toBe(3000);
     });
+  });
+});
+
+describe("maxEncodedLength", () => {
+  it("computes the raw-length cap as data chars plus padding and wrapping allowance", () => {
+    // maxBytes=1000 -> dataChars = ceil(1000/3)*4 = 1336; allowance = ceil(1336/16)+64 = 148.
+    expect(maxEncodedLength(1000)).toBe(1484);
+  });
+
+  it("grows with maxBytes", () => {
+    expect(maxEncodedLength(2000)).toBeGreaterThan(maxEncodedLength(1000));
   });
 });

--- a/tests/utils/md5.test.ts
+++ b/tests/utils/md5.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The implementation in src/utils/md5.ts is hand-written so that the shared
+ * client does not depend on `node:crypto` being present (it is not, on
+ * Workers). These tests are what make that trade safe: the RFC 1321 vectors pin
+ * it to the published standard, and the differential test pins it to a
+ * battle-tested implementation across every length where MD5 padding bugs live.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createHash, randomBytes } from "node:crypto";
+import { md5, md5Base64 } from "../../src/utils/md5.js";
+
+function hex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+const utf8 = (text: string) => new TextEncoder().encode(text);
+
+describe("md5", () => {
+  // RFC 1321, Appendix A.5 "Test suite" — verbatim.
+  const RFC_1321_VECTORS: Array<[string, string]> = [
+    ["", "d41d8cd98f00b204e9800998ecf8427e"],
+    ["a", "0cc175b9c0f1b6a831c399e269772661"],
+    ["abc", "900150983cd24fb0d6963f7d28e17f72"],
+    ["message digest", "f96b697d7cb7938d525a2f31aaf161d0"],
+    ["abcdefghijklmnopqrstuvwxyz", "c3fcd3d76192e4007dfb496cca67e13b"],
+    [
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+      "d174ab98d277d9f5a5611c2c9f419d9f",
+    ],
+    [
+      "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+      "57edf4a22be3c955ac49da2e2107b67a",
+    ],
+  ];
+
+  it.each(RFC_1321_VECTORS)("matches the RFC 1321 vector for %j", (input, expected) => {
+    expect(hex(md5(utf8(input)))).toBe(expected);
+  });
+
+  // 55/56 and 63/64/65 straddle the padding boundaries: 56 bytes is the largest
+  // message whose length field still fits in its own block, so an off-by-one in
+  // the padding arithmetic shows up here and almost nowhere else.
+  const BOUNDARY_LENGTHS = [0, 1, 55, 56, 57, 63, 64, 65, 119, 120, 127, 128, 129, 1000];
+
+  it.each(BOUNDARY_LENGTHS)("agrees with node:crypto at %i bytes", (length) => {
+    const bytes = new Uint8Array(randomBytes(length));
+    const expected = createHash("md5").update(bytes).digest("hex");
+    expect(hex(md5(bytes))).toBe(expected);
+  });
+
+  it("agrees with node:crypto on a payload larger than one megabyte", () => {
+    const bytes = new Uint8Array(randomBytes(1024 * 1024 + 7));
+    expect(hex(md5(bytes))).toBe(createHash("md5").update(bytes).digest("hex"));
+  });
+
+  it("handles bytes outside the ASCII range", () => {
+    const bytes = new Uint8Array([0x00, 0xff, 0x80, 0x7f, 0xfe, 0x01]);
+    expect(hex(md5(bytes))).toBe(createHash("md5").update(bytes).digest("hex"));
+  });
+});
+
+describe("md5Base64", () => {
+  it("produces the Base64 encoding Fizzy's checksum field expects, not hex", () => {
+    const bytes = utf8("abc");
+    expect(md5Base64(bytes)).toBe(createHash("md5").update(bytes).digest("base64"));
+    expect(md5Base64(bytes)).toBe("kAFQmDzST7DWlj99KOF/cg==");
+    // The trap this guards: hex is accepted by the type system and rejected by
+    // the API, with an error that does not explain why.
+    expect(md5Base64(bytes)).not.toBe(hex(md5(bytes)));
+  });
+
+  it("agrees with node:crypto over random inputs", () => {
+    for (const length of [1, 16, 64, 1024]) {
+      const bytes = new Uint8Array(randomBytes(length));
+      expect(md5Base64(bytes)).toBe(createHash("md5").update(bytes).digest("base64"));
+    }
+  });
+});

--- a/tests/verify-refactoring.test.ts
+++ b/tests/verify-refactoring.test.ts
@@ -17,8 +17,9 @@ describe("Refactored Server Verification", () => {
     expect(() => createFizzyServer(client)).not.toThrow();
   });
 
-  it("should have all 49 tools defined in definitions.ts", () => {
-    expect(ALL_TOOLS).toHaveLength(49);
+  it("should have all 50 tools defined in definitions.ts", () => {
+    expect(ALL_TOOLS).toHaveLength(50);
+    expect(ALL_TOOLS.map((tool) => tool.name)).toContain("fizzy_upload_file");
   });
 
   it("should have all tools with required metadata", () => {

--- a/tsconfig.cloudflare.json
+++ b/tsconfig.cloudflare.json
@@ -23,7 +23,11 @@
     "src/tools/**/*",
     "src/utils/errors.ts",
     "src/utils/etag-cache.ts",
-    "src/utils/logger.ts"
+    "src/utils/logger.ts",
+    "src/utils/attachments.ts",
+    "src/utils/base64.ts",
+    "src/utils/file-source.ts",
+    "src/utils/md5.ts"
   ],
   "exclude": ["node_modules", "dist", "tests"]
 }


### PR DESCRIPTION
## Summary

Adds one tool, `fizzy_upload_file`, which runs ActionText's two-step direct upload and
returns a ready-to-paste `<action-text-attachment>` snippet. Until now the server could
not attach a file to anything, so you had to add screenshots to cards by hand.

The tool does not attach anything itself. Rich-text fields already accept HTML, so you
compose the returned snippet into whichever field you want:

```jsonc
// 1. Upload
{ "name": "fizzy_upload_file",
  "arguments": { "account_slug": "123456", "file_path": "/tmp/screenshot.png" } }
// -> { "attachable_sgid": "eyJfcmFpbHMi...", "filename": "screenshot.png",
//      "content_type": "image/png", "byte_size": 8124,
//      "attachment_html": "<action-text-attachment sgid=\"...\"></action-text-attachment>" }

// 2. Reference it — a comment body here; a card description works the same way
{ "name": "fizzy_create_comment",
  "arguments": { "account_slug": "123456", "card_number": "42",
                 "body": "<p>Steps to reproduce:</p><action-text-attachment sgid=\"...\"></action-text-attachment>" } }
```

No existing tool changes and no existing behaviour changes. Outside the new files, the
only edits are the additive tool registration, one tool-count assertion, and four
entries added to `tsconfig.cloudflare.json`'s `include`.

### What the tool accepts, and why

`base64_data` works on every transport. `file_path` is also accepted, but only where a
local-file reader has been installed, and the stdio entry point is the only thing that
installs one.

| Input | stdio | HTTP / SSE | Cloudflare Workers |
|-------|-------|-----------|--------------------|
| `base64_data` (+ `filename`) | yes | yes | yes |
| `file_path` | yes | rejected | rejected |

Accepting only a path would work locally and break in production, since the deployed
transport is a Worker with no filesystem. The sharper constraint is that this server also
ships multi-user HTTP and SSE transports serving remote callers. Honouring a
caller-supplied path there would make the server read its own disk and upload the
contents to Fizzy. So the boundary is stdio versus everything else, not Node versus
Workers: on stdio the MCP client is the same user who owns the process, so reading their
disk grants them nothing they could not already do.

Accepting only base64 was the other candidate. A 1 MB screenshot becomes ~1.37 MB of
base64 inlined into the tool call, which is expensive and can exceed message limits,
while a path costs a few dozen bytes.

The capability is injected (`utils/file-source.ts`) rather than imported. A transport
that does nothing gets no reader, so new transports start closed.

I left remote-URL input out. On the hosted Worker it would mean fetching a
caller-chosen URL server-side, which is an SSRF vector and would need an allowlist.

### Two things the API does not make obvious

Uploading for real surfaced both. Mocks would not have.

**The `sgid` attribute needs `attachable_sgid`, not `signed_id`.** The documented flow
points at `signed_id`. The API accepts it, the comment saves, and it then renders as an
unresolved-attachment placeholder. They are different tokens for the same blob:

```
signed_id       {"data":"03gl…",                              "pur":"blob_id"}
attachable_sgid {"data":"gid://…/ActiveStorage::Blob/03gl…",  "pur":"attachable"}
```

Only the second resolves. The tool returns `attachable_sgid` and does not expose
`signed_id`, so the wrong one is not reachable by accident.

**The upload PUT echoes step one's headers wholesale.** The response carries a
`Content-Disposition` alongside `Content-Type` and `Content-MD5`, and the storage
signature covers what it sent, so picking headers out by name breaks the upload with an
error that never mentions headers.

The checksum is a Base64-encoded MD5. Hex fails with an equally unhelpful error.

### MD5 without `node:crypto`

WebCrypto has no MD5. Using `node:crypto` would tie this shared code path to the
`nodejs_compat` flag staying enabled and to workerd implementing MD5, neither of which
the Node test suite can check. A self-contained implementation produces identical bytes
in every runtime with no branch to get wrong.

The RFC 1321 published vectors pin it, and a differential test against `node:crypto`
covers the block-boundary lengths where MD5 padding bugs live (0, 1, 55, 56, 57, 63, 64,
65, 119, 120, 127, 128, 129, 1 MB+7) plus non-ASCII bytes. It is an upload integrity
checksum, never a security primitive.

## Test plan

**The live round trip is committed, not just described.** `tests/integration/` gains a
token-gated attachment phase that uploads a real PNG, attaches it to a comment, and
asserts the server resolved it by reporting the image's own dimensions back — which it
can only know by analysing the stored bytes. Swapping `attachable_sgid` for `signed_id`
makes that test fail, so it guards the trap rather than narrating it. It skips cleanly
without a token, like the rest of that file, and cleans up after itself in the existing
DELETE phase.

Beyond the suite, I exercised it four ways against real services:

| What | Result |
|---|---|
| **Real workerd** (`wrangler dev`, the actual deploy target) | 14/14 |
| Live stdio, end to end through the built server over MCP JSON-RPC | 19/19 |
| Multi-user HTTP transport, probed as a remote caller would | 6/6 |
| SSE transport | 3/3 |

The workerd run is the one that matters most: the hand-written MD5 and the `btoa`/`atob`
helpers executed on the deploy runtime, and the upload succeeded — which only happens if
the checksum matched the bytes. `file_path` was refused there, and the Cloudflare
dispatch path (raw arguments, no Zod) correctly rejected a non-string argument, a missing
filename, and an empty call.

Throwaway cards were created for each run and deleted afterwards. No real ticket was
touched.

Compatibility was checked rather than assumed: building `main` and this branch and
diffing the published tool surface shows all 49 pre-existing tools byte-identical in
name, title, description, annotations and input schema, with `fizzy_upload_file` the only
addition and no exported symbol removed.

**Gates:** typecheck, Cloudflare typecheck, build, 650 unit tests, 98 Cloudflare tests and
29 live integration tests, all green. 88 tests are new (86 across five new unit files,
plus the two integration cases above).

`npm run lint` is **not** in that list because it cannot run: `eslint` is not a
devDependency and there is no config for it. That is true of `main` as well, and CI does
not run lint either, so it is pre-existing rather than something this branch changed — but
worth stating plainly rather than leaving a reader to assume the script was exercised.

## Declarations

- [ ] This PR adds or changes dependencies (`package.json` / `package-lock.json`)
- [x] This PR changes build or deploy configuration (`tsconfig*.json`, `wrangler.jsonc`, `.github/`)
- [ ] This PR adds npm lifecycle scripts (preinstall/postinstall/prepare)

The build-configuration box covers one change: four new `src/utils/*.ts` files added to
`tsconfig.cloudflare.json`'s `include` array. Without it the Cloudflare typecheck skips
them, since that config lists `src/utils` files individually rather than by glob. No
compiler option changed, and `wrangler.jsonc` and `.github/` are untouched.

## Mentions

I investigated mentions and left them out. They use the same
`<action-text-attachment sgid>` mechanism with a `User` global id, but `GET /users`
returns no sgid, and each one ends in an HMAC signed with the app's secret, so a client
cannot mint one for a user nobody has mentioned yet. Harvesting sgids out of existing
rich text would work, but that is a different data source with different failure modes.
