### PR TITLE
feat(tools): add fields=summary projection to cut list-tool payload size

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ npx fizzy-mcp --transport http --port 3000
 ### Cards (6)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_cards` | List cards with optional filters (board, indexed_by, column, assignees, tags, search) |
+| `fizzy_get_cards` | List cards with optional filters (board, indexed_by, column, assignees, tags, search); `fields="summary"` returns a much smaller payload for browsing |
 | `fizzy_get_card` | Get card details including description, assignees, tags |
 | `fizzy_create_card` | Create a new card with title, description, status, column, assignees, tags, due date |
 | `fizzy_update_card` | Update any card property |
@@ -548,7 +548,7 @@ npx fizzy-mcp --transport http --port 3000
 ### Comments (5)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_card_comments` | List comments on a card |
+| `fizzy_get_card_comments` | List comments on a card; `fields="summary"` drops the duplicated HTML body and repeated card/creator detail |
 | `fizzy_get_comment` | Get a specific comment |
 | `fizzy_create_comment` | Add a comment to a card (supports HTML) |
 | `fizzy_update_comment` | Update a comment |
@@ -594,7 +594,7 @@ npx fizzy-mcp --transport http --port 3000
 ### Notifications (4)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_notifications` | List notifications for current user |
+| `fizzy_get_notifications` | List notifications for current user; `fields="summary"` shrinks the embedded card and creator objects |
 | `fizzy_mark_notification_read` | Mark notification as read |
 | `fizzy_mark_notification_unread` | Mark notification as unread |
 | `fizzy_mark_all_notifications_read` | Mark all notifications as read |

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -137,7 +137,10 @@ export const TOOL_DEFINITIONS = {
         "of cards matching the filters (NOT the length of this page). " +
         "To enumerate every match, call repeatedly with page = next_page until has_more is false OR cards comes back " +
         "empty — an out-of-range page returns empty cards but may still report has_more true. " +
-        "A board's cards_count from fizzy_get_boards can exceed a single page of results; that is expected, not a discrepancy.",
+        "A board's cards_count from fizzy_get_boards can exceed a single page of results; that is expected, not a discrepancy. " +
+        "Use fields='summary' when browsing, searching, or scanning many cards — it drops full descriptions/HTML and " +
+        "returns a much smaller payload (often 100x+ smaller). Once you've identified the specific card you need, " +
+        "call fizzy_get_card for its full detail.",
       schema: schemas.getCardsSchema,
       annotations: {
         readOnlyHint: true,
@@ -340,7 +343,9 @@ export const TOOL_DEFINITIONS = {
       title: "List Card Comments",
       description:
         "Get all comments on a card in chronological order. Returns comment text (HTML), authors, timestamps, " +
-        "and reaction counts. Use this to review discussion and feedback on a card.",
+        "and reaction counts. Use this to review discussion and feedback on a card. " +
+        "Use fields='summary' to drop the duplicated HTML body and the repeated per-comment card/creator " +
+        "detail — comment text itself is never truncated in either mode.",
       schema: schemas.getCardCommentsSchema,
       annotations: {
         readOnlyHint: true,
@@ -628,7 +633,9 @@ export const TOOL_DEFINITIONS = {
       title: "List Notifications",
       description:
         "Get all notifications for the current user in an account. Returns notification content, " +
-        "read/unread status, timestamps, and related cards or comments.",
+        "read/unread status, timestamps, and related cards or comments. " +
+        "Use fields='summary' to shrink the embedded card and creator objects down to their key " +
+        "identifying fields — typically several times smaller than the full payload.",
       schema: schemas.getNotificationsSchema,
       annotations: {
         readOnlyHint: true,

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -12,6 +12,12 @@ import type { FizzyClient } from "../client/fizzy-client.js";
 import { COLUMN_COLORS, type ColumnColor, type CardListOptions } from "../client/types.js";
 import { resolveCardNumber } from "../utils/card-resolver.js";
 import { attachmentHtml, resolveAttachment } from "../utils/attachments.js";
+import {
+  parseFieldsMode,
+  summarizeCard,
+  summarizeComment,
+  summarizeNotification,
+} from "../utils/projections.js";
 
 /**
  * Tool handler result - either data to serialize or a success message
@@ -111,6 +117,7 @@ export const toolHandlers: Record<string, ToolHandler> = {
         `Card listings always contain published cards; use indexed_by="closed" for closed cards.`
       );
     }
+    const fieldsMode = parseFieldsMode(args.fields);
     const options: CardListOptions = {
       board_ids: args.board_id ? [args.board_id as string] : undefined,
       column_ids: args.column_id ? [args.column_id as string] : undefined,
@@ -120,7 +127,17 @@ export const toolHandlers: Record<string, ToolHandler> = {
       tag_ids: args.tag_ids as string[] | undefined,
       page: parseCardsPage(args.page),
     };
-    return client.getCards(args.account_slug as string, options);
+    const result = await client.getCards(args.account_slug as string, options);
+    if (fieldsMode === "full") return result;
+    return {
+      cards: result.cards.map((card) =>
+        summarizeCard(card as unknown as Record<string, unknown>)
+      ),
+      page: result.page,
+      total_count: result.total_count,
+      has_more: result.has_more,
+      next_page: result.next_page,
+    };
   },
 
   fizzy_get_card: async (client, args) => {
@@ -233,7 +250,12 @@ export const toolHandlers: Record<string, ToolHandler> = {
       args.card_id as string | undefined,
       args.card_number as string | undefined
     );
-    return client.getCardComments(args.account_slug as string, cardNumber);
+    const fieldsMode = parseFieldsMode(args.fields);
+    const comments = await client.getCardComments(args.account_slug as string, cardNumber);
+    if (fieldsMode === "full") return comments;
+    return comments.map((comment) =>
+      summarizeComment(comment as unknown as Record<string, unknown>)
+    );
   },
 
   fizzy_get_comment: async (client, args) => {
@@ -410,7 +432,12 @@ export const toolHandlers: Record<string, ToolHandler> = {
 
   // ============ Notification Tools ============
   fizzy_get_notifications: async (client, args) => {
-    return client.getNotifications(args.account_slug as string);
+    const fieldsMode = parseFieldsMode(args.fields);
+    const notifications = await client.getNotifications(args.account_slug as string);
+    if (fieldsMode === "full") return notifications;
+    return notifications.map((notification) =>
+      summarizeNotification(notification as unknown as Record<string, unknown>)
+    );
   },
 
   fizzy_mark_notification_read: async (client, args) => {

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -244,13 +244,16 @@ export const toolHandlers: Record<string, ToolHandler> = {
 
   // ============ Comment Tools ============
   fizzy_get_card_comments: async (client, args) => {
+    // Validated before resolveCardNumber, which makes its own API round-trip: on the
+    // unvalidated Cloudflare path a bad `fields` value would otherwise spend a request
+    // first, and a failure there would mask the real invalid-argument error.
+    const fieldsMode = parseFieldsMode(args.fields);
     const cardNumber = await resolveCardNumber(
       client,
       args.account_slug as string,
       args.card_id as string | undefined,
       args.card_number as string | undefined
     );
-    const fieldsMode = parseFieldsMode(args.fields);
     const comments = await client.getCardComments(args.account_slug as string, cardNumber);
     if (fieldsMode === "full") return comments;
     return comments.map((comment) =>

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -62,6 +62,24 @@ export const stepIdSchema = z.string().describe(
   "Step IDs are returned when creating steps or fetching card details."
 );
 
+// Shared `fields` projection schema for the list tools whose full payloads are
+// dominated by fields most callers don't need (long descriptions, duplicated
+// HTML bodies, repeated embedded objects). Referenced by getCardsSchema,
+// getCardCommentsSchema, and getNotificationsSchema.
+export const fieldsSchema = z
+  .enum(["summary", "full"])
+  .optional()
+  .describe(
+    "Response projection. 'full' (the default — used when this parameter is omitted) " +
+    "returns every field exactly as the API provides it, unchanged from prior behavior. " +
+    "'summary' strips large, rarely-needed fields — full HTML/rich-text bodies and " +
+    "descriptions, duplicated plain-text/HTML pairs, and repeated embedded objects like " +
+    "the full creator or card — keeping only IDs, names, and short previews. Summary " +
+    "responses are typically 4x to over 100x smaller depending on the tool. Prefer " +
+    "'summary' when scanning, searching, or listing many results; switch to 'full' (or a " +
+    "single-item fetch tool) once you need complete detail on a specific item."
+  );
+
 // Status schemas with detailed descriptions
 export const cardStatusSchema = z
   .enum(["draft", "published", "archived"])
@@ -164,6 +182,7 @@ export const getCardsSchema = z.object({
     "(early pages are small, e.g. 15 cards; later pages are larger). Omit for the first page; " +
     "pass the next_page value from the previous response to fetch subsequent pages."
   ),
+  fields: fieldsSchema,
 });
 
 
@@ -275,7 +294,9 @@ const commentCardSelectorBase = z.object({
     ),
 });
 
-export const getCardCommentsSchema = commentCardSelectorBase;
+export const getCardCommentsSchema = commentCardSelectorBase.extend({
+  fields: fieldsSchema,
+});
 
 export const createCommentSchema = commentCardSelectorBase.extend({
   body: z.string().describe(
@@ -358,6 +379,7 @@ export const deactivateUserSchema = z.object({
 // Notification schemas
 export const getNotificationsSchema = z.object({
   account_slug: accountSlugSchema,
+  fields: fieldsSchema,
 });
 
 export const markNotificationReadSchema = z.object({

--- a/src/utils/projections.ts
+++ b/src/utils/projections.ts
@@ -81,7 +81,28 @@ const CARD_SCALAR_KEYS = [
   "postponed",
   "golden",
   "has_attachments",
+  // Kept even though the summary also carries `assignees`: the API truncates that
+  // list and sets this flag, so dropping it would make a partial list read as the
+  // complete set of assignees — exactly the kind of wrong conclusion a triaging
+  // caller would draw from a summary.
+  "has_more_assignees",
 ] as const;
+
+/** Longest `description_preview` emitted by `summarizeCard`, in UTF-16 code units. */
+const DESCRIPTION_PREVIEW_LIMIT = 200;
+
+/**
+ * Truncate to `limit` code units, appending `…`, without splitting a surrogate
+ * pair. Cutting between the two halves of an astral character (an emoji) would
+ * emit a lone surrogate — still valid JSON once escaped, but a malformed
+ * character for whoever renders the preview.
+ */
+function truncatePreview(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  const lastUnit = text.charCodeAt(limit - 1);
+  const isHighSurrogate = lastUnit >= 0xd800 && lastUnit <= 0xdbff;
+  return `${text.slice(0, isHighSurrogate ? limit - 1 : limit)}…`;
+}
 
 /**
  * Project a card down to the fields a browsing/searching caller needs.
@@ -111,8 +132,7 @@ export function summarizeCard(card: Obj): Obj {
 
   const description = card.description;
   if (typeof description === "string" && description.length > 0) {
-    out.description_preview =
-      description.length > 200 ? `${description.slice(0, 200)}…` : description;
+    out.description_preview = truncatePreview(description, DESCRIPTION_PREVIEW_LIMIT);
   }
 
   return out;

--- a/src/utils/projections.ts
+++ b/src/utils/projections.ts
@@ -1,0 +1,180 @@
+/**
+ * Response projections for `fields: "summary"` on the three list tools whose
+ * `"full"` payloads are dominated by fields most callers never look at:
+ * fizzy_get_cards (description/description_html), fizzy_get_card_comments
+ * (body.html duplicating body.plain_text, plus a repeated creator/card per
+ * row), and fizzy_get_notifications (a full embedded card + creator object
+ * per row). See tools/handlers.ts for how these are wired into the tools.
+ *
+ * `"full"` (the default) is an untouched passthrough — byte-for-byte
+ * identical to pre-`fields` behavior. `"summary"` is strictly opt-in.
+ *
+ * The live API returns many fields the `Fizzy*` interfaces in
+ * client/types.ts do not model — confirmed present on real responses:
+ * `description_html`, `board`, `golden`, `closed`, `postponed`,
+ * `last_active_at`, `has_attachments`, `has_more_assignees`, `image_url`,
+ * `comments_url`, `reactions_url`, `unread_count`, `source_type`,
+ * `board_name`, and `column.color` as an object `{name, value}` rather than
+ * the `string` the type claims. So these summarizers operate structurally on
+ * `Record<string, unknown>` and pick keys defensively, never relying on the
+ * declared interfaces being complete or correct.
+ */
+
+export type FieldsMode = "summary" | "full";
+
+/**
+ * Parse the optional `fields` argument shared by fizzy_get_cards,
+ * fizzy_get_card_comments, and fizzy_get_notifications.
+ *
+ * This has to exist (not just live in the zod schema) because the Cloudflare
+ * transport executes raw args with no zod validation — mirrors the reasoning
+ * behind `parseCardsPage` in tools/handlers.ts, and for the same reason: a
+ * bad value must fail loudly here rather than silently falling through to
+ * `"full"` on one transport and a zod error on the other.
+ */
+export function parseFieldsMode(value: unknown): FieldsMode {
+  if (value === undefined) return "full";
+  if (value === "summary" || value === "full") return value;
+  throw new Error(`fields must be "summary" or "full", got: ${JSON.stringify(value)}`);
+}
+
+type Obj = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is Obj {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Copy `keys` from `source`, omitting any that are absent or explicitly `undefined`. */
+function pick(source: Obj, keys: readonly string[]): Obj {
+  const out: Obj = {};
+  for (const key of keys) {
+    if (source[key] !== undefined) {
+      out[key] = source[key];
+    }
+  }
+  return out;
+}
+
+/** Reduce a nested object-valued field to `{id, name}`; `undefined` when the source isn't an object. */
+function toIdName(value: unknown): Obj | undefined {
+  if (!isPlainObject(value)) return undefined;
+  return pick(value, ["id", "name"]);
+}
+
+/** Reduce a nested object-valued field to `{id, title}`; `undefined` when the source isn't an object. */
+function toIdTitle(value: unknown): Obj | undefined {
+  if (!isPlainObject(value)) return undefined;
+  return pick(value, ["id", "title"]);
+}
+
+const CARD_SCALAR_KEYS = [
+  "id",
+  "number",
+  "title",
+  "status",
+  "url",
+  "due_on",
+  "created_at",
+  "updated_at",
+  "last_active_at",
+  "closed",
+  "postponed",
+  "golden",
+  "has_attachments",
+] as const;
+
+/**
+ * Project a card down to the fields a browsing/searching caller needs.
+ * Drops `description`, `description_html`, `comments_url`, `reactions_url`,
+ * and `image_url`; adds `description_preview` (first 200 chars of the
+ * plain-text `description`, `…`-truncated, omitted when there is none).
+ */
+export function summarizeCard(card: Obj): Obj {
+  const out = pick(card, CARD_SCALAR_KEYS);
+
+  const board = toIdName(card.board);
+  if (board) out.board = board;
+
+  const column = toIdName(card.column);
+  if (column) out.column = column;
+
+  const creator = toIdName(card.creator);
+  if (creator) out.creator = creator;
+
+  if (Array.isArray(card.assignees)) {
+    out.assignees = card.assignees.map(toIdName).filter((a): a is Obj => a !== undefined);
+  }
+
+  if (Array.isArray(card.tags)) {
+    out.tags = card.tags.map(toIdTitle).filter((t): t is Obj => t !== undefined);
+  }
+
+  const description = card.description;
+  if (typeof description === "string" && description.length > 0) {
+    out.description_preview =
+      description.length > 200 ? `${description.slice(0, 200)}…` : description;
+  }
+
+  return out;
+}
+
+/**
+ * Project a comment down to the fields a discussion reader needs. Keeps
+ * `body` as an object shaped `{ plain_text }` — never a bare string — so the
+ * `body.plain_text` access path is identical in both modes; see
+ * client/types.ts:80-90 on why treating this as a string yields
+ * "[object Object]". Drops `body.html`, the repeated `card` object, and
+ * `reactions_url`. Comment bodies are never truncated: a discussion is what
+ * the caller asked for.
+ */
+export function summarizeComment(comment: Obj): Obj {
+  const out = pick(comment, ["id", "created_at", "updated_at", "url"]);
+
+  const creator = toIdName(comment.creator);
+  if (creator) out.creator = creator;
+
+  if (isPlainObject(comment.body) && comment.body.plain_text !== undefined) {
+    out.body = { plain_text: comment.body.plain_text };
+  }
+
+  return out;
+}
+
+const NOTIFICATION_CARD_KEYS = [
+  "id",
+  "number",
+  "title",
+  "status",
+  "url",
+  "closed",
+  "postponed",
+  "board_name",
+] as const;
+
+/**
+ * Project a notification down to the fields needed to triage it. Reduces the
+ * embedded `card` to `{id, number, title, status, url, closed, postponed,
+ * board_name}` — dropping the nested `card.column` object and everything
+ * else — and `creator` to `{id, name}`.
+ */
+export function summarizeNotification(notification: Obj): Obj {
+  const out = pick(notification, [
+    "id",
+    "title",
+    "body",
+    "read",
+    "read_at",
+    "created_at",
+    "url",
+    "unread_count",
+  ]);
+
+  const creator = toIdName(notification.creator);
+  if (creator) out.creator = creator;
+
+  if (isPlainObject(notification.card)) {
+    out.card = pick(notification.card, NOTIFICATION_CARD_KEYS);
+  }
+
+  return out;
+}

--- a/tests/tools/published-schemas.test.ts
+++ b/tests/tools/published-schemas.test.ts
@@ -75,6 +75,7 @@ describe("published tool schemas", () => {
       "account_slug",
       "card_id",
       "card_number",
+      "fields",
     ]);
   });
 

--- a/tests/tools/tool-execution.test.ts
+++ b/tests/tools/tool-execution.test.ts
@@ -751,4 +751,47 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
       expect(mockClient.getCards).not.toHaveBeenCalled();
     });
   });
+
+  describe("fields projection is validated before any API call is spent", () => {
+    it("rejects a bogus fields value on fizzy_get_cards without calling the client", async () => {
+      const mockClient = { getCards: vi.fn().mockResolvedValue({ cards: [] }) };
+
+      await expect(
+        toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          fields: "compact",
+        })
+      ).rejects.toThrow(/fields must be "summary" or "full"/);
+      expect(mockClient.getCards).not.toHaveBeenCalled();
+    });
+
+    it("rejects a bogus fields value on fizzy_get_card_comments before resolving card_id", async () => {
+      // resolveCardNumber spends a getCard round-trip. On the Cloudflare transport,
+      // which runs handlers with unvalidated args, that request would be wasted and a
+      // failure in it would mask the real invalid-argument error.
+      const mockClient = { getCard: vi.fn(), getCardComments: vi.fn() };
+
+      await expect(
+        toolHandlers.fizzy_get_card_comments(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          card_id: "card-abc",
+          fields: "compact",
+        })
+      ).rejects.toThrow(/fields must be "summary" or "full"/);
+      expect(mockClient.getCard).not.toHaveBeenCalled();
+      expect(mockClient.getCardComments).not.toHaveBeenCalled();
+    });
+
+    it("rejects a bogus fields value on fizzy_get_notifications without calling the client", async () => {
+      const mockClient = { getNotifications: vi.fn().mockResolvedValue([]) };
+
+      await expect(
+        toolHandlers.fizzy_get_notifications(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          fields: 7,
+        })
+      ).rejects.toThrow(/fields must be "summary" or "full"/);
+      expect(mockClient.getNotifications).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/tools/tools-list-over-protocol.test.ts
+++ b/tests/tools/tools-list-over-protocol.test.ts
@@ -57,6 +57,7 @@ describe("tools/list over a real MCP connection", () => {
       "account_slug",
       "card_id",
       "card_number",
+      "fields",
     ]);
   });
 

