### PR TITLE
feat(tools): add pin/unpin and pinned-card listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This MCP server allows AI assistants like Claude, Cursor, and GitHub Copilot to 
 
 ## Features
 
-- **Full Fizzy API Coverage**: 44 tools covering Boards, Cards, Card Actions, Comments, Reactions, Steps, Columns, Tags, Users, and Notifications
+- **Full Fizzy API Coverage**: 53 tools covering Boards, Cards, Card Actions, Pins, Comments, Reactions, Steps, Columns, Tags, Users, and Notifications
 - **Multiple Transport Protocols**: Stdio (CLI/IDE), HTTP (Streamable), and SSE (deprecated)
 - **Multi-User Support**: HTTP and SSE transports support multiple users with per-user authentication
 - **Flexible Deployment**: Run locally (Node.js) or deploy globally (Cloudflare Workers)
@@ -505,14 +505,13 @@ npx fizzy-mcp --transport http --port 3000
 
 ---
 
-## Available Tools (50 total)
+## Available Tools (53 total)
 
-### Identity & Accounts (3)
+### Identity & Accounts (2)
 | Tool | Description |
 |------|-------------|
 | `fizzy_get_identity` | Get current user's identity and accounts |
 | `fizzy_get_accounts` | List all accessible accounts |
-| `fizzy_get_account` | Get details of a specific account |
 
 ### Boards (5)
 | Tool | Description |
@@ -527,12 +526,13 @@ npx fizzy-mcp --transport http --port 3000
 | Tool | Description |
 |------|-------------|
 | `fizzy_get_cards` | List cards with optional filters (board, indexed_by, column, assignees, tags, search); `fields="summary"` returns a much smaller payload for browsing |
+| `fizzy_get_pins` | List the current user's pinned cards (not paginated, max 100); prefer `fields="summary"` |
 | `fizzy_get_card` | Get card details including description, assignees, tags |
 | `fizzy_create_card` | Create a new card with title, description, status, column, assignees, tags, due date |
 | `fizzy_update_card` | Update any card property |
 | `fizzy_delete_card` | Delete a card |
 
-### Card Actions (9)
+### Card Actions (13)
 | Tool | Description |
 |------|-------------|
 | `fizzy_close_card` | Close a card (mark as done) |
@@ -544,6 +544,10 @@ npx fizzy-mcp --transport http --port 3000
 | `fizzy_toggle_card_assignment` | Toggle a user assignment on/off for a card |
 | `fizzy_watch_card` | Subscribe to notifications for a card |
 | `fizzy_unwatch_card` | Unsubscribe from notifications for a card |
+| `fizzy_gild_card` | Mark a card as golden (team-wide priority); filter with `indexed_by="golden"` |
+| `fizzy_ungild_card` | Remove a card's golden status |
+| `fizzy_pin_card` | Pin a card to the current user's personal quick-access list |
+| `fizzy_unpin_card` | Unpin a card for the current user |
 
 ### Comments (5)
 | Tool | Description |

--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -891,6 +891,46 @@ export class FizzyClient {
     await this.request<void>("DELETE", `/${slug}/cards/${cardNumber}/goldness`);
   }
 
