### PR TITLE
fix(tools): publish the parameter list for the two refined comment schemas

### DIFF
--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -246,34 +246,46 @@ export const deleteCardSchema = z.object({
   card_id: cardNumberSchema,
 });
 
-// Comment schemas with HTML formatting guidance
+// Comment schemas with HTML formatting guidance.
+//
+// These deliberately carry no `.refine()`. McpServer reads a tool's fields off
+// its schema's shape, and refining produces a ZodEffects, which has none — so a
+// refined schema publishes `{"type":"object","properties":{}}` to stdio clients
+// and leaves the model unable to see any argument at all.
+//
+// The "one of card_id or card_number" rule is not lost by dropping it here: it
+// is enforced a layer down by resolveCardNumber, which throws when neither is
+// supplied. That layer has to own it regardless, because the Cloudflare
+// transport dispatches raw arguments without running Zod at all — so before
+// this, stdio and Cloudflare rejected the same call with different errors.
 const commentCardSelectorBase = z.object({
   account_slug: accountSlugSchema,
-  card_id: cardIdSchema.optional(),
-  card_number: cardNumberSchema.optional(),
+  card_id: cardIdSchema
+    .optional()
+    .describe(
+      "The unique card identifier (numeric string, e.g., '67890'). " +
+      "Provide either card_id or card_number. " +
+      "Get available card IDs from fizzy_get_cards."
+    ),
+  card_number: cardNumberSchema
+    .optional()
+    .describe(
+      "The card number - the visible ID shown on the board (e.g., '#123'). " +
+      "Provide either card_id or card_number."
+    ),
 });
 
-const cardSelectorRefinement = (data: { card_id?: string; card_number?: string }) =>
-  Boolean(data.card_id || data.card_number);
+export const getCardCommentsSchema = commentCardSelectorBase;
 
-const cardSelectorRefinementMessage = { message: "Provide either card_id or card_number." };
-
-export const getCardCommentsSchema = commentCardSelectorBase.refine(
-  cardSelectorRefinement,
-  cardSelectorRefinementMessage
-);
-
-export const createCommentSchema = commentCardSelectorBase
-  .extend({
-    body: z.string().describe(
-      "Comment content (required). Supports HTML formatting: " +
-      "<b>bold</b>, <i>italic</i>, <a href='...'>links</a>, <code>code</code>, " +
-      "<ul><li>bullet lists</li></ul>, <ol><li>numbered lists</li></ol>, " +
-      "<pre>code blocks</pre>, <blockquote>quotes</blockquote>. " +
-      "Use plain text for simple comments."
-    ),
-  })
-  .refine(cardSelectorRefinement, cardSelectorRefinementMessage);
+export const createCommentSchema = commentCardSelectorBase.extend({
+  body: z.string().describe(
+    "Comment content (required). Supports HTML formatting: " +
+    "<b>bold</b>, <i>italic</i>, <a href='...'>links</a>, <code>code</code>, " +
+    "<ul><li>bullet lists</li></ul>, <ol><li>numbered lists</li></ol>, " +
+    "<pre>code blocks</pre>, <blockquote>quotes</blockquote>. " +
+    "Use plain text for simple comments."
+  ),
+});
 
 export const deleteCommentSchema = z.object({
   account_slug: accountSlugSchema,

--- a/tests/comment-card-resolution.test.ts
+++ b/tests/comment-card-resolution.test.ts
@@ -145,4 +145,28 @@ describe("Comment tool card resolution (integration)", () => {
     expect(client.getCard).toHaveBeenCalledWith("/123", "card-789");
     expect(client.getCardComments).toHaveBeenCalledWith("/123", "42");
   });
+
+  // The "one of card_id or card_number" rule used to sit in a Zod .refine(),
+  // which cost these two tools their published parameter lists. The rule now
+  // lives only in resolveCardNumber, so these assert it still bites at the tool
+  // boundary — and on every transport, since the Cloudflare path never ran Zod.
+  it("rejects fizzy_create_comment when neither card_id nor card_number is given", async () => {
+    const server = createFizzyServer(client as any) as any;
+    const handler = server.tools["fizzy_create_comment"].handler;
+
+    await expect(handler({ account_slug: "/123", body: "Test" })).rejects.toThrow(
+      "card_id or card_number is required"
+    );
+    expect(client.createCardComment).not.toHaveBeenCalled();
+  });
+
+  it("rejects fizzy_get_card_comments when neither card_id nor card_number is given", async () => {
+    const server = createFizzyServer(client as any) as any;
+    const handler = server.tools["fizzy_get_card_comments"].handler;
+
+    await expect(handler({ account_slug: "/123" })).rejects.toThrow(
+      "card_id or card_number is required"
+    );
+    expect(client.getCardComments).not.toHaveBeenCalled();
+  });
 });

