### PR TITLE
fix: stop unhandled Worker exceptions and unbounded ETag cache growth

### DIFF
--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -57,6 +57,20 @@ export interface FizzyClientConfig {
   enableCache?: boolean;
   /** Maximum age for cached responses in ms (default: 1 hour) */
   cacheMaxAge?: number;
+  /**
+   * Maximum total size across all cached responses (default: 8388608 / 8MB),
+   * measured as JSON source length in UTF-16 code units — not UTF-8 wire
+   * bytes, and not the retained heap size of the parsed response. Forwarded
+   * to `ETagCache`'s `maxBytes`; see `ETagCacheOptions.maxBytes` for why
+   * that's a deliberately simple sizing proxy rather than a hard memory bound.
+   */
+  cacheMaxBytes?: number;
+  /**
+   * Maximum size for a single cached response; larger responses are not
+   * cached (default: 262144 / 256KB). Same UTF-16-code-unit measurement as
+   * `cacheMaxBytes` — see `ETagCacheOptions.maxEntryBytes`.
+   */
+  cacheMaxEntryBytes?: number;
 }
 
 export class FizzyClient {
@@ -78,7 +92,11 @@ export class FizzyClient {
     
     // Initialize ETag cache if enabled (default: true)
     this.cache = (config.enableCache ?? true)
-      ? new ETagCache({ maxAge: config.cacheMaxAge ?? 60 * 60 * 1000 })
+      ? new ETagCache({
+          maxAge: config.cacheMaxAge ?? 60 * 60 * 1000,
+          maxBytes: config.cacheMaxBytes,
+          maxEntryBytes: config.cacheMaxEntryBytes,
+        })
       : null;
   }
 
@@ -327,17 +345,37 @@ export class FizzyClient {
 
       // Handle 204 No Content
       if (response.status === 204) {
-        // Invalidate related caches on mutations
         if (!isGetRequest && this.cache) {
+          // Invalidate related caches on mutations
           this.invalidateCacheForMutation(url);
+        } else if (isGetRequest && this.cache) {
+          // A GET that comes back 204 carries no ETag either, so any
+          // previously cached representation for this exact URL is now
+          // stale — same reasoning as the no-ETag branch below in the 200
+          // path, just reached via a different response shape.
+          this.cache.invalidate(url);
         }
         return { data: undefined as T, meta: undefined };
       }
 
       // Parse JSON response
       let data: T;
+      // Prefer text() so the cache can bound itself by the JSON source's length
+      // (in UTF-16 code units — a proxy for actual body size, not an exact byte
+      // count; see ETagCacheOptions.maxBytes for why that's an acceptable
+      // trade-off). response.json() materialises the same string internally, so
+      // this costs nothing extra in production. Partial mocks in the test suite
+      // only define json(), hence the capability check — same defensive posture
+      // as the header access in parsePaginationMeta().
+      let rawLength: number | undefined;
       try {
-        data = (await response.json()) as T;
+        if (typeof response.text === "function") {
+          const raw = await response.text();
+          rawLength = raw.length;
+          data = JSON.parse(raw) as T;
+        } else {
+          data = (await response.json()) as T;
+        }
       } catch (parseError) {
         // Handle 201 Created with empty body (Fizzy returns Location header only)
         if (response.status === 201) {
@@ -370,8 +408,15 @@ export class FizzyClient {
       if (isGetRequest && this.cache && response.headers) {
         const etag = response.headers.get("ETag");
         if (etag) {
-          this.cache.set(url, etag, data, meta);
+          this.cache.set(url, etag, data, meta, rawLength);
           this.log.debug(`${logPrefix}Cached response with ETag: ${etag}`);
+        } else {
+          // A successful GET with no ETag can't be cached going forward, but
+          // it can still be *fresher* than whatever's already cached for this
+          // URL. Without this, a prior ETagged entry would survive untouched
+          // and we'd keep sending its (now stale) If-None-Match on every
+          // later request for a resource that no longer emits ETags.
+          this.cache.invalidate(url);
         }
       }
 

--- a/src/cloudflare/index.ts
+++ b/src/cloudflare/index.ts
@@ -27,6 +27,7 @@
 import type { Env, ExecutionContext, SecurityResult, HealthResponse } from "./types.js";
 import { SERVER_VERSION } from "./types.js";
 import { RateLimiter, createLogger, createAnalytics, type LogLevel } from "./utils/index.js";
+import { buildWorkerErrorEnvelope } from "./utils/worker-errors.js";
 
 // Re-export Durable Object classes for Wrangler
 export { McpSessionDO } from "./mcp-session.js";
@@ -249,6 +250,20 @@ async function handleMcp(
     responseHeaders.set("mcp-session-id", sessionId);
   }
 
+  // Residual limitation: `doResponse.body` is streamed through, not buffered.
+  // The try/catch around the top-level `fetch` handler (see the default
+  // export below) only covers the `await handleMcp(...)` call settling —
+  // reading this body happens later and asynchronously, disconnected from
+  // that await, once the platform starts consuming the Response this
+  // function returns. A DO failure *while this body is being consumed
+  // downstream* therefore happens outside that boundary and can still
+  // surface as an uncaught error, no matter what the caller does with the
+  // Response in between. Buffering here with `doResponse.arrayBuffer()`
+  // would make that case catchable too, but at the cost of holding the
+  // *entire* response (e.g. a large `get_cards` page) in the calling
+  // Worker's own memory — which reintroduces the memory pressure this
+  // change exists to relieve. Kept streaming deliberately; this gap is
+  // accepted.
   return new Response(doResponse.body, {
     status: doResponse.status,
     statusText: doResponse.statusText,
@@ -265,87 +280,125 @@ export default {
     env: Env,
     ctx: ExecutionContext
   ): Promise<Response> {
-    const startTime = Date.now();
-    const url = new URL(request.url);
-    const path = url.pathname;
+    // `path` is computed defensively (outside the try's happy path) so the
+    // catch block below can still report which route failed even if the
+    // failure happened before or during URL parsing.
+    let path = "";
 
-    // Initialize logger
-    const logger = createLogger({
-      level: (env.LOG_LEVEL as LogLevel) || "info",
-      r2Bucket: env.AUDIT_LOGS,
-      consoleOutput: true,
-    });
+    try {
+      const startTime = Date.now();
+      const url = new URL(request.url);
+      path = url.pathname;
 
-    // Initialize analytics
-    const analytics = createAnalytics(env.ANALYTICS);
+      // Initialize logger
+      const logger = createLogger({
+        level: (env.LOG_LEVEL as LogLevel) || "info",
+        r2Bucket: env.AUDIT_LOGS,
+        consoleOutput: true,
+      });
 
-    // Validate Durable Objects binding
-    if (!env.MCP_SESSIONS) {
-      console.error("MCP_SESSIONS Durable Objects binding not configured");
-      return errorResponse(500, "Server configuration error: Missing Durable Objects binding");
-    }
+      // Initialize analytics
+      const analytics = createAnalytics(env.ANALYTICS);
 
-    // Handle health check (skip security for monitoring)
-    if (path === "/health" && request.method === "GET") {
-      const security = validateSecurity(request, env);
-      return handleHealth(security.corsOrigin || "*", env);
-    }
-
-    // Validate security for all other requests
-    const security = validateSecurity(request, env);
-
-    // Handle CORS preflight
-    if (request.method === "OPTIONS") {
-      return handleOptions(security.corsOrigin || "*");
-    }
-
-    // Check security result
-    if (!security.allowed) {
-      analytics.trackRequest(request.method, path, security.statusCode || 403, Date.now() - startTime);
-      return errorResponse(
-        security.statusCode || 403,
-        security.error || "Access denied",
-        security.corsOrigin
-      );
-    }
-
-    // Route to MCP handler (Streamable HTTP transport)
-    if (path === "/mcp") {
-      // Check rate limit if enabled
-      if (env.RATE_LIMITER && env.ENABLE_RATE_LIMIT !== "false") {
-        const fizzyToken = extractFizzyToken(request);
-        if (fizzyToken) {
-          const rateLimiter = new RateLimiter(env.RATE_LIMITER, {
-            limit: parseInt(env.RATE_LIMIT_RPM || "10000", 10),
-            windowSeconds: 60,
-          });
-
-          const rateLimitResult = await rateLimiter.checkByToken(fizzyToken);
-          
-          if (!rateLimitResult.allowed) {
-            logger.warn("Rate limit exceeded", {
-              remaining: rateLimitResult.remaining,
-              resetAt: rateLimitResult.resetAt,
-            });
-            analytics.trackRequest(request.method, path, 429, Date.now() - startTime);
-            return RateLimiter.createRateLimitResponse(rateLimitResult, security.corsOrigin);
-          }
-        }
+      // Validate Durable Objects binding
+      if (!env.MCP_SESSIONS) {
+        console.error("MCP_SESSIONS Durable Objects binding not configured");
+        return errorResponse(500, "Server configuration error: Missing Durable Objects binding");
       }
 
-      const response = await handleMcp(request, env, security.corsOrigin!);
-      
-      // Track request metrics
-      analytics.trackRequest(request.method, path, response.status, Date.now() - startTime);
-      
-      // Flush logs asynchronously
-      ctx.waitUntil(logger.flush());
-      
-      return response;
-    }
+      // Handle health check (skip security for monitoring)
+      if (path === "/health" && request.method === "GET") {
+        const security = validateSecurity(request, env);
+        return handleHealth(security.corsOrigin || "*", env);
+      }
 
-    // 404 for unknown routes
-    analytics.trackRequest(request.method, path, 404, Date.now() - startTime);
-    return errorResponse(404, "Not found", security.corsOrigin);
+      // Validate security for all other requests
+      const security = validateSecurity(request, env);
+
+      // Handle CORS preflight
+      if (request.method === "OPTIONS") {
+        return handleOptions(security.corsOrigin || "*");
+      }
+
+      // Check security result
+      if (!security.allowed) {
+        analytics.trackRequest(request.method, path, security.statusCode || 403, Date.now() - startTime);
+        return errorResponse(
+          security.statusCode || 403,
+          security.error || "Access denied",
+          security.corsOrigin
+        );
+      }
+
+      // Route to MCP handler (Streamable HTTP transport)
+      if (path === "/mcp") {
+        // Check rate limit if enabled
+        if (env.RATE_LIMITER && env.ENABLE_RATE_LIMIT !== "false") {
+          const fizzyToken = extractFizzyToken(request);
+          if (fizzyToken) {
+            const rateLimiter = new RateLimiter(env.RATE_LIMITER, {
+              limit: parseInt(env.RATE_LIMIT_RPM || "10000", 10),
+              windowSeconds: 60,
+            });
+
+            const rateLimitResult = await rateLimiter.checkByToken(fizzyToken);
+
+            if (!rateLimitResult.allowed) {
+              logger.warn("Rate limit exceeded", {
+                remaining: rateLimitResult.remaining,
+                resetAt: rateLimitResult.resetAt,
+              });
+              analytics.trackRequest(request.method, path, 429, Date.now() - startTime);
+              return RateLimiter.createRateLimitResponse(rateLimitResult, security.corsOrigin);
+            }
+          }
+        }
+
+        // `doStub.fetch()` below rejects when Cloudflare kills the session's
+        // Durable Object for exceeding its memory/CPU budget (see the
+        // byte-bounded ETag cache in utils/etag-cache.ts for the main source
+        // of that memory pressure). That rejection — like any exception in
+        // this handler — is caught by the try/catch wrapping this whole
+        // function, which is what keeps it from surfacing as an uncatchable
+        // Cloudflare error 1101 to the client.
+        const response = await handleMcp(request, env, security.corsOrigin!);
+
+        // Track request metrics
+        analytics.trackRequest(request.method, path, response.status, Date.now() - startTime);
+
+        // Flush logs asynchronously
+        ctx.waitUntil(logger.flush());
+
+        return response;
+      }
+
+      // 404 for unknown routes
+      analytics.trackRequest(request.method, path, 404, Date.now() - startTime);
+      return errorResponse(404, "Not found", security.corsOrigin);
+    } catch (error) {
+      // Last-resort error boundary: converts anything that would otherwise
+      // escape this handler uncaught — and surface to the client as an
+      // opaque, misleadingly-"non-retryable" Cloudflare error 1101 — into a
+      // diagnosable JSON-RPC error response instead.
+      console.error("Unhandled error in Worker fetch handler", error);
+
+      // The origin may be unknown at this point (the failure could have
+      // happened before `validateSecurity` ran, or `validateSecurity` itself
+      // could be the thing that threw), so recompute it defensively and
+      // never let this fallback itself throw.
+      let corsOrigin = "*";
+      try {
+        corsOrigin = validateSecurity(request, env).corsOrigin || "*";
+      } catch {
+        corsOrigin = "*";
+      }
+
+      const { status, body } = buildWorkerErrorEnvelope(path, error);
+      const headers = new Headers({ "Content-Type": "application/json" });
+      setCorsHeaders(headers, corsOrigin);
+      setSecurityHeaders(headers);
+
+      return new Response(JSON.stringify(body), { status, headers });
+    }
   },
 };

--- a/src/cloudflare/utils/worker-errors.ts
+++ b/src/cloudflare/utils/worker-errors.ts
@@ -1,0 +1,88 @@
+/**
+ * Top-level Worker error envelope construction.
+ *
+ * Deliberately kept out of `index.ts` (and out of `cloudflare/utils/index.ts`,
+ * which re-exports `RateLimiterDO` and therefore transitively imports
+ * `cloudflare:workers`). This file imports nothing Workers-specific, so it can
+ * be unit tested under plain Node vitest without a Workers runtime.
+ *
+ * When an exception escapes the top-level `fetch` handler uncaught, Cloudflare
+ * renders an opaque error 1101 ("Worker threw exception") with a response body
+ * that claims `"retryable": false` — which is misleading for the failure mode
+ * this was written for (a Durable Object killed for exceeding its memory/CPU
+ * budget rejects `doStub.fetch()`, and that rejection *is* transient/retryable).
+ * Converting it into a diagnosable JSON-RPC error here means clients get a
+ * real, retryable error instead of a generic platform failure page.
+ */
+
+/** JSON-RPC 2.0 error envelope, per https://www.jsonrpc.org/specification#error_object */
+export interface JsonRpcErrorBody {
+  jsonrpc: "2.0";
+  id: null;
+  error: { code: number; message: string };
+}
+
+/** Plain `{ error }` shape used by `errorResponse()` elsewhere in this module. */
+export interface PlainErrorBody {
+  error: string;
+}
+
+export interface WorkerErrorEnvelope {
+  status: number;
+  body: JsonRpcErrorBody | PlainErrorBody;
+}
+
+/**
+ * Extract a human-readable message from an unknown thrown value.
+ *
+ * Never throws, and always returns an actual `string` (not just a value
+ * typed as one): reading `.message` off an `Error`, and the `String()`
+ * fallback for everything else, are both inside the same try/catch — either
+ * can throw on a hostile value, such as an `Error` with a poisoned `message`
+ * getter, or a plain object with a poisoned `toString()`. JS also doesn't
+ * enforce that `Error.message` itself is a string, so a hostile instance
+ * could hand back a BigInt or a cyclic object without ever throwing; the
+ * `typeof` check below catches that case too and coerces it with `String()`
+ * — otherwise a non-string "message" would sail through here only to make
+ * `JSON.stringify` throw later, at the call site building the response body.
+ * Any failure along the way falls back to a fixed message rather than
+ * propagating a second exception out of an error handler.
+ */
+export function getErrorMessage(error: unknown): string {
+  try {
+    const value = error instanceof Error ? error.message : error;
+    return typeof value === "string" ? value : String(value);
+  } catch {
+    return "Unknown error";
+  }
+}
+
+/**
+ * Build the status code and JSON body for an error that escaped the
+ * top-level Worker `fetch` handler.
+ *
+ * `/mcp` requests get a JSON-RPC 2.0 error envelope (`code: -32603`, Internal
+ * error, matching the convention in `mcp-session.ts`'s `jsonError`) with
+ * `id: null` since the original JSON-RPC request id may never have been
+ * parsed. Every other path gets the same plain `{ error }` shape used by this
+ * module's `errorResponse()` helper. Both cases use HTTP 500.
+ */
+export function buildWorkerErrorEnvelope(path: string, error: unknown): WorkerErrorEnvelope {
+  const message = getErrorMessage(error);
+
+  if (path === "/mcp") {
+    return {
+      status: 500,
+      body: {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32603, message },
+      },
+    };
+  }
+
+  return {
+    status: 500,
+    body: { error: message },
+  };
+}

--- a/src/utils/etag-cache.ts
+++ b/src/utils/etag-cache.ts
@@ -1,9 +1,9 @@
 /**
  * ETag Cache for HTTP Conditional Requests
- * 
+ *
  * Implements caching based on ETags as described in the Fizzy API:
  * https://github.com/basecamp/fizzy/blob/main/docs/API.md#caching
- * 
+ *
  * When a response includes an ETag header, we store it along with the response.
  * On subsequent requests, we send the ETag in the If-None-Match header.
  * If the resource hasn't changed, we receive a 304 Not Modified and return cached data.
@@ -21,6 +21,18 @@ export interface CacheEntry<T> {
    * pagination headers of a list response) so a later 304 can still report it.
    */
   meta?: unknown;
+  /**
+   * Best-effort measured size of the response body, as counted toward
+   * `maxBytes`. This is the JSON source's length in UTF-16 code units
+   * (`raw.length`, passed in as `set`'s `sizeBytes` parameter) — not UTF-8
+   * wire bytes, and not the retained heap size of the parsed `data` this
+   * entry actually holds. See `ETagCacheOptions.maxBytes` for why that gap
+   * is treated as an acceptable, deliberately simple sizing proxy rather
+   * than a precise byte count. 0 when the caller couldn't measure the body
+   * — such entries still occupy a slot toward `maxEntries` but are not
+   * counted toward the byte budget.
+   */
+  sizeBytes: number;
 }
 
 export interface ETagCacheOptions {
@@ -28,18 +40,54 @@ export interface ETagCacheOptions {
   maxEntries?: number;
   /** Maximum age of cache entries in milliseconds (default: 1 hour) */
   maxAge?: number;
+  /**
+   * Maximum size for a single cached entry (default: 262144 / 256KB),
+   * measured as the JSON response source's length in UTF-16 code units (see
+   * `maxBytes` below for why that's a proxy, not a precise byte count). A
+   * response measured larger than this is not cached at all — if a
+   * (now-stale) entry already exists for that URL, it is deleted rather than
+   * left behind an uncacheable response.
+   */
+  maxEntryBytes?: number;
+  /**
+   * Maximum total size across all cached entries (default: 8388608 / 8MB),
+   * summing the same code-unit measurement as `maxEntryBytes`. Once
+   * exceeded, the oldest (least-recently-used) entries are evicted until the
+   * total is back at or below this bound.
+   *
+   * This is a deliberately simple sizing proxy, not a hard memory bound —
+   * the measurement itself is only a lower bound, so it's the chosen limit,
+   * not the measurement, that has to do the conservative work. `.length`
+   * counts UTF-16 code units, which is a lower bound on UTF-8 wire bytes for
+   * non-ASCII content (e.g. ~200K CJK characters measure under 256K here but
+   * are closer to 600K bytes on the wire); and the cache retains the
+   * *parsed* object graph, whose heap footprint typically runs several times
+   * its JSON source length. The 8MB default is set with that multiplier in
+   * mind, giving nominal headroom against a Durable Object's roughly 128MB
+   * isolate budget — not a guarantee about retained heap size, since
+   * sufficiently object-dense JSON can still expand well past what a "several
+   * times" multiplier assumes.
+   */
+  maxBytes?: number;
 }
 
 export class ETagCache<T = unknown> {
   private cache = new Map<string, CacheEntry<T>>();
   private log = logger.child("etag-cache");
-  
+
+  /** Running total of `sizeBytes` across all entries; kept in sync on every mutation rather than recomputed. */
+  private totalBytes = 0;
+
   readonly maxEntries: number;
   readonly maxAge: number;
+  readonly maxEntryBytes: number;
+  readonly maxBytes: number;
 
   constructor(options: ETagCacheOptions = {}) {
     this.maxEntries = options.maxEntries ?? 1000;
     this.maxAge = options.maxAge ?? 60 * 60 * 1000; // 1 hour default
+    this.maxEntryBytes = options.maxEntryBytes ?? 262144; // 256KB default
+    this.maxBytes = options.maxBytes ?? 8388608; // 8MB default
   }
 
   /**
@@ -60,11 +108,12 @@ export class ETagCache<T = unknown> {
     const entry = this.cache.get(url);
     if (entry && !this.isExpired(entry)) {
       this.log.debug(`Cache hit: ${url}`);
+      this.touch(url, entry);
       return entry.data;
     }
     if (entry) {
       // Expired, remove it
-      this.cache.delete(url);
+      this.removeEntry(url);
     }
     return undefined;
   }
@@ -76,44 +125,83 @@ export class ETagCache<T = unknown> {
     const entry = this.cache.get(url);
     if (entry && !this.isExpired(entry)) {
       this.log.debug(`Cache hit: ${url}`);
+      this.touch(url, entry);
       return { data: entry.data, meta: entry.meta };
     }
     if (entry) {
       // Expired, remove it
-      this.cache.delete(url);
+      this.removeEntry(url);
     }
     return undefined;
   }
 
   /**
-   * Store response data with its ETag, plus optional endpoint-specific metadata
+   * Store response data with its ETag, plus optional endpoint-specific
+   * metadata and the response body's measured size.
+   *
+   * `sizeBytes` is best-effort and expected to be the JSON source's length
+   * in UTF-16 code units (i.e. `raw.length` from `JSON.parse(raw)`) — see
+   * `ETagCacheOptions.maxBytes` for why that's treated as a deliberately
+   * simple sizing proxy rather than a precise byte count. Pass `undefined`
+   * when the caller couldn't measure the body at all (it's then treated as
+   * 0 toward the byte budget, but still occupies a slot toward
+   * `maxEntries`). When it exceeds `maxEntryBytes`, the response is not
+   * cached at all, and any existing (now-stale) entry for the URL is
+   * removed instead of being left behind an uncacheable response.
    */
-  set(url: string, etag: string, data: T, meta?: unknown): void {
-    // Enforce max entries (LRU-style: remove oldest if at limit)
+  set(url: string, etag: string, data: T, meta?: unknown, sizeBytes?: number): void {
+    if (sizeBytes !== undefined && sizeBytes > this.maxEntryBytes) {
+      if (this.removeEntry(url)) {
+        this.log.debug(`Cache invalidated (stale entry behind uncacheable response): ${url}`);
+      }
+      this.log.debug(`Cache skipped (response too large to cache): ${url}`, {
+        sizeBytes,
+        maxEntryBytes: this.maxEntryBytes,
+      });
+      return;
+    }
+
+    // Enforce max entries (LRU: evict least-recently-used if at limit)
     if (this.cache.size >= this.maxEntries) {
       const oldestKey = this.cache.keys().next().value;
-      if (oldestKey) {
-        this.cache.delete(oldestKey);
+      if (oldestKey !== undefined) {
+        this.removeEntry(oldestKey);
         this.log.debug(`Cache evicted: ${oldestKey}`);
       }
     }
 
+    // Back out the old byte contribution when overwriting an existing key,
+    // so the running total doesn't double-count it. `cache.set` below
+    // preserves the key's existing position in Map iteration order on
+    // overwrite (only a brand-new key is appended at the end) — matching
+    // pre-existing behavior here, unlike the deliberate LRU touch in
+    // get()/getEntry().
+    const existing = this.cache.get(url);
+    if (existing) {
+      this.totalBytes -= existing.sizeBytes;
+    }
+
+    const effectiveSize = sizeBytes ?? 0;
     this.cache.set(url, {
       etag,
       data,
       cachedAt: Date.now(),
       url,
       meta,
+      sizeBytes: effectiveSize,
     });
+    this.totalBytes += effectiveSize;
 
     this.log.debug(`Cache stored: ${url}`, { etag });
+
+    this.evictToByteBudget();
   }
 
   /**
    * Invalidate cache for a URL (e.g., after a mutation)
    */
   invalidate(url: string): boolean {
-    const deleted = this.cache.delete(url);
+    const deleted = this.removeEntry(url);
     if (deleted) {
       this.log.debug(`Cache invalidated: ${url}`);
     }
@@ -128,7 +216,7 @@ export class ETagCache<T = unknown> {
     let count = 0;
     for (const key of this.cache.keys()) {
       if (key.startsWith(urlPrefix)) {
-        this.cache.delete(key);
+        this.removeEntry(key);
         count++;
       }
     }
@@ -144,6 +232,7 @@ export class ETagCache<T = unknown> {
   clear(): void {
     const size = this.cache.size;
     this.cache.clear();
+    this.totalBytes = 0;
     this.log.debug(`Cache cleared: ${size} entries`);
   }
 
@@ -154,6 +243,8 @@ export class ETagCache<T = unknown> {
     size: number;
     maxEntries: number;
     oldestEntry: number | null;
+    bytes: number;
+    maxBytes: number;
   } {
     let oldest = Infinity;
     for (const entry of this.cache.values()) {
@@ -164,6 +255,8 @@ export class ETagCache<T = unknown> {
       size: this.cache.size,
       maxEntries: this.maxEntries,
       oldestEntry: this.cache.size > 0 ? Date.now() - oldest : null,
+      bytes: this.totalBytes,
+      maxBytes: this.maxBytes,
     };
   }
 
@@ -175,13 +268,55 @@ export class ETagCache<T = unknown> {
   }
 
   /**
+   * Move an entry to the back of the Map (most-recently-used position) on a
+   * cache hit, so `set`'s eviction — which always removes from the front —
+   * behaves as true LRU rather than plain FIFO. Deliberately not used by
+   * `getETag()`, which stays pure; every 304 path calls `getEntry()` right
+   * after, so recency is still tracked there.
+   */
+  private touch(url: string, entry: CacheEntry<T>): void {
+    this.cache.delete(url);
+    this.cache.set(url, entry);
+  }
+
+  /**
+   * Delete an entry (if present) and keep `totalBytes` in sync. The single
+   * choke point for removal so byte accounting can't drift out of sync with
+   * the Map across the various call sites that delete entries.
+   */
+  private removeEntry(url: string): boolean {
+    const entry = this.cache.get(url);
+    if (!entry) {
+      return false;
+    }
+    this.cache.delete(url);
+    this.totalBytes -= entry.sizeBytes;
+    return true;
+  }
+
+  /**
+   * Evict entries from the front of the Map (oldest / least-recently-used)
+   * until the running byte total is at or below `maxBytes`.
+   */
+  private evictToByteBudget(): void {
+    while (this.totalBytes > this.maxBytes && this.cache.size > 0) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey === undefined) {
+        break;
+      }
+      this.removeEntry(oldestKey);
+      this.log.debug(`Cache evicted (byte budget): ${oldestKey}`);
+    }
+  }
+
+  /**
    * Clean up expired entries
    */
   cleanup(): number {
     let cleaned = 0;
     for (const [url, entry] of this.cache) {
       if (this.isExpired(entry)) {
-        this.cache.delete(url);
+        this.removeEntry(url);
         cleaned++;
       }
     }
@@ -191,4 +326,3 @@ export class ETagCache<T = unknown> {
     return cleaned;
   }
 }
-

--- a/tests/client/fizzy-client.test.ts
+++ b/tests/client/fizzy-client.test.ts
@@ -1422,6 +1422,25 @@ describe("FizzyClient", () => {
       await expect(client.getBoards("123")).rejects.toThrow(FizzyParseError);
     });
 
+    it("should extract id from Location header on 201 Created with empty body (text() capability path)", async () => {
+      // Regression check for the switch to text()+JSON.parse: an empty body
+      // must still fall through to the 201-Location fallback exactly as it
+      // did when parsing went through response.json().
+      const headers = new Headers();
+      headers.set("Location", "/123/boards/board99.json");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        headers,
+        text: async () => "",
+      });
+
+      const result = await client.createBoard("123", { name: "New Board" });
+
+      expect(result).toEqual({ id: "board99", url: "/123/boards/board99.json" });
+    });
+
     it("should throw FizzyTimeoutError on timeout", async () => {
       const clientWithShortTimeout = new FizzyClient({
         accessToken: "test-token",
@@ -1684,6 +1703,92 @@ describe("FizzyClient", () => {
       expect(stats?.size).toBe(0);
     });
 
+    it("should invalidate a previously-cached entry when a later response for the same URL has no ETag", async () => {
+      // Regression: cache.set() is only reached when an ETag is present, so
+      // without an explicit invalidation on the no-ETag path, an old cached
+      // entry (and its ETag) would survive a later 200 that stopped sending
+      // one — and every subsequent request would keep sending a now-stale
+      // If-None-Match for a resource that no longer emits ETags at all.
+      const etaggedHeaders = new Headers();
+      etaggedHeaders.set("ETag", '"abc123"');
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: etaggedHeaders,
+        json: async () => [{ id: "board1" }],
+      });
+
+      await client.getBoards("123");
+      expect(client.getCacheStats()?.size).toBe(1);
+
+      // A later response for the same URL carries no ETag.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => [{ id: "board1", name: "changed" }],
+      });
+
+      await client.getBoards("123");
+      expect(client.getCacheStats()?.size).toBe(0);
+
+      // A third request must not carry the old (now-stale) If-None-Match.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => [{ id: "board1", name: "changed again" }],
+      });
+
+      await client.getBoards("123");
+
+      const thirdCall = mockFetch.mock.calls[2];
+      expect(thirdCall[1].headers["If-None-Match"]).toBeUndefined();
+    });
+
+    it("should invalidate a previously-cached entry when a GET for the same URL returns 204 No Content", async () => {
+      // Regression: the 204 branch used to return before reaching the
+      // no-ETag invalidation added above, so a URL that previously had a
+      // cached ETagged representation would keep it (and keep sending its
+      // stale If-None-Match) after a later 204 for the same URL.
+      const etaggedHeaders = new Headers();
+      etaggedHeaders.set("ETag", '"abc123"');
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: etaggedHeaders,
+        json: async () => [{ id: "board1" }],
+      });
+
+      await client.getBoards("123");
+      expect(client.getCacheStats()?.size).toBe(1);
+
+      // A later GET for the same URL returns 204 No Content.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        headers: new Headers(),
+      });
+
+      await client.getBoards("123");
+      expect(client.getCacheStats()?.size).toBe(0);
+
+      // The next request must not carry the old (now-stale) If-None-Match.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => [{ id: "board1" }],
+      });
+
+      await client.getBoards("123");
+
+      const thirdCall = mockFetch.mock.calls[2];
+      expect(thirdCall[1].headers["If-None-Match"]).toBeUndefined();
+    });
+
     it("should not use cache for POST requests", async () => {
       const headers = new Headers();
       headers.set("ETag", '"abc123"');
@@ -1763,6 +1868,86 @@ describe("FizzyClient", () => {
 
       const secondCall = mockFetch.mock.calls[1];
       expect(secondCall[1].headers["If-None-Match"]).toBeUndefined();
+    });
+  });
+
+  describe("Byte-Bounded ETag Caching", () => {
+    // These mocks define `text()` (unlike the `json()`-only mocks used
+    // elsewhere in this file) to exercise the size-measurement path in
+    // `executeRequestWithMeta`. The `json()`-only mocks must keep working
+    // unchanged — that's what the capability check (`typeof response.text
+    // === "function"`) is for.
+    it("should not cache a response whose measured body exceeds cacheMaxEntryBytes", async () => {
+      const boundedClient = new FizzyClient({
+        accessToken: "test-token",
+        baseUrl: "https://app.fizzy.do",
+        maxRetries: 0,
+        cacheMaxEntryBytes: 50,
+      });
+
+      const bigBody = JSON.stringify([{ id: "board1", name: "x".repeat(100) }]);
+      const headers = new Headers();
+      headers.set("ETag", '"big-etag"');
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers,
+        text: async () => bigBody,
+      });
+
+      await boundedClient.getBoards("123");
+
+      // Too large to cache at all.
+      expect(boundedClient.getCacheStats()?.size).toBe(0);
+
+      // A second request must not carry If-None-Match, since nothing was cached.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers,
+        text: async () => bigBody,
+      });
+
+      await boundedClient.getBoards("123");
+
+      const secondCall = mockFetch.mock.calls[1];
+      expect(secondCall[1].headers["If-None-Match"]).toBeUndefined();
+    });
+
+    it("should cache a response whose measured body is within cacheMaxEntryBytes and send If-None-Match on the next request", async () => {
+      const boundedClient = new FizzyClient({
+        accessToken: "test-token",
+        baseUrl: "https://app.fizzy.do",
+        maxRetries: 0,
+        cacheMaxEntryBytes: 50,
+      });
+
+      const smallBody = JSON.stringify([{ id: "board1" }]);
+      const headers = new Headers();
+      headers.set("ETag", '"small-etag"');
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers,
+        text: async () => smallBody,
+      });
+
+      const result1 = await boundedClient.getBoards("123");
+      expect(result1).toEqual([{ id: "board1" }]);
+      expect(boundedClient.getCacheStats()?.size).toBe(1);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 304,
+        headers,
+      });
+
+      await boundedClient.getBoards("123");
+
+      const secondCall = mockFetch.mock.calls[1];
+      expect(secondCall[1].headers["If-None-Match"]).toBe('"small-etag"');
     });
   });
 });