--- a/tests/utils/projections.test.ts
+++ b/tests/utils/projections.test.ts
@@ -204,6 +204,28 @@ describe("summarizeCard", () => {
     expect(summary).not.toHaveProperty("description_preview");
   });
 
+  it("never splits a surrogate pair when truncating description_preview", () => {
+    // The emoji straddles the 200-unit boundary: naive slice(0, 200) keeps only its
+    // high surrogate and emits a lone, malformed code unit.
+    const summary = summarizeCard({ ...fullCard, description: `${"A".repeat(199)}😀tail` });
+    const preview = summary.description_preview as string;
+
+    expect(preview).toBe(`${"A".repeat(199)}…`);
+    expect(preview).not.toMatch(/[\uD800-\uDBFF]/);
+    expect([...preview].every((char) => char.codePointAt(0)! <= 0xd7ff || char.codePointAt(0)! >= 0xe000)).toBe(true);
+  });
+
+  it("keeps a surrogate pair that fits entirely within the limit", () => {
+    const summary = summarizeCard({ ...fullCard, description: `${"A".repeat(198)}😀tail` });
+    expect(summary.description_preview).toBe(`${"A".repeat(198)}😀…`);
+  });
+
+  it("keeps has_more_assignees so a truncated assignee list cannot read as complete", () => {
+    const summary = summarizeCard({ ...fullCard, assignees: [{ id: "u1", name: "Bob" }], has_more_assignees: true });
+    expect(summary.has_more_assignees).toBe(true);
+    expect(summary.assignees).toEqual([{ id: "u1", name: "Bob" }]);
+  });
+
   it("carries unmodeled-but-listed fields through: golden, closed, last_active_at, has_attachments", () => {
     const summary = summarizeCard(fullCard);
     expect(summary.golden).toBe(true);

--- a/tests/utils/projections.test.ts
+++ b/tests/utils/projections.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Tests for src/utils/projections.ts — the fields="summary" projections used
+ * by fizzy_get_cards, fizzy_get_card_comments, and fizzy_get_notifications.
+ *
+ * Fixtures are built from the real, live-API response shapes (including
+ * fields the `Fizzy*` interfaces in src/client/types.ts do not model), not
+ * from the declared interfaces — the whole point of the summarizers is that
+ * they cannot rely on those interfaces being complete or correct.
+ */
+
+import {
+  parseFieldsMode,
+  summarizeCard,
+  summarizeComment,
+  summarizeNotification,
+} from "../../src/utils/projections.js";
+
+// ---- Fixtures -------------------------------------------------------------
+
+const longDescription = "A".repeat(250);
+
+/** A card as the live API actually returns it — richer than FizzyCard. */
+const fullCard = {
+  id: "123",
+  number: 42,
+  title: "Fix the thing",
+  description: longDescription,
+  description_html: `<p>${longDescription}</p>`,
+  status: "published",
+  board: { id: "b1", name: "Engineering", cards_count: 99 },
+  // column.color is an object on the real API, not the string FizzyColumn claims.
+  column: { id: "c1", name: "In Progress", color: { name: "blue", value: "#123456" } },
+  creator: { id: "u1", name: "Alice", role: "member", email_address: "alice@example.com" },
+  assignees: [
+    { id: "u2", name: "Bob", role: "member", email_address: "bob@example.com" },
+    { id: "u3", name: "Carol", role: "member", email_address: "carol@example.com" },
+  ],
+  tags: [
+    { id: "t1", title: "bug", created_at: "2026-01-01T00:00:00Z", url: "https://example.com/tags/t1" },
+  ],
+  due_on: "2026-02-01",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-02T00:00:00Z",
+  // Unmodeled fields confirmed present on real responses:
+  last_active_at: "2026-01-03T00:00:00Z",
+  closed: false,
+  postponed: false,
+  golden: true,
+  has_attachments: true,
+  has_more_assignees: false,
+  image_url: "https://example.com/cards/42/image.png",
+  comments_url: "https://example.com/cards/42/comments",
+  reactions_url: "https://example.com/cards/42/reactions",
+  url: "https://example.com/cards/42",
+};
+
+/** A comment as the live API returns it. */
+const fullComment = {
+  id: "cm1",
+  body: { plain_text: "Looks good to me.", html: "<p>Looks good to me.</p>" },
+  creator: { id: "u1", name: "Alice", role: "member", email_address: "alice@example.com" },
+  // The same card object repeated on every comment row.
+  card: {
+    id: "123",
+    number: 42,
+    title: "Fix the thing",
+    status: "published",
+    url: "https://example.com/cards/42",
+  },
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  reactions_url: "https://example.com/comments/cm1/reactions",
+  url: "https://example.com/comments/cm1",
+};
+
+/** A notification as the live API returns it. */
+const fullNotification = {
+  id: "n1",
+  title: "New comment on Fix the thing",
+  body: "Alice commented on card #42",
+  read: false,
+  read_at: null,
+  created_at: "2026-01-01T00:00:00Z",
+  url: "https://example.com/notifications/n1",
+  unread_count: 5,
+  source_type: "Comment",
+  creator: { id: "u1", name: "Alice", role: "member", email_address: "alice@example.com" },
+  card: {
+    id: "123",
+    number: 42,
+    title: "Fix the thing",
+    status: "published",
+    url: "https://example.com/cards/42",
+    closed: false,
+    postponed: false,
+    board_name: "Engineering",
+    // Nested column object — dropped entirely in summary mode.
+    column: { id: "c1", name: "In Progress", color: { name: "blue", value: "#123456" } },
+  },
+};
+
+// ---- parseFieldsMode --------------------------------------------------------
+
+describe("parseFieldsMode", () => {
+  it("defaults to full when the value is undefined", () => {
+    expect(parseFieldsMode(undefined)).toBe("full");
+  });
+
+  it("accepts both valid values", () => {
+    expect(parseFieldsMode("summary")).toBe("summary");
+    expect(parseFieldsMode("full")).toBe("full");
+  });
+
+  it("throws on a bogus string value", () => {
+    expect(() => parseFieldsMode("compact")).toThrow(/summary.*full|full.*summary/i);
+  });
+
+  it("throws on a non-string value", () => {
+    expect(() => parseFieldsMode(123)).toThrow();
+    expect(() => parseFieldsMode({})).toThrow();
+    expect(() => parseFieldsMode(null)).toThrow();
+  });
+});
+
+// ---- full mode is an untouched passthrough ---------------------------------
+//
+// This mirrors the gating in tools/handlers.ts: fields is resolved via
+// parseFieldsMode, and only "summary" reaches the summarizers at all — "full"
+// (including the omitted-arg default) returns exactly what the client sent,
+// by identity of content.
+
+describe("full mode (fields omitted) leaves the payload byte-for-byte unchanged", () => {
+  it("card", () => {
+    const mode = parseFieldsMode(undefined);
+    const result = mode === "full" ? fullCard : summarizeCard(fullCard);
+    expect(result).toEqual(fullCard);
+  });
+
+  it("comment", () => {
+    const mode = parseFieldsMode(undefined);
+    const result = mode === "full" ? fullComment : summarizeComment(fullComment);
+    expect(result).toEqual(fullComment);
+  });
+
+  it("notification", () => {
+    const mode = parseFieldsMode(undefined);
+    const result = mode === "full" ? fullNotification : summarizeNotification(fullNotification);
+    expect(result).toEqual(fullNotification);
+  });
+
+  it("CardsPage envelope (page, total_count, has_more, next_page) passes through untouched too", () => {
+    const page = {
+      cards: [fullCard],
+      page: 1,
+      total_count: 293,
+      has_more: true,
+      next_page: 2,
+    };
+    const mode = parseFieldsMode(undefined);
+    const result =
+      mode === "full"
+        ? page
+        : {
+            cards: page.cards.map(summarizeCard),
+            page: page.page,
+            total_count: page.total_count,
+            has_more: page.has_more,
+            next_page: page.next_page,
+          };
+    expect(result).toEqual(page);
+  });
+});
+
+// ---- summarizeCard ----------------------------------------------------------
+
+describe("summarizeCard", () => {
+  it("drops description and description_html", () => {
+    const summary = summarizeCard(fullCard);
+    expect(summary).not.toHaveProperty("description");
+    expect(summary).not.toHaveProperty("description_html");
+  });
+
+  it("also drops comments_url, reactions_url, and image_url", () => {
+    const summary = summarizeCard(fullCard);
+    expect(summary).not.toHaveProperty("comments_url");
+    expect(summary).not.toHaveProperty("reactions_url");
+    expect(summary).not.toHaveProperty("image_url");
+  });
+
+  it("truncates description_preview to 200 chars with an ellipsis when longer", () => {
+    const summary = summarizeCard(fullCard);
+    expect(summary.description_preview).toBe(`${"A".repeat(200)}…`);
+  });
+
+  it("leaves a short description whole, with no ellipsis", () => {
+    const shortCard = { ...fullCard, description: "Short description." };
+    const summary = summarizeCard(shortCard);
+    expect(summary.description_preview).toBe("Short description.");
+  });
+
+  it("omits description_preview entirely when there is no description", () => {
+    const { description, ...cardWithoutDescription } = fullCard;
+    const summary = summarizeCard(cardWithoutDescription);
+    expect(summary).not.toHaveProperty("description_preview");
+  });
+
+  it("carries unmodeled-but-listed fields through: golden, closed, last_active_at, has_attachments", () => {
+    const summary = summarizeCard(fullCard);
+    expect(summary.golden).toBe(true);
+    expect(summary.closed).toBe(false);
+    expect(summary.last_active_at).toBe("2026-01-03T00:00:00Z");
+    expect(summary.has_attachments).toBe(true);
+  });
+
+  it("reduces board, column, creator to {id, name}", () => {
+    const summary = summarizeCard(fullCard);
+    expect(summary.board).toEqual({ id: "b1", name: "Engineering" });
+    expect(summary.column).toEqual({ id: "c1", name: "In Progress" });
+    expect(summary.creator).toEqual({ id: "u1", name: "Alice" });
+  });
+
+  it("reduces assignees to [{id, name}] and tags to [{id, title}]", () => {
+    const summary = summarizeCard(fullCard);
+    expect(summary.assignees).toEqual([
+      { id: "u2", name: "Bob" },
+      { id: "u3", name: "Carol" },
+    ]);
+    expect(summary.tags).toEqual([{ id: "t1", title: "bug" }]);
+  });
+
+  it("does not emit keys absent from the source as undefined", () => {
+    const { due_on, ...cardWithoutDueOn } = fullCard;
+    const summary = summarizeCard(cardWithoutDueOn);
+    expect(Object.prototype.hasOwnProperty.call(summary, "due_on")).toBe(false);
+    expect(JSON.stringify(summary)).not.toContain("undefined");
+  });
+});
+
+// ---- summarizeComment --------------------------------------------------------
+
+describe("summarizeComment", () => {
+  it("keeps body as an object with plain_text, and drops body.html", () => {
+    const summary = summarizeComment(fullComment);
+    expect(summary.body).toEqual({ plain_text: "Looks good to me." });
+    expect(typeof summary.body).toBe("object");
+    // The access path from client/types.ts must stay identical between modes.
+    expect((summary.body as { plain_text: string }).plain_text).toBe("Looks good to me.");
+  });
+
+  it("drops the repeated card object and reactions_url", () => {
+    const summary = summarizeComment(fullComment);
+    expect(summary).not.toHaveProperty("card");
+    expect(summary).not.toHaveProperty("reactions_url");
+  });
+
+  it("reduces creator to {id, name}", () => {
+    const summary = summarizeComment(fullComment);
+    expect(summary.creator).toEqual({ id: "u1", name: "Alice" });
+  });
+
+  it("does not truncate the comment body", () => {
+    const longBody = "L".repeat(5000);
+    const summary = summarizeComment({
+      ...fullComment,
+      body: { plain_text: longBody, html: `<p>${longBody}</p>` },
+    });
+    expect((summary.body as { plain_text: string }).plain_text).toBe(longBody);
+  });
+
+  it("keeps id, created_at, updated_at, url", () => {
+    const summary = summarizeComment(fullComment);
+    expect(summary.id).toBe("cm1");
+    expect(summary.created_at).toBe("2026-01-01T00:00:00Z");
+    expect(summary.updated_at).toBe("2026-01-01T00:00:00Z");
+    expect(summary.url).toBe("https://example.com/comments/cm1");
+  });
+});
+
+// ---- summarizeNotification ---------------------------------------------------
+
+describe("summarizeNotification", () => {
+  it("drops the nested card.column object", () => {
+    const summary = summarizeNotification(fullNotification);
+    expect(summary.card).not.toHaveProperty("column");
+  });
+
+  it("reduces card to {id, number, title, status, url, closed, postponed, board_name}", () => {
+    const summary = summarizeNotification(fullNotification);
+    expect(summary.card).toEqual({
+      id: "123",
+      number: 42,
+      title: "Fix the thing",
+      status: "published",
+      url: "https://example.com/cards/42",
+      closed: false,
+      postponed: false,
+      board_name: "Engineering",
+    });
+  });
+
+  it("reduces creator to {id, name}", () => {
+    const summary = summarizeNotification(fullNotification);
+    expect(summary.creator).toEqual({ id: "u1", name: "Alice" });
+  });
+
+  it("keeps id, title, body, read, read_at, created_at, url, unread_count", () => {
+    const summary = summarizeNotification(fullNotification);
+    expect(summary).toMatchObject({
+      id: "n1",
+      title: "New comment on Fix the thing",
+      body: "Alice commented on card #42",
+      read: false,
+      read_at: null,
+      created_at: "2026-01-01T00:00:00Z",
+      url: "https://example.com/notifications/n1",
+      unread_count: 5,
+    });
+  });
+
+  it("drops source_type, which is not in the kept list", () => {
+    const summary = summarizeNotification(fullNotification);
+    expect(summary).not.toHaveProperty("source_type");
+  });
+
+  it("does not emit keys absent from the source as undefined", () => {
+    const { read_at, ...notificationWithoutReadAt } = fullNotification;
+    const summary = summarizeNotification(notificationWithoutReadAt);
+    expect(Object.prototype.hasOwnProperty.call(summary, "read_at")).toBe(false);
+    expect(JSON.stringify(summary)).not.toContain("undefined");
+  });
+});

--- a/tsconfig.cloudflare.json
+++ b/tsconfig.cloudflare.json
@@ -27,7 +27,8 @@
     "src/utils/attachments.ts",
     "src/utils/base64.ts",
     "src/utils/file-source.ts",
-    "src/utils/md5.ts"
+    "src/utils/md5.ts",
+    "src/utils/projections.ts"
   ],
   "exclude": ["node_modules", "dist", "tests"]
 }