+  // ============ Pins ============
+
+  /**
+   * Pin a card for the current user
+   * @endpoint POST /:account_slug/cards/:card_number/pin
+   * @see https://github.com/basecamp/fizzy/blob/main/docs/api/sections/pins.md
+   */
+  async pinCard(accountSlug: string, cardNumber: string): Promise<void> {
+    const slug = this.normalizeSlug(accountSlug);
+    await this.request<void>("POST", `/${slug}/cards/${cardNumber}/pin`);
+  }
+
+  /**
+   * Unpin a card for the current user
+   * @endpoint DELETE /:account_slug/cards/:card_number/pin
+   * @see https://github.com/basecamp/fizzy/blob/main/docs/api/sections/pins.md
+   */
+  async unpinCard(accountSlug: string, cardNumber: string): Promise<void> {
+    const slug = this.normalizeSlug(accountSlug);
+    await this.request<void>("DELETE", `/${slug}/cards/${cardNumber}/pin`);
+  }
+
+  /**
+   * Get the current user's pinned cards for an account.
+   *
+   * Unlike {@link getCards} this endpoint is NOT paginated: the server returns
+   * at most 100 pinned cards in a bare array, so there is no page envelope to
+   * build and nothing to walk. Pins are per-user *and* per-account — the path
+   * is account-scoped despite living under the `/my` namespace, because
+   * My::PinsController (unlike My::IdentitiesController) does not declare
+   * `disallow_account_scope`.
+   * @endpoint GET /:account_slug/my/pins
+   * @see https://github.com/basecamp/fizzy/blob/main/docs/api/sections/pins.md
+   */
+  async getPins(accountSlug: string): Promise<FizzyCard[]> {
+    const slug = this.normalizeSlug(accountSlug);
+    const cards = await this.request<FizzyCard[]>("GET", `/${slug}/my/pins`);
+    return cards ?? [];
+  }
+
   // ============ Comments ============
 
   /**

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -148,6 +148,25 @@ export const TOOL_DEFINITIONS = {
       },
     },
     {
+      name: "fizzy_get_pins",
+      title: "List Pinned Cards",
+      description:
+        "Get the cards the current user has pinned in an account, as a plain array of cards. " +
+        "Pins are per-user and per-account, so this returns only the authenticated user's pins — " +
+        "it is not a view of what anyone else pinned. " +
+        "This listing is NOT paginated: the server returns at most 100 pinned cards, and there is " +
+        "no page or next_page to follow. " +
+        "Strongly prefer fields='summary' here — the response carries full card descriptions and " +
+        "HTML by default, so a large pin list can run to several megabytes; summary returns the " +
+        "same cards far smaller. Call fizzy_get_card for the full detail of a specific pin. " +
+        "Use fizzy_pin_card and fizzy_unpin_card to change what appears in this list.",
+      schema: schemas.getPinsSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+      },
+    },
+    {
       name: "fizzy_get_card",
       title: "Get Card Details",
       description:
@@ -329,6 +348,34 @@ export const TOOL_DEFINITIONS = {
         "Remove golden status from a card. The card will no longer appear in golden card filters " +
         "and will lose its priority highlighting.",
       schema: schemas.ungildCardSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
+    },
+    {
+      name: "fizzy_pin_card",
+      title: "Pin Card",
+      description:
+        "Pin a card for the current user, keeping it in their personal quick-access list. " +
+        "Pins are per-user and per-account: pinning affects only the authenticated user's list, " +
+        "not what teammates see. Use this to keep track of a card you need to return to. " +
+        "Retrieve the resulting list with fizzy_get_pins. " +
+        "To flag a card as high-priority for the whole team instead, use fizzy_gild_card.",
+      schema: schemas.pinCardSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
+    },
+    {
+      name: "fizzy_unpin_card",
+      title: "Unpin Card",
+      description:
+        "Unpin a card for the current user, removing it from their personal quick-access list. " +
+        "Only affects the authenticated user's pins; the card itself is unchanged and remains " +
+        "on its board.",
+      schema: schemas.unpinCardSchema,
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -242,6 +242,28 @@ export const toolHandlers: Record<string, ToolHandler> = {
     return `Card ${args.card_number} golden status removed`;
   },
 
+  // ============ Pin Tools ============
+  fizzy_pin_card: async (client, args) => {
+    await client.pinCard(args.account_slug as string, args.card_number as string);
+    return `Card ${args.card_number} pinned`;
+  },
+
+  fizzy_unpin_card: async (client, args) => {
+    await client.unpinCard(args.account_slug as string, args.card_number as string);
+    return `Card ${args.card_number} unpinned`;
+  },
+
+  fizzy_get_pins: async (client, args) => {
+    // Parsed before the request so an invalid `fields` value fails fast on the
+    // unvalidated Cloudflare path rather than after spending an API round-trip.
+    const fieldsMode = parseFieldsMode(args.fields);
+    const pins = await client.getPins(args.account_slug as string);
+    if (fieldsMode === "full") return pins;
+    return pins.map((card) =>
+      summarizeCard(card as unknown as Record<string, unknown>)
+    );
+  },
+
   // ============ Comment Tools ============
   fizzy_get_card_comments: async (client, args) => {
     // Validated before resolveCardNumber, which makes its own API round-trip: on the

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -65,7 +65,7 @@ export const stepIdSchema = z.string().describe(
 // Shared `fields` projection schema for the list tools whose full payloads are
 // dominated by fields most callers don't need (long descriptions, duplicated
 // HTML bodies, repeated embedded objects). Referenced by getCardsSchema,
-// getCardCommentsSchema, and getNotificationsSchema.
+// getCardCommentsSchema, getNotificationsSchema, and getPinsSchema.
 export const fieldsSchema = z
   .enum(["summary", "full"])
   .optional()
@@ -541,6 +541,25 @@ export const gildCardSchema = z.object({
 export const ungildCardSchema = z.object({
   account_slug: accountSlugSchema,
   card_number: cardNumberSchema,
+});
+
+// ============ Pin schemas ============
+
+export const pinCardSchema = z.object({
+  account_slug: accountSlugSchema,
+  card_number: cardNumberSchema,
+});
+
+export const unpinCardSchema = z.object({
+  account_slug: accountSlugSchema,
+  card_number: cardNumberSchema,
+});
+
+// No `page` field: unlike the card listing, GET /:account_slug/my/pins is not
+// paginated — it returns at most 100 pinned cards in one bare array.
+export const getPinsSchema = z.object({
+  account_slug: accountSlugSchema,
+  fields: fieldsSchema,
 });
 
 // ============ Attachment schemas ============

--- a/src/utils/projections.ts
+++ b/src/utils/projections.ts
@@ -24,7 +24,7 @@ export type FieldsMode = "summary" | "full";
 
 /**
  * Parse the optional `fields` argument shared by fizzy_get_cards,
- * fizzy_get_card_comments, and fizzy_get_notifications.
+ * fizzy_get_card_comments, fizzy_get_notifications, and fizzy_get_pins.
  *
  * This has to exist (not just live in the zod schema) because the Cloudflare
  * transport executes raw args with no zod validation — mirrors the reasoning

--- a/src/utils/projections.ts
+++ b/src/utils/projections.ts
@@ -127,7 +127,15 @@ export function summarizeCard(card: Obj): Obj {
   }
 
   if (Array.isArray(card.tags)) {
-    out.tags = card.tags.map(toIdTitle).filter((t): t is Obj => t !== undefined);
+    // Card tags arrive as plain title strings, not objects: fizzy's
+    // cards/_card.json.jbuilder serializes them as
+    // `json.tags card.tags.pluck(:title).sort`. Routing those through
+    // toIdTitle mapped every one to undefined, so summary mode reported
+    // every tagged card as untagged. Object-shaped tags are still reduced,
+    // in case the serializer ever grows ids.
+    out.tags = card.tags
+      .map((tag) => (typeof tag === "string" ? tag : toIdTitle(tag)))
+      .filter((t): t is string | Obj => t !== undefined);
   }
 
   const description = card.description;

--- a/tests/client/fizzy-client.test.ts
+++ b/tests/client/fizzy-client.test.ts
@@ -35,7 +35,14 @@
  *   POST   /:account_slug/cards/:card_number/assignments - Toggle assignment
  *   POST   /:account_slug/cards/:card_number/watch       - Watch card
  *   DELETE /:account_slug/cards/:card_number/watch       - Unwatch card
- * 
+ *   POST   /:account_slug/cards/:card_number/goldness    - Mark card golden
+ *   DELETE /:account_slug/cards/:card_number/goldness    - Remove golden status
+ *
+ * PINS
+ *   POST   /:account_slug/cards/:card_number/pin  - Pin card for current user
+ *   DELETE /:account_slug/cards/:card_number/pin  - Unpin card for current user
+ *   GET    /:account_slug/my/pins                 - List current user's pinned cards (not paginated, max 100)
+ *
  * COMMENTS
  *   GET    /:account_slug/cards/:card_number/comments              - List comments
  *   GET    /:account_slug/cards/:card_number/comments/:comment_id  - Get comment
@@ -1294,6 +1301,69 @@ describe("FizzyClient", () => {
           method: "POST",
         })
       );
+    });
+  });
+
+  describe("Pins", () => {
+    it("should pin a card", async () => {
+      mockFetch.mockResolvedValueOnce(createMockNoContent());
+
+      await client.pinCard("123", "42");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://app.fizzy.do/123/cards/42/pin",
+        expect.objectContaining({
+          method: "POST",
+        })
+      );
+    });
+
+    it("should unpin a card", async () => {
+      mockFetch.mockResolvedValueOnce(createMockNoContent());
+
+      await client.unpinCard("123", "42");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://app.fizzy.do/123/cards/42/pin",
+        expect.objectContaining({
+          method: "DELETE",
+        })
+      );
+    });
+
+    // The pins index lives under the /my namespace but is still account-scoped,
+    // because My::PinsController does not declare `disallow_account_scope` the
+    // way My::IdentitiesController does. A slug-less "/my/pins" would 404.
+    it("should get pinned cards from the account-scoped /my/pins path", async () => {
+      const mockPins = [
+        { id: "card1", number: 1, title: "First!", status: "published", created_at: "2025-12-05T19:38:48.540Z", url: "https://app.fizzy.do/123/cards/1" },
+      ];
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockPins));
+
+      const result = await client.getPins("123");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://app.fizzy.do/123/my/pins",
+        expect.any(Object)
+      );
+      expect(result).toEqual(mockPins);
+    });
+
+    it("should strip the leading slash from the account slug for pins", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse([]));
+
+      await client.getPins("/6117483");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://app.fizzy.do/6117483/my/pins",
+        expect.any(Object)
+      );
+    });
+
+    it("should return an empty array when the pins response has no body", async () => {
+      mockFetch.mockResolvedValueOnce(createMockNoContent());
+
+      await expect(client.getPins("123")).resolves.toEqual([]);
     });
   });
 

--- a/tests/tools/tool-execution.test.ts
+++ b/tests/tools/tool-execution.test.ts
@@ -752,6 +752,86 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
     });
   });
 
+  describe("Pin handlers", () => {
+    it("fizzy_pin_card forwards slug and card number to the client", async () => {
+      const mockClient = { pinCard: vi.fn().mockResolvedValue(undefined) };
+
+      const result = await toolHandlers.fizzy_pin_card(
+        mockClient as unknown as FizzyClient,
+        { account_slug: "123", card_number: "42" }
+      );
+
+      expect(mockClient.pinCard).toHaveBeenCalledWith("123", "42");
+      expect(result).toBe("Card 42 pinned");
+    });
+
+    it("fizzy_unpin_card forwards slug and card number to the client", async () => {
+      const mockClient = { unpinCard: vi.fn().mockResolvedValue(undefined) };
+
+      const result = await toolHandlers.fizzy_unpin_card(
+        mockClient as unknown as FizzyClient,
+        { account_slug: "123", card_number: "42" }
+      );
+
+      expect(mockClient.unpinCard).toHaveBeenCalledWith("123", "42");
+      expect(result).toBe("Card 42 unpinned");
+    });
+
+    it("fizzy_get_pins returns the client's array unchanged when fields is omitted", async () => {
+      const pins = [{ id: "card1", title: "First!", description: "Hello, World!" }];
+      const mockClient = { getPins: vi.fn().mockResolvedValue(pins) };
+
+      const result = await toolHandlers.fizzy_get_pins(
+        mockClient as unknown as FizzyClient,
+        { account_slug: "123" }
+      );
+
+      expect(mockClient.getPins).toHaveBeenCalledWith("123");
+      expect(result).toEqual(pins);
+    });
+
+    it("fizzy_get_pins projects each card when fields='summary'", async () => {
+      const mockClient = {
+        getPins: vi.fn().mockResolvedValue([
+          {
+            id: "card1",
+            title: "First!",
+            description: "Hello, World!",
+            description_html: "<div>Hello, World!</div>",
+            creator: { id: "u1", name: "David", email_address: "david@example.com" },
+          },
+        ]),
+      };
+
+      const result = (await toolHandlers.fizzy_get_pins(
+        mockClient as unknown as FizzyClient,
+        { account_slug: "123", fields: "summary" }
+      )) as Record<string, unknown>[];
+
+      expect(result).toHaveLength(1);
+      expect(result[0].description).toBeUndefined();
+      expect(result[0].description_html).toBeUndefined();
+      expect(result[0].description_preview).toBe("Hello, World!");
+      expect(result[0].creator).toEqual({ id: "u1", name: "David" });
+    });
+
+    it("fizzy_get_pins handles an empty pin list under both projections", async () => {
+      const mockClient = { getPins: vi.fn().mockResolvedValue([]) };
+
+      await expect(
+        toolHandlers.fizzy_get_pins(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+        })
+      ).resolves.toEqual([]);
+      await expect(
+        toolHandlers.fizzy_get_pins(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          fields: "summary",
+        })
+      ).resolves.toEqual([]);
+    });
+  });
+
   describe("fields projection is validated before any API call is spent", () => {
     it("rejects a bogus fields value on fizzy_get_cards without calling the client", async () => {
       const mockClient = { getCards: vi.fn().mockResolvedValue({ cards: [] }) };
@@ -792,6 +872,18 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
         })
       ).rejects.toThrow(/fields must be "summary" or "full"/);
       expect(mockClient.getNotifications).not.toHaveBeenCalled();
+    });
+
+    it("rejects a bogus fields value on fizzy_get_pins without calling the client", async () => {
+      const mockClient = { getPins: vi.fn().mockResolvedValue([]) };
+
+      await expect(
+        toolHandlers.fizzy_get_pins(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          fields: "compact",
+        })
+      ).rejects.toThrow(/fields must be "summary" or "full"/);
+      expect(mockClient.getPins).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/utils/projections.test.ts
+++ b/tests/utils/projections.test.ts
@@ -250,6 +250,28 @@ describe("summarizeCard", () => {
     expect(summary.tags).toEqual([{ id: "t1", title: "bug" }]);
   });
 
+  // The live API sends card tags as plain title strings —
+  // `json.tags card.tags.pluck(:title).sort` in fizzy's cards/_card.json.jbuilder.
+  // Reducing those as objects silently emptied the list, so a tagged card read as
+  // untagged in summary mode.
+  it("passes through string tags, the shape the API actually sends", () => {
+    const summary = summarizeCard({ ...fullCard, tags: ["programming", "urgent"] });
+    expect(summary.tags).toEqual(["programming", "urgent"]);
+  });
+
+  it("keeps string tags when a card mixes both tag shapes", () => {
+    const summary = summarizeCard({
+      ...fullCard,
+      tags: ["programming", { id: "t1", title: "bug" }],
+    });
+    expect(summary.tags).toEqual(["programming", { id: "t1", title: "bug" }]);
+  });
+
+  it("emits an empty tag list for a card with no tags", () => {
+    const summary = summarizeCard({ ...fullCard, tags: [] });
+    expect(summary.tags).toEqual([]);
+  });
+
   it("does not emit keys absent from the source as undefined", () => {
     const { due_on, ...cardWithoutDueOn } = fullCard;
     const summary = summarizeCard(cardWithoutDueOn);

--- a/tests/verify-refactoring.test.ts
+++ b/tests/verify-refactoring.test.ts
@@ -17,9 +17,13 @@ describe("Refactored Server Verification", () => {
     expect(() => createFizzyServer(client)).not.toThrow();
   });
 
-  it("should have all 50 tools defined in definitions.ts", () => {
-    expect(ALL_TOOLS).toHaveLength(50);
-    expect(ALL_TOOLS.map((tool) => tool.name)).toContain("fizzy_upload_file");
+  it("should have all 53 tools defined in definitions.ts", () => {
+    expect(ALL_TOOLS).toHaveLength(53);
+    const names = ALL_TOOLS.map((tool) => tool.name);
+    expect(names).toContain("fizzy_upload_file");
+    expect(names).toEqual(
+      expect.arrayContaining(["fizzy_pin_card", "fizzy_unpin_card", "fizzy_get_pins"])
+    );
   });
 
   it("should have all tools with required metadata", () => {


### PR DESCRIPTION
Adds the three pin tools requested in #7: `fizzy_pin_card`, `fizzy_unpin_card`, and `fizzy_get_pins`.

## Two corrections to the issue

**Golden was already implemented.** `fizzy_gild_card`/`fizzy_ungild_card` have existed since 6885ee8 — only pin/unpin was actually missing. The likely reason they looked missing: the README's tool tables never listed them. That drift is fixed here (see below).

**The listing endpoint is account-scoped.** The issue says `GET /my/pins`; it is actually `GET /:account_slug/my/pins`. Confirmed three ways — the upstream `docs/api/sections/pins.md`, `config/routes.rb`, and decisively `My::PinsController` lacking the `disallow_account_scope` declaration that `My::IdentitiesController` carries, which is exactly why the existing slug-less `/my/identity` call is correct. Built as written in the issue, the tool would 404.

## Design notes

The listing is **unpaginated and capped at 100 cards** (`pins_limit` is 100 for JSON), so `getPins` returns a bare `FizzyCard[]` with no page envelope and `getPinsSchema` has no `page` field, unlike `fizzy_get_cards`.

It accepts the shared `fields` projection, because a full-fidelity response is potentially large: a 15-card page of `fizzy_get_cards` measures ~578 KB, almost all `description`/`description_html`, so 100 pinned cards could run to several megabytes.

**Open decision — the `fields` default.** It is left at `"full"`, consistent with every other list tool, with the payload steering in the tool description instead. The counter-argument is that a brand-new tool has no existing callers to protect, so `"summary"` would be the safer greenfield default; review independently reached that same conclusion. Deferred here because it reverses a preference stated on #37 rather than an oversight. Flipping it is a one-line change to `getPinsSchema` plus a tool-specific description — say the word.

## Included fix: summary mode was dropping every card tag

Found while reviewing this change, and fixed in bff0f2f because `fizzy_get_pins` steers callers hard toward summary mode, where a silently empty tag list is most likely to be believed.

`summarizeCard` reduced each tag through an object-only reducer, which returns `undefined` for anything that isn't an object. The API serializes card tags as plain strings — `json.tags card.tags.pluck(:title).sort` in fizzy's `cards/_card.json.jbuilder` — so every tag was mapped to `undefined` and filtered out, and `fields="summary"` reported every tagged card as **untagged**.

This reaches `fizzy_get_cards` too, so it is a live bug from 28d8f6e, not one introduced here. Existing tests missed it because their fixture uses object-shaped tags, matching the `FizzyCard.tags` declaration — which is itself inaccurate against the serializer. Object-shaped tags are still reduced, so a future serializer change stays handled.

## README reconciliation

The tool tables had drifted independently of this change: the total said 50 (actually 53), gild/ungild were absent, and a `fizzy_get_account` tool was listed that does not exist. The tables are now verified to match `ALL_TOOLS` exactly, name-for-name and section-by-section.

## Follow-ups filed separately

- `FizzyCard.tags` declares `FizzyTag[]` but the API sends `string[]`; part of broader inaccuracy in the `Fizzy*` interfaces — #42
- `tests/server.test.ts` and `tests/cloudflare/mcp-session.test.ts` assert hardcoded tool lists against themselves, so they pass while verifying nothing and are already stale at 47/49 vs 53 — #43

## Verification

`typecheck`, `typecheck:cf`, `test:cloudflare` (118), and `build` all pass. The non-transport test subset goes 499 → 516 against clean `main`: 11 new tests here, 3 more auto-generated because `json-schema.test.ts` runs `it.each(ALL_TOOLS…)`, plus 3 for the tag fix. The full run's only failures are the 5 pre-existing `sse-multi-user`/`security-warnings` tests that need port 3100, which a foreign process holds locally; they are unrelated and pass in CI.

Fixes #7