--- a/tests/cloudflare/worker-errors.test.ts
+++ b/tests/cloudflare/worker-errors.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Worker Error Envelope Tests
+ *
+ * `buildWorkerErrorEnvelope` builds the response body for the top-level
+ * Worker `fetch` handler's error boundary — see `src/cloudflare/index.ts`.
+ * It's kept in its own file, importing nothing from `cloudflare:workers`, so
+ * it can be exercised here under plain Node vitest.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildWorkerErrorEnvelope, getErrorMessage } from "../../src/cloudflare/utils/worker-errors.js";
+
+describe("buildWorkerErrorEnvelope", () => {
+  it("returns a JSON-RPC -32603 envelope with id: null for /mcp", () => {
+    const { status, body } = buildWorkerErrorEnvelope("/mcp", new Error("Durable Object exceeded memory budget"));
+
+    expect(status).toBe(500);
+    expect(body).toEqual({
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32603,
+        message: "Durable Object exceeded memory budget",
+      },
+    });
+  });
+
+  it("returns the plain { error } shape for a non-/mcp path", () => {
+    const { status, body } = buildWorkerErrorEnvelope("/health", new Error("boom"));
+
+    expect(status).toBe(500);
+    expect(body).toEqual({ error: "boom" });
+  });
+
+  it("returns the plain { error } shape for an empty/unparsed path", () => {
+    const { status, body } = buildWorkerErrorEnvelope("", new Error("URL parse failed"));
+
+    expect(status).toBe(500);
+    expect(body).toEqual({ error: "URL parse failed" });
+  });
+
+  it("stringifies a non-Error thrown value without throwing", () => {
+    expect(() => buildWorkerErrorEnvelope("/mcp", "just a string")).not.toThrow();
+    const { body } = buildWorkerErrorEnvelope("/mcp", "just a string");
+    expect(body).toEqual({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32603, message: "just a string" },
+    });
+  });
+
+  it("stringifies a thrown value with a poisoned toString() without throwing", () => {
+    const poisoned = {
+      toString() {
+        throw new Error("cannot stringify");
+      },
+    };
+
+    expect(() => buildWorkerErrorEnvelope("/mcp", poisoned)).not.toThrow();
+    const { body } = buildWorkerErrorEnvelope("/mcp", poisoned);
+    expect((body as { error: { message: string } }).error.message).toBe("Unknown error");
+  });
+
+  it("handles a real Error instance with a poisoned message getter without throwing", () => {
+    // Regression case: the `instanceof Error` branch reads `error.message`,
+    // which is not covered by a `String()` try/catch alone — this must be
+    // guarded independently of the non-Error poisoned-toString() case above.
+    const poisonedError = new Error("original message");
+    Object.defineProperty(poisonedError, "message", {
+      get() {
+        throw new Error("poisoned message getter");
+      },
+    });
+
+    expect(() => buildWorkerErrorEnvelope("/mcp", poisonedError)).not.toThrow();
+    const { body } = buildWorkerErrorEnvelope("/mcp", poisonedError);
+    expect((body as { error: { message: string } }).error.message).toBe("Unknown error");
+  });
+
+  it("stringifies a plain object thrown value", () => {
+    const { body } = buildWorkerErrorEnvelope("/other", { reason: "config missing" });
+    expect(body).toEqual({ error: "[object Object]" });
+  });
+
+  it("coerces a non-string Error.message (BigInt) so the body survives JSON.stringify", () => {
+    // JS doesn't enforce that Error.message is a string. A hostile instance
+    // handing back a BigInt would make `JSON.stringify(body)` throw at the
+    // call site (index.ts's catch block) if it weren't coerced here first.
+    const weirdError = new Error("will be overridden");
+    Object.defineProperty(weirdError, "message", {
+      get() {
+        return 123n;
+      },
+    });
+
+    expect(() => buildWorkerErrorEnvelope("/mcp", weirdError)).not.toThrow();
+    const { body } = buildWorkerErrorEnvelope("/mcp", weirdError);
+    const message = (body as { error: { message: string } }).error.message;
+    expect(typeof message).toBe("string");
+    expect(message).toBe("123");
+    expect(() => JSON.stringify(body)).not.toThrow();
+  });
+
+  it("coerces a non-string Error.message (cyclic object) so the body survives JSON.stringify", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+
+    const weirdError = new Error("will be overridden");
+    Object.defineProperty(weirdError, "message", {
+      get() {
+        return cyclic;
+      },
+    });
+
+    expect(() => buildWorkerErrorEnvelope("/mcp", weirdError)).not.toThrow();
+    const { body } = buildWorkerErrorEnvelope("/mcp", weirdError);
+    const message = (body as { error: { message: string } }).error.message;
+    expect(typeof message).toBe("string");
+    expect(() => JSON.stringify(body)).not.toThrow();
+  });
+});
+
+describe("getErrorMessage", () => {
+  it("returns the message of an Error instance", () => {
+    expect(getErrorMessage(new TypeError("nope"))).toBe("nope");
+  });
+
+  it("never throws, even for values that can't be stringified", () => {
+    const poisoned = {
+      toString() {
+        throw new Error("cannot stringify");
+      },
+    };
+    expect(() => getErrorMessage(poisoned)).not.toThrow();
+    expect(getErrorMessage(poisoned)).toBe("Unknown error");
+  });
+
+  it("never throws for a real Error with a poisoned message getter", () => {
+    const poisonedError = new Error("original message");
+    Object.defineProperty(poisonedError, "message", {
+      get() {
+        throw new Error("poisoned message getter");
+      },
+    });
+
+    expect(() => getErrorMessage(poisonedError)).not.toThrow();
+    expect(getErrorMessage(poisonedError)).toBe("Unknown error");
+  });
+
+  it("always returns a real string, even when Error.message is a non-string value", () => {
+    const bigintError = new Error("will be overridden");
+    Object.defineProperty(bigintError, "message", { get: () => 123n });
+    expect(typeof getErrorMessage(bigintError)).toBe("string");
+    expect(getErrorMessage(bigintError)).toBe("123");
+
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const cyclicError = new Error("will be overridden");
+    Object.defineProperty(cyclicError, "message", { get: () => cyclic });
+    expect(typeof getErrorMessage(cyclicError)).toBe("string");
+  });
+});

