### PR TITLE
fix(types): type FizzyComment.body as rich text, matching what the API returns

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -62,9 +62,28 @@ export interface FizzyTag {
   url: string;
 }
 
+/**
+ * A rich-text field as the API returns it. Both representations of the same
+ * content: `html` carries the markup, including `<action-text-attachment>`
+ * elements; `plain_text` is the same content flattened.
+ *
+ * Only responses use this shape. Rich text is *written* as a plain HTML string
+ * — see `CreateCommentRequest.body`.
+ *
+ * @see https://github.com/basecamp/fizzy/blob/main/docs/api/sections/comments.md
+ */
+export interface FizzyRichText {
+  plain_text: string;
+  html: string;
+}
+
 export interface FizzyComment {
   id: string;
-  body: string;
+  /**
+   * Rich text, not a string. Reading `.html` or `.plain_text` is required;
+   * treating this as a string yields "[object Object]".
+   */
+  body: FizzyRichText;
   creator: FizzyUser;
   created_at: string;
   updated_at?: string;

--- a/tests/client/fizzy-client.test.ts
+++ b/tests/client/fizzy-client.test.ts
@@ -964,7 +964,14 @@ describe("FizzyClient", () => {
   describe("Comments", () => {
     // Expected URL: GET /:account_slug/cards/:card_number/comments
     it("should get card comments", async () => {
-      const mockComments = [{ id: "comment1", body: "Comment 1" }];
+      // The API returns rich text as { plain_text, html }. Mocking it as a bare
+      // string is what let the declared type stay wrong without any test noticing.
+      const mockComments = [
+        {
+          id: "comment1",
+          body: { plain_text: "Comment 1", html: "<div>Comment 1</div>" },
+        },
+      ];
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -982,7 +989,10 @@ describe("FizzyClient", () => {
     });
 
     it("should create a comment", async () => {
-      const mockComment = { id: "comment1", body: "New Comment" };
+      const mockComment = {
+        id: "comment1",
+        body: { plain_text: "New Comment", html: "<div>New Comment</div>" },
+      };
 
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/tests/comment-card-resolution.test.ts
+++ b/tests/comment-card-resolution.test.ts
@@ -135,7 +135,9 @@ describe("Comment tool card resolution (integration)", () => {
       number: 42,
       url: "https://app.fizzy.do/123/cards/42",
     });
-    client.getCardComments.mockResolvedValue([{ id: "comment-1", body: "Hello" }]);
+    client.getCardComments.mockResolvedValue([
+      { id: "comment-1", body: { plain_text: "Hello", html: "<div>Hello</div>" } },
+    ]);
 
     const server = createFizzyServer(client as any) as any;
     const handler = server.tools["fizzy_get_card_comments"].handler;

--- a/tests/integration/api.integration.test.ts
+++ b/tests/integration/api.integration.test.ts
@@ -295,9 +295,9 @@ describe.skipIf(!shouldRun)("Fizzy API Integration Tests", () => {
       expect(typeof comment.body).toBe("object");
       expect(typeof comment.body.html).toBe("string");
       expect(typeof comment.body.plain_text).toBe("string");
-      // The failure this prevents: string operations on `body` compile and then
-      // silently operate on "[object Object]".
-      expect(String(comment.body)).toBe("[object Object]");
+      // The html carries the markup, which is what made the old `string` type
+      // actively harmful: substring searches for tags silently found nothing.
+      expect(comment.body.html).toContain("<");
 
       console.log(`✓ Read: body is { plain_text, html }`);
     });

--- a/tests/integration/api.integration.test.ts
+++ b/tests/integration/api.integration.test.ts
@@ -280,6 +280,28 @@ describe.skipIf(!shouldRun)("Fizzy API Integration Tests", () => {
       console.log(`✓ Read: Comment verified`);
     });
 
+    // Pins what the API actually sends, which is the evidence the declared type
+    // rests on. It does not guard the type itself: tests sit outside tsconfig's
+    // include and vitest strips annotations without checking them, so reverting
+    // `body` to `string` still passes here. That gap is precisely how the wrong
+    // type survived, and it is why this asserts the runtime shape instead.
+    it("returns comment bodies as rich text, not a string", async () => {
+      const comment = await client!.getComment(
+        testData.accountSlug,
+        testData.createdCardNumber,
+        testData.createdCommentId
+      );
+
+      expect(typeof comment.body).toBe("object");
+      expect(typeof comment.body.html).toBe("string");
+      expect(typeof comment.body.plain_text).toBe("string");
+      // The failure this prevents: string operations on `body` compile and then
+      // silently operate on "[object Object]".
+      expect(String(comment.body)).toBe("[object Object]");
+
+      console.log(`✓ Read: body is { plain_text, html }`);
+    });
+
     it("GET /:account_slug/tags - reads tags", async () => {
       const tags = await client!.getTags(testData.accountSlug);
       

--- a/tests/tools/tool-execution.test.ts
+++ b/tests/tools/tool-execution.test.ts
@@ -293,9 +293,10 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
 
   describe("Comment Operations", () => {
     it("getCardComments retrieves comments for a card", async () => {
+      // Comment bodies come back as rich text, not strings.
       const mockComments = [
-        { id: "comment1", body: "First comment" },
-        { id: "comment2", body: "Second comment" },
+        { id: "comment1", body: { plain_text: "First comment", html: "<div>First comment</div>" } },
+        { id: "comment2", body: { plain_text: "Second comment", html: "<div>Second comment</div>" } },
       ];
 
       mockFetch.mockResolvedValueOnce(mockResponse(mockComments));
@@ -310,7 +311,10 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
     });
 
     it("createCardComment creates a comment", async () => {
-      const mockComment = { id: "comment1", body: "New comment" };
+      const mockComment = {
+        id: "comment1",
+        body: { plain_text: "New comment", html: "<div>New comment</div>" },
+      };
 
       mockFetch.mockResolvedValueOnce(mockResponse(mockComment, 201));
 


### PR DESCRIPTION
Fixes #33.

`FizzyComment.body` was declared `string`. Every comment endpoint returns an object:

```json
"body": { "plain_text": "This looks great!", "html": "<div class=\"action-text-content\">This looks great!</div>" }
```

Confirmed against the live API and against the upstream documentation in `docs/api/sections/comments.md`.

## Why it matters

TypeScript reported `body` as a string, so the obvious code compiled and quietly did the wrong thing:

```ts
comment.body.includes("action-text-attachment")  // always false
`${comment.body}`                                 // "[object Object]"
```

Neither produces an error. I hit this scanning comments for attachment markup: the search reported zero matches across dozens of comments that did contain attachments, because the regex was running against `[object Object]`.

## The change

Adds a `FizzyRichText` interface and points `FizzyComment.body` at it.

The mismatch is read-only. `CreateCommentRequest.body` and `UpdateCommentRequest.body` genuinely are strings on the way in and are unchanged.

## Which other fields were checked

Two neighbours look like candidates for the identical bug, so both were checked against the live API rather than assumed:

- **`FizzyNotification.body`** really does return a string. Correctly typed, left alone.
- **`FizzyCard.description`** is the more interesting one, because the tool schemas describe it as accepting HTML in exactly the language comment `body` used. It is **not** the same shape. Cards use a different convention: `description` is a plain string and the markup lives in a separate `description_html` field alongside it. Checked across four real cards:

```
card 2105 | description: string | description_html: string | desc is object? false
card 1834 | description: string | description_html: string | desc is object? false
card 1689 | description: string | description_html: string | desc is object? false
card 2086 | description: string | description_html: string | desc is object? false
```

So `FizzyCard.description?: string` is correct as declared. `FizzyComment` is the only affected type.

Separately, and not fixed here: `FizzyCard` does not model several fields the API returns, including `description_html`, `image_url`, `has_attachments`, `closed`, `golden` and `steps`. That is an incomplete type rather than a wrong one — consumers still receive those fields at runtime — so widening it belongs in its own change.

## Breaking change

This breaks TypeScript consumers that read comment bodies. Those call sites now fail to compile.

That is deliberate. They are already producing wrong results at runtime, and a compile error is the only signal that reaches them. Silently correcting the runtime data instead would have broken anyone already reading `body.html` correctly, and would have thrown away `plain_text`.

No runtime behaviour changes. The client returns exactly what it always returned.

There are no internal consumers: the only `.body` reads in `src/` are on the write path, where it remains a string.

I left `package.json` alone, since this repo publishes manually via `docs/PUBLISHING.md`. It warrants a minor bump whenever it next ships, and a note in the release description.

## Tests

Three test files mocked comment `body` as a bare string. That is a large part of why the declared type stayed wrong without anything objecting, so all three now mock the real shape — `fizzy-client.test.ts`, `tool-execution.test.ts` and `comment-card-resolution.test.ts`. Only read-side mocks changed; every remaining string `body` in the suite is on the write path, where a string is correct.

A live integration assertion pins what the API sends. Two limits worth stating rather than leaving a reader to assume otherwise:

- It does **not** guard the declared type. Reverting `body` to `string` still passes it, because tests sit outside `tsconfig`'s `include` and vitest strips annotations without checking them. That gap is how the wrong type survived, so it is written into the test rather than left implied.
- It does not run in CI. `test:integration` is not part of the workflow and the suite is gated on `FIZZY_ACCESS_TOKEN`, so this assertion executes locally with a live token and nowhere else.

Gates: typecheck, Cloudflare typecheck, build, 563 unit tests, 98 Cloudflare tests and 28 live integration tests green. `npm run lint` is not included because it cannot run in this repo: `eslint` is not a devDependency and CI does not invoke it either.