### PR DESCRIPTION
Adds an optional `fields` parameter — `"summary"` or `"full"` — to the three list tools whose responses are dominated by content most callers never read: `fizzy_get_cards`, `fizzy_get_card_comments`, and `fizzy_get_notifications`.

Fixes #37

## Why

Measured against a live account with 293 cards:

| Tool | Current | `fields="summary"` | Dominated by |
|---|---|---|---|
| `fizzy_get_cards` | **578 KB** / 15-card page | 3.8 KB | `description` + `description_html` = 94.7% |
| `fizzy_get_notifications` | **127 KB** / 96 rows | ~32 KB | embedded `card` 41.5%, repeated `creator` 25.7% |
| `fizzy_get_card_comments` | — | — | `plain_text` + `html` twins, repeated creator/card per row |

Enumerating that account's cards costs roughly 11 MB. A single page is already large enough to crowd out most of an LLM caller's context, which makes the list tools hard to use for the thing they exist for: finding a card.

## What changed

`fields` defaults to `"full"`, which is an untouched passthrough — **existing callers see byte-identical responses**. `summary` is strictly opt-in, and the tool descriptions steer callers toward it for browsing and toward `fizzy_get_card` for full detail once a card is identified.

The summaries keep identity and triage fields (ids, title, status, board/column, assignees, tags, dates, flags) and add a 200-character `description_preview`. They drop the heavy content: descriptions and their HTML twins, duplicated rich-text representations, and repeated embedded user/card objects.