--- a/tests/utils/etag-cache.test.ts
+++ b/tests/utils/etag-cache.test.ts
@@ -160,6 +160,213 @@ describe("ETagCache", () => {
       expect(cache.getETag("/api/resource")).toBe(specialETag);
     });
   });
+
+  describe("Byte-Bounded Cache", () => {
+    it("should not cache entries over maxEntryBytes", () => {
+      const smallByteCache = new ETagCache<{ data: string }>({
+        maxEntryBytes: 100,
+        maxAge: 60000,
+      });
+
+      smallByteCache.set("/api/big", '"etag1"', { data: "big" }, undefined, 200);
+
+      expect(smallByteCache.get("/api/big")).toBeUndefined();
+      expect(smallByteCache.getStats().size).toBe(0);
+      expect(smallByteCache.getStats().bytes).toBe(0);
+    });
+
+    it("should delete an existing entry when replaced by an oversized response", () => {
+      const smallByteCache = new ETagCache<{ data: string }>({
+        maxEntryBytes: 100,
+        maxAge: 60000,
+      });
+
+      smallByteCache.set("/api/resource", '"etag1"', { data: "small" }, undefined, 10);
+      expect(smallByteCache.get("/api/resource")).toEqual({ data: "small" });
+
+      // A later, oversized response for the same URL must not leave the old
+      // (now stale) entry lingering behind it.
+      smallByteCache.set("/api/resource", '"etag2"', { data: "big" }, undefined, 500);
+
+      expect(smallByteCache.get("/api/resource")).toBeUndefined();
+      expect(smallByteCache.getStats().size).toBe(0);
+    });
+
+    it("should evict oldest entries once total bytes exceeds maxBytes", () => {
+      const boundedCache = new ETagCache<{ data: string }>({
+        maxBytes: 250,
+        maxEntries: 100,
+        maxAge: 60000,
+      });
+
+      boundedCache.set("/api/1", '"etag1"', { data: "1" }, undefined, 100);
+      boundedCache.set("/api/2", '"etag2"', { data: "2" }, undefined, 100);
+      // Total would be 300 > 250 once this is inserted, so the oldest
+      // entry (/api/1) must be evicted to bring it back under budget.
+      boundedCache.set("/api/3", '"etag3"', { data: "3" }, undefined, 100);
+
+      expect(boundedCache.get("/api/1")).toBeUndefined();
+      expect(boundedCache.get("/api/2")).toEqual({ data: "2" });
+      expect(boundedCache.get("/api/3")).toEqual({ data: "3" });
+      expect(boundedCache.getStats().bytes).toBe(200);
+    });
+
+    it("should keep byte accounting correct across overwrite, invalidate, invalidatePrefix, and clear", () => {
+      const boundedCache = new ETagCache<{ data: string }>({
+        maxBytes: 10_000,
+        maxAge: 60000,
+      });
+
+      boundedCache.set("/api/boards/1", '"etag1"', { data: "a" }, undefined, 100);
+      boundedCache.set("/api/boards/2", '"etag2"', { data: "b" }, undefined, 200);
+      boundedCache.set("/api/cards/1", '"etag3"', { data: "c" }, undefined, 300);
+
+      expect(boundedCache.getStats().bytes).toBe(600);
+
+      // Overwrite: the old contribution (100) must be backed out before the
+      // new one (150) is added, not simply added on top.
+      boundedCache.set("/api/boards/1", '"etag4"', { data: "a2" }, undefined, 150);
+      expect(boundedCache.getStats().bytes).toBe(650); // 150 + 200 + 300
+
+      boundedCache.invalidate("/api/boards/1");
+      expect(boundedCache.getStats().bytes).toBe(500); // 200 + 300
+
+      boundedCache.invalidatePrefix("/api/cards");
+      expect(boundedCache.getStats().bytes).toBe(200); // just /api/boards/2
+
+      boundedCache.clear();
+      expect(boundedCache.getStats().bytes).toBe(0);
+    });
+
+    it("should keep byte accounting correct when an entry expires via get()/getEntry()", () => {
+      const boundedCache = new ETagCache<{ data: string }>({
+        maxBytes: 10_000,
+        maxAge: 60000,
+      });
+
+      boundedCache.set("/api/1", '"etag1"', { data: "a" }, undefined, 100);
+      boundedCache.set("/api/2", '"etag2"', { data: "b" }, undefined, 200);
+      expect(boundedCache.getStats().bytes).toBe(300);
+
+      vi.advanceTimersByTime(61000);
+
+      // get() on an expired entry deletes it and backs its bytes out.
+      expect(boundedCache.get("/api/1")).toBeUndefined();
+      expect(boundedCache.getStats().bytes).toBe(200);
+
+      // getEntry() on an expired entry does the same.
+      expect(boundedCache.getEntry("/api/2")).toBeUndefined();
+      expect(boundedCache.getStats().bytes).toBe(0);
+    });
+
+    it("should keep byte accounting correct across cleanup()", () => {
+      const boundedCache = new ETagCache<{ data: string }>({
+        maxBytes: 10_000,
+        maxAge: 60000,
+      });
+
+      boundedCache.set("/api/1", '"etag1"', { data: "a" }, undefined, 100);
+      vi.advanceTimersByTime(61000);
+      boundedCache.set("/api/2", '"etag2"', { data: "b" }, undefined, 200);
+
+      expect(boundedCache.getStats().bytes).toBe(300);
+
+      const cleaned = boundedCache.cleanup();
+
+      expect(cleaned).toBe(1);
+      expect(boundedCache.getStats().bytes).toBe(200);
+    });
+
+    it("should treat unmeasured entries (sizeBytes undefined) as zero bytes", () => {
+      const boundedCache = new ETagCache<{ data: string }>({ maxBytes: 100, maxAge: 60000 });
+
+      boundedCache.set("/api/1", '"etag1"', { data: "a" }); // no sizeBytes passed
+
+      expect(boundedCache.getStats().bytes).toBe(0);
+      expect(boundedCache.get("/api/1")).toEqual({ data: "a" });
+    });
+
+    it("should report bytes and maxBytes in getStats()", () => {
+      const boundedCache = new ETagCache<{ data: string }>({ maxBytes: 12345, maxAge: 60000 });
+
+      boundedCache.set("/api/1", '"etag1"', { data: "a" }, undefined, 42);
+
+      const stats = boundedCache.getStats();
+      expect(stats.bytes).toBe(42);
+      expect(stats.maxBytes).toBe(12345);
+    });
+
+    it("should account sizeBytes as UTF-16 code units, not UTF-8 wire bytes", () => {
+      // Pins the documented semantics: callers pass `raw.length` (UTF-16 code
+      // units of the JSON source), which the cache treats as-is — it does not
+      // attempt to measure actual UTF-8 wire size. Each of these CJK
+      // characters is 1 UTF-16 code unit but 3 UTF-8 bytes, so the two
+      // measurements diverge sharply for non-ASCII content.
+      const nonAsciiPayload = "漢".repeat(50);
+      expect(nonAsciiPayload.length).toBe(50);
+      expect(Buffer.byteLength(nonAsciiPayload, "utf8")).toBe(150);
+
+      const boundedCache = new ETagCache<{ data: string }>({ maxBytes: 10_000, maxAge: 60000 });
+      boundedCache.set("/api/cjk", '"etag1"', { data: nonAsciiPayload }, undefined, nonAsciiPayload.length);
+
+      // Accounted by the code-unit count (50), not the UTF-8 byte length (150).
+      expect(boundedCache.getStats().bytes).toBe(50);
+    });
+  });
+
+  describe("LRU Recency", () => {
+    it("should protect a recently get()-hit entry from eviction", () => {
+      const smallCache = new ETagCache<{ data: string }>({ maxEntries: 3, maxAge: 60000 });
+
+      smallCache.set("/api/1", '"etag1"', { data: "first" });
+      smallCache.set("/api/2", '"etag2"', { data: "second" });
+      smallCache.set("/api/3", '"etag3"', { data: "third" });
+
+      // Touch /api/1 so it becomes the most-recently-used entry.
+      smallCache.get("/api/1");
+
+      // Adding a 4th entry should now evict /api/2 (the true
+      // least-recently-used entry), not /api/1.
+      smallCache.set("/api/4", '"etag4"', { data: "fourth" });
+
+      expect(smallCache.get("/api/1")).toEqual({ data: "first" });
+      expect(smallCache.get("/api/2")).toBeUndefined();
+      expect(smallCache.get("/api/3")).toEqual({ data: "third" });
+      expect(smallCache.get("/api/4")).toEqual({ data: "fourth" });
+    });
+
+    it("should protect a recently getEntry()-hit entry from eviction", () => {
+      const smallCache = new ETagCache<{ data: string }>({ maxEntries: 3, maxAge: 60000 });
+
+      smallCache.set("/api/1", '"etag1"', { data: "first" }, { note: "meta1" });
+      smallCache.set("/api/2", '"etag2"', { data: "second" });
+      smallCache.set("/api/3", '"etag3"', { data: "third" });
+
+      smallCache.getEntry("/api/1");
+
+      smallCache.set("/api/4", '"etag4"', { data: "fourth" });
+
+      expect(smallCache.getEntry("/api/1")).toEqual({ data: { data: "first" }, meta: { note: "meta1" } });
+      expect(smallCache.get("/api/2")).toBeUndefined();
+      expect(smallCache.get("/api/3")).toEqual({ data: "third" });
+    });
+
+    it("should leave getETag() pure (no reordering) since every 304 path calls getEntry() right after", () => {
+      const smallCache = new ETagCache<{ data: string }>({ maxEntries: 3, maxAge: 60000 });
+
+      smallCache.set("/api/1", '"etag1"', { data: "first" });
+      smallCache.set("/api/2", '"etag2"', { data: "second" });
+      smallCache.set("/api/3", '"etag3"', { data: "third" });
+
+      // getETag() alone must not protect /api/1 from eviction.
+      smallCache.getETag("/api/1");
+
+      smallCache.set("/api/4", '"etag4"', { data: "fourth" });
+
+      expect(smallCache.get("/api/1")).toBeUndefined();
+      expect(smallCache.get("/api/2")).toEqual({ data: "second" });
+    });
+  });
 });
 
 describe("ETagCache with FizzyClient Integration", () => {


### PR DESCRIPTION
## Summary

Fixes the intermittent Cloudflare **error 1101** ("Worker threw exception") reported on `fizzy_get_cards` against the deployed Worker.

The Durable Object already caught tool-handler exceptions and returned JSON-RPC `-32603` (`src/cloudflare/mcp-session.ts`), so a thrown handler error was never the cause. Two gaps were:

**1. The top-level Worker `fetch` handler had no try/catch.** When Cloudflare kills a Durable Object for exceeding its memory budget, `doStub.fetch()` rejects in the *calling* Worker — that rejection escaped `fetch`, and the platform rendered a 1101 whose body claims `"retryable": false`. That hint is misleading for this failure mode, which is transient: a client that obeys it gives up on a request that would succeed on a fresh isolate. The handler is now wrapped and returns a JSON-RPC `-32603` envelope for `/mcp` (the module's plain `{ error }` shape elsewhere), so the failure is diagnosable and honestly retryable.

The envelope is built in a new `src/cloudflare/utils/worker-errors.ts` that imports nothing Workers-specific — `index.ts` transitively imports `cloudflare:workers` via the `McpSessionDO` re-export and so can't be imported from a Node vitest test.

**2. The ETag cache was bounded by entry count only** — 1000 entries, no size accounting. A single `get_cards` page-2 response measured ~2.4M characters, so a handful of cached pages can exhaust one isolate. It is now bounded by size too: responses over 256KB aren't cached at all (they're the least cacheable and most memory-expensive entries), under an 8MB total budget.

The trade-off is deliberate: multi-MB card pages no longer get `If-None-Match`, so they re-download rather than 304. The measurement is a deliberately simple proxy and is documented as such — it counts UTF-16 code units of the JSON source, which undercounts non-ASCII wire bytes and does not measure the retained parsed-object graph. The limit, not the measurement, is what does the conservative work.

### Also in scope

- **Eviction was FIFO despite claiming to be LRU** — reads never reordered the Map. `get()`/`getEntry()` now move entries to the back, so the new size budget evicts what is actually cold. `getETag()` stays pure; every 304 path calls `getEntry()` immediately after, so recency is still tracked.
- **Cache coherency**: a successful GET that returns no ETag (including a `204`) now invalidates the URL, instead of leaving a stale representation behind that keeps sending its old `If-None-Match`.
- `FizzyClient` gains `cacheMaxBytes` / `cacheMaxEntryBytes` pass-throughs.

### Known residual limitation

`handleMcp` streams `doResponse.body` rather than buffering it, so a DO failure that surfaces *while that body is being consumed* is still outside the boundary. Buffering with `arrayBuffer()` would make it catchable but would hold entire large responses in the calling Worker's memory — reintroducing the exact pressure this PR relieves. Kept streaming deliberately; documented in place.

## Test plan

- `npm run typecheck`, `npm run typecheck:cf`, `npm run build` — clean.
- `npm run test:cloudflare` — 118/118 pass.
- `npm test` — 579/584 pass. The 5 failures are a pre-existing `EADDRINUSE` flake on ports 3001/3100 in `tests/transports/security-warnings.test.ts` and `sse-multi-user.test.ts`, confirmed identical against a clean stashed baseline before these changes.

New coverage: size-cap rejection and stale-entry cleanup, byte accounting across overwrite/invalidate/invalidatePrefix/clear/cleanup/expiry, LRU recency, `getETag()` purity, UTF-16 sizing semantics, the oversized-body and no-ETag/204 cache-invalidation paths, the 201-Location empty-body fallback through the new parse path, and the error envelope against hostile thrown values (poisoned `toString()`, poisoned `message` getter, and a `message` getter returning a `BigInt` or cyclic object).

No local smoke steps — the failure mode only reproduces under real Durable Object memory pressure, and the behaviour that replaces it is covered above.

## Declarations

- [ ] This PR adds or changes dependencies (`package.json` / `package-lock.json`)
- [ ] This PR changes build or deploy configuration (`tsconfig*.json`, `wrangler.jsonc`, `.github/`)
- [ ] This PR adds npm lifecycle scripts (preinstall/postinstall/prepare)

Fixes #29