--- a/tests/tools/published-schemas.test.ts
+++ b/tests/tools/published-schemas.test.ts
@@ -55,6 +55,45 @@ describe("published tool schemas", () => {
   });
 
   it("the two tools that regressed publish their full parameter lists", () => {
+    // Read off the Zod shape, which is the thing McpServer reads. Asserting the
+    // Cloudflare JSON Schema here would prove nothing: zod-to-json-schema
+    // unwraps ZodEffects by default, so it emitted the full list even while the
+    // bug was live.
+    const shapeOf = (name: string) =>
+      Object.keys(
+        ((ALL_TOOLS.find((t) => t.name === name)!.schema as z.ZodObject<z.ZodRawShape>) ?? {})
+          .shape ?? {}
+      );
+
+    expect(shapeOf("fizzy_create_comment")).toEqual([
+      "account_slug",
+      "card_id",
+      "card_number",
+      "body",
+    ]);
+    expect(shapeOf("fizzy_get_card_comments")).toEqual([
+      "account_slug",
+      "card_id",
+      "card_number",
+    ]);
+  });
+
+  it("keeps documenting that card_id and card_number are alternatives", () => {
+    // The rule left the schema as a refinement, so the descriptions are now the
+    // only place a model learns it before calling.
+    const shape = (
+      ALL_TOOLS.find((t) => t.name === "fizzy_create_comment")!
+        .schema as z.ZodObject<z.ZodRawShape>
+    ).shape;
+
+    expect(shape.card_id.description).toMatch(/either card_id or card_number/i);
+    expect(shape.card_number.description).toMatch(/either card_id or card_number/i);
+  });
+
+  it("the Cloudflare path was never affected and still publishes everything", () => {
+    // Recorded deliberately: this path unwraps ZodEffects, so it stayed correct
+    // throughout. It is here to catch a regression in the other direction, not
+    // to guard the bug this file is about.
     const published = new Map(
       buildMcpToolDefinitions().map((tool) => [
         tool.name,
@@ -68,22 +107,5 @@ describe("published tool schemas", () => {
       "card_number",
       "body",
     ]);
-    expect(published.get("fizzy_get_card_comments")).toEqual([
-      "account_slug",
-      "card_id",
-      "card_number",
-    ]);
-  });
-
-  it("keeps documenting that card_id and card_number are alternatives", () => {
-    // The rule left the schema as a refinement, so the descriptions are now the
-    // only place a model learns it before calling.
-    const schema = buildMcpToolDefinitions().find((t) => t.name === "fizzy_create_comment");
-    const properties = (schema?.inputSchema as {
-      properties: Record<string, { description?: string }>;
-    }).properties;
-
-    expect(properties.card_id.description).toMatch(/either card_id or card_number/i);
-    expect(properties.card_number.description).toMatch(/either card_id or card_number/i);
   });
 });

--- a/tests/tools/published-schemas.test.ts
+++ b/tests/tools/published-schemas.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Guards the parameter list every tool publishes to clients.
+ *
+ * McpServer reads a tool's fields off its schema's shape. A `.refine()`d schema
+ * is a ZodEffects, which has no shape, so the SDK falls back to
+ * `{"type":"object","properties":{}}` and the tool arrives at the client with no
+ * discoverable arguments. It still executes — the SDK validates against the
+ * unwrapped schema at call time — so nothing fails loudly, and two tools shipped
+ * that way unnoticed.
+ *
+ * These tests assert the property list directly rather than trusting that a
+ * schema "looks fine", because the failure is invisible in the schema source.
+ */
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { ALL_TOOLS } from "../../src/tools/definitions.js";
+import * as schemas from "../../src/tools/schemas.js";
+import { buildMcpToolDefinitions } from "../../src/tools/json-schema.js";
+
+/** What McpServer.registerTool can read fields from. */
+function publishesItsFields(schema: unknown): boolean {
+  return schema instanceof z.ZodObject;
+}
+
+describe("published tool schemas", () => {
+  it("every tool exposes a shape the MCP server can read fields from", () => {
+    const unreadable = ALL_TOOLS.filter((tool) => !publishesItsFields(tool.schema)).map(
+      (tool) => tool.name
+    );
+
+    expect(unreadable).toEqual([]);
+  });
+
+  it("no exported schema is wrapped in ZodEffects", () => {
+    const refined = Object.entries(schemas)
+      .filter(([, schema]) => schema instanceof z.ZodEffects)
+      .map(([name]) => name);
+
+    // Refinements belong in the handlers, which must own them anyway: the
+    // Cloudflare transport dispatches raw arguments and never runs Zod.
+    expect(refined).toEqual([]);
+  });
+
+  it("only the genuinely argument-less tools publish an empty property list", () => {
+    const empty = ALL_TOOLS.filter((tool) => {
+      const shape = (tool.schema as z.ZodObject<z.ZodRawShape>).shape;
+      return !shape || Object.keys(shape).length === 0;
+    }).map((tool) => tool.name);
+
+    // These two take no arguments at all, so empty is correct for them. Naming
+    // them rather than allowing any empty tool keeps the check meaningful: a
+    // tool that loses its parameters still fails here.
+    expect(empty.sort()).toEqual(["fizzy_get_accounts", "fizzy_get_identity"]);
+  });
+
+  it("the two tools that regressed publish their full parameter lists", () => {
+    const published = new Map(
+      buildMcpToolDefinitions().map((tool) => [
+        tool.name,
+        Object.keys((tool.inputSchema as { properties?: Record<string, unknown> }).properties ?? {}),
+      ])
+    );
+
+    expect(published.get("fizzy_create_comment")).toEqual([
+      "account_slug",
+      "card_id",
+      "card_number",
+      "body",
+    ]);
+    expect(published.get("fizzy_get_card_comments")).toEqual([
+      "account_slug",
+      "card_id",
+      "card_number",
+    ]);
+  });
+
+  it("keeps documenting that card_id and card_number are alternatives", () => {
+    // The rule left the schema as a refinement, so the descriptions are now the
+    // only place a model learns it before calling.
+    const schema = buildMcpToolDefinitions().find((t) => t.name === "fizzy_create_comment");
+    const properties = (schema?.inputSchema as {
+      properties: Record<string, { description?: string }>;
+    }).properties;
+
+    expect(properties.card_id.description).toMatch(/either card_id or card_number/i);
+    expect(properties.card_number.description).toMatch(/either card_id or card_number/i);
+  });
+});

--- a/tests/tools/tools-list-over-protocol.test.ts
+++ b/tests/tools/tools-list-over-protocol.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Asks a real McpServer for its tool list over a real MCP connection.
+ *
+ * Every other transport test in this repo mocks `@modelcontextprotocol/sdk`
+ * and invokes the stored callback directly, which skips the very machinery that
+ * produced this bug: `McpServer` reads a tool's fields off its schema's shape,
+ * and a refined schema has none, so `tools/list` served
+ * `{"type":"object","properties":{}}` while every mocked test stayed green.
+ *
+ * This file deliberately does not mock the SDK. It connects the actual server to
+ * the actual client over an in-memory transport pair, so what it asserts is what
+ * a client on the wire would receive.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createFizzyServer } from "../../src/server.js";
+import type { FizzyClient } from "../../src/client/fizzy-client.js";
+
+/** No tool is invoked here; only the published tool list is read. */
+const unusedClient = {} as FizzyClient;
+
+async function listToolsOverProtocol() {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  const server = createFizzyServer(unusedClient);
+  await server.connect(serverTransport);
+
+  const client = new Client({ name: "published-schema-test", version: "1.0.0" });
+  await client.connect(clientTransport);
+
+  const { tools } = await client.listTools();
+  await client.close();
+
+  return new Map(
+    tools.map((tool) => [
+      tool.name,
+      Object.keys(
+        (tool.inputSchema as { properties?: Record<string, unknown> }).properties ?? {}
+      ),
+    ])
+  );
+}
+
+describe("tools/list over a real MCP connection", () => {
+  it("serves the full parameter list for the two tools that regressed", async () => {
+    const published = await listToolsOverProtocol();
+
+    expect(published.get("fizzy_create_comment")).toEqual([
+      "account_slug",
+      "card_id",
+      "card_number",
+      "body",
+    ]);
+    expect(published.get("fizzy_get_card_comments")).toEqual([
+      "account_slug",
+      "card_id",
+      "card_number",
+    ]);
+  });
+
+  it("serves a non-empty parameter list for every tool that takes arguments", async () => {
+    const published = await listToolsOverProtocol();
+
+    const empty = [...published.entries()]
+      .filter(([, properties]) => properties.length === 0)
+      .map(([name]) => name)
+      .sort();
+
+    // Only these two genuinely take no arguments.
+    expect(empty).toEqual(["fizzy_get_accounts", "fizzy_get_identity"]);
+  });
+
+  it("carries the field descriptions a model relies on", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createFizzyServer(unusedClient);
+    await server.connect(serverTransport);
+    const client = new Client({ name: "published-schema-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+
+    const { tools } = await client.listTools();
+    await client.close();
+
+    const properties = (
+      tools.find((t) => t.name === "fizzy_create_comment")!.inputSchema as {
+        properties: Record<string, { description?: string }>;
+      }
+    ).properties;
+
+    expect(properties.card_id.description).toMatch(/either card_id or card_number/i);
+    expect(properties.body.description).toMatch(/comment content/i);
+  });
+});


### PR DESCRIPTION
Fixes #32.

`fizzy_create_comment` and `fizzy_get_card_comments` reach stdio clients with no discoverable arguments:

```json
{"type":"object","properties":{}}
```

A model reading the tool list cannot tell that they take `account_slug`, `card_id`, `card_number` and `body`. Both tools still execute, which is why this went unnoticed for so long.

## Cause

`McpServer` reads a tool's fields off its schema's shape. Both schemas ended in `.refine()`, which wraps the object in a `ZodEffects` that has no shape, so the SDK's `normalizeObjectSchema` returns `undefined` and `tools/list` falls back to an empty object schema. These were the only two refined schemas in `src/tools/schemas.ts`.

## Why not just unwrap the effects

The obvious fix is to hand `registerTool` the inner object. It would publish the fields, and it would also silently drop the rule.

The SDK's `validateToolInput` does this:

```js
const inputObj = normalizeObjectSchema(tool.inputSchema);
const schemaToParse = inputObj ?? tool.inputSchema;
```

For a `ZodEffects` that falls through to the refined schema, so the "one of `card_id` or `card_number`" check is enforced at call time today. Registering the unwrapped object would publish the parameters and stop enforcing the constraint, trading a visible problem for an invisible one.

So the rule moves rather than disappears. `resolveCardNumber` already throws `card_id or card_number is required` when neither is supplied, and it already had to: the Cloudflare transport dispatches raw arguments without running Zod at all. The two transports previously rejected the same call with different errors, and now agree.

## Impact

Valid calls are unaffected. A caller passing neither identifier still gets an error before any API request; only the wording changes, from the Zod message to `card_id or card_number is required`, which is what Cloudflare callers already saw.

Both fields now state the either/or rule in their descriptions, since the schema no longer encodes it.

The Cloudflare path is untouched. It builds schemas through `zod-to-json-schema`, which handles `ZodEffects` correctly and always published these two tools properly.

## Before and after

Asking a real stdio server for `fizzy_create_comment`, on `main`:

```
fizzy_create_comment        | (EMPTY)
fizzy_get_card_comments     | (EMPTY)
fizzy_get_card              | account_slug, card_id
```

On this branch:

```
fizzy_create_comment        | account_slug, card_id, card_number, body
fizzy_get_card_comments     | account_slug, card_id, card_number
fizzy_get_card              | account_slug, card_id
```

The published schema now carries every field with its description and `required: ["account_slug","body"]`. Calling the tool behaves identically either way, confirmed by sending the same arguments to both and getting the same API response.

## Tests

`tests/tools/tools-list-over-protocol.test.ts` asks a real `McpServer` for its tool list over a real connection, using the SDK's in-memory transport pair. This matters: every other transport test in the repo mocks the SDK and invokes the stored callback directly, which skips the exact machinery that produced this bug. The tool list served `{properties:{}}` while all of them stayed green.

`tests/tools/published-schemas.test.ts` asserts that no exported schema is a `ZodEffects`, that every tool exposes a readable shape, and that these two carry their exact fields.

A note on how those assertions are written, because the first version got it wrong: two of them originally read `buildMcpToolDefinitions()`, which is the Cloudflare path. `zod-to-json-schema` unwraps `ZodEffects` by default, so it emitted the full property list even while the bug was live, and both assertions stayed green when the `.refine()` was reinstated. They now read the Zod shape, which is what `McpServer` reads and what a refined schema does not have. One Cloudflare assertion remains, renamed to say what it actually guards.

Reinstating `.refine()` now fails both files, including over the protocol.

Two handler tests cover the constraint at the tool boundary, since that is where enforcement now lives.

Gates: typecheck, Cloudflare typecheck, build, 574 unit tests and 98 Cloudflare tests green. `npm run lint` is not included because it cannot run in this repo: `eslint` is not a devDependency and CI does not invoke it either.