Projections live in `src/utils/projections.ts` and are applied in the shared handlers, so both the stdio and Cloudflare paths get them. `parseFieldsMode` validates there rather than only in the Zod schema, because the Cloudflare transport executes tool args without Zod — the same reason the existing `parseCardsPage` sits in that layer.

Note the summarizers read responses structurally rather than through the `Fizzy*` interfaces. Those interfaces are missing about a dozen fields the API actually returns (`description_html`, `board`, `golden`, `closed`, `last_active_at`, `has_attachments`, `unread_count`, …) and type `column.color` as `string` when it is really `{name, value}`. Filed separately as #40 rather than widened into this change.

## Tests

34 new tests in `tests/utils/projections.test.ts` and `tests/tools/tool-execution.test.ts`, covering full-mode passthrough for all three tools, the `CardsPage` envelope, preview truncation (including that it never splits a surrogate pair), survival of unmodeled fields, the no-`undefined`-keys guarantee, and `fields` validation rejecting bad values before any API call is spent.

Verified: `npm test`, `npm run typecheck`, `npm run typecheck:cf`, `npm run test:cloudflare`, `npm run build` — all green. (`tests/transports/sse-multi-user.test.ts` and one case in `security-warnings.test.ts` fail on this machine only because unrelated processes hold ports 3100/3001; they pass when those ports are free.)
