### PR TITLE
fix(tools): actually assign users passed to fizzy_create_card and fizzy_update_card

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -40,7 +40,14 @@ export interface FizzyCard {
   status: "draft" | "published" | "archived";
   column?: FizzyColumn;
   creator?: FizzyUser;
+  /**
+   * Capped at five entries by the API (`app/views/cards/_card.json.jbuilder`
+   * renders `card.assignees.limit(5)`), so this is not necessarily the full
+   * roster — check `has_more_assignees` before treating it as complete.
+   */
   assignees?: FizzyUser[];
+  /** True when the card has more assignees than the five `assignees` carries. */
+  has_more_assignees?: boolean;
   tags?: FizzyTag[];
   due_on?: string;
   created_at: string;
@@ -123,12 +130,18 @@ export interface FizzyStep {
 }
 
 // Request types
+//
+// `assignee_ids` is deliberately absent from both card request types. Upstream's
+// `CardsController#card_params` permits only
+// `[ :title, :description, :image, :created_at, :last_active_at ]`, so Rails
+// strong params silently drop it and the card comes back unassigned. Assignments
+// are only reachable through `POST /:slug/cards/:number/assignments`, which the
+// card handlers call after the create/update lands.
 export interface CreateCardRequest {
   title: string;
   description?: string;
   status?: "draft" | "published";
   column_id?: string;
-  assignee_ids?: string[];
   tag_ids?: string[];
   due_on?: string;
 }
@@ -138,7 +151,6 @@ export interface UpdateCardRequest {
   description?: string;
   status?: "draft" | "published" | "archived";
   column_id?: string;
-  assignee_ids?: string[];
   tag_ids?: string[];
   due_on?: string;
 }

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -366,14 +366,27 @@ export const toolHandlers: Record<string, ToolHandler> = {
       currentAssignees = (existing.assignees ?? []).map((user) => user.id);
     }
 
-    await client.updateCard(accountSlug, cardId, {
+    const cardFields = {
       title: args.title as string,
       description: args.description as string,
       status: args.status as "draft" | "published" | "archived" | undefined,
       column_id: args.column_id as string,
       tag_ids: args.tag_ids as string[],
       due_on: args.due_on as string,
-    });
+    };
+
+    // Only send the card payload when it actually carries something. Upstream's
+    // `params.expect(card: [...])` raises ParameterMissing on an empty hash, so
+    // an assignments-only update would otherwise serialize to `{"card":{}}` and
+    // come back 400 before reaching the assignment calls below.
+    if (Object.values(cardFields).some((value) => value !== undefined)) {
+      await client.updateCard(accountSlug, cardId, cardFields);
+    } else if (!desiredAssignees) {
+      throw new Error(
+        `No changes given for card ${cardId}. Pass at least one of title, description, ` +
+        "status, column_id, tag_ids, due_on or assignee_ids."
+      );
+    }
 
     if (!desiredAssignees) return `Card ${cardId} updated successfully`;
 

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -9,7 +9,12 @@
  */
 
 import type { FizzyClient } from "../client/fizzy-client.js";
-import { COLUMN_COLORS, type ColumnColor, type CardListOptions } from "../client/types.js";
+import {
+  COLUMN_COLORS,
+  type ColumnColor,
+  type CardListOptions,
+  type FizzyCard,
+} from "../client/types.js";
 import { resolveCardNumber } from "../utils/card-resolver.js";
 import { attachmentHtml, resolveAttachment } from "../utils/attachments.js";
 import {
@@ -58,6 +63,130 @@ function parseCardsPage(value: unknown): number | undefined {
     if (Number.isSafeInteger(parsed) && parsed >= 1) return parsed;
   }
   throw new Error("page must be a positive integer (1-based), e.g. 2");
+}
+
+/**
+ * Validate the optional `assignee_ids` argument of the card create/update tools.
+ *
+ * Like the guards above, this has to run here because the Cloudflare transport
+ * executes raw args without zod: a non-array value would otherwise reach the
+ * toggle loop and either iterate a string character by character or silently
+ * assign nobody.
+ *
+ * Duplicates are dropped because the upstream endpoint *toggles* assignment —
+ * the same id twice would assign and then immediately unassign the same user.
+ */
+function parseAssigneeIds(value: unknown): string[] | undefined {
+  // Only an omitted value means "leave assignments alone". `null` is rejected
+  // rather than treated as omission, so this matches what zod does on the
+  // validated path instead of quietly ignoring a malformed argument.
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error("assignee_ids must be an array of user ID strings");
+  }
+  for (const entry of value) {
+    if (typeof entry !== "string" || entry.trim() === "") {
+      throw new Error("assignee_ids must contain non-empty user ID strings");
+    }
+  }
+  return [...new Set(value as string[])];
+}
+
+/**
+ * The assignee ids a card payload reports, or `undefined` when it declines to
+ * report them all — `_card.json.jbuilder` renders `card.assignees.limit(5)`, so
+ * a card over that limit only sets `has_more_assignees` and cannot be compared
+ * against a requested set.
+ */
+function assigneeRoster(card: FizzyCard): string[] | undefined {
+  if (card.has_more_assignees) return undefined;
+  return (card.assignees ?? []).map((user) => user.id);
+}
+
+/**
+ * Toggle whatever separates `current` from `desired`, returning the reason each
+ * failed id failed.
+ *
+ * Failures are collected rather than thrown: the card already exists by the time
+ * this runs, so aborting on the first bad user id would leave the caller unable
+ * to tell what happened to the rest.
+ */
+async function applyAssignmentDiff(
+  client: FizzyClient,
+  accountSlug: string,
+  cardNumber: string,
+  desired: string[],
+  current: string[]
+): Promise<Map<string, string>> {
+  const reasons = new Map<string, string>();
+  const toAssign = desired.filter((id) => !current.includes(id));
+  const toUnassign = current.filter((id) => !desired.includes(id));
+
+  for (const userId of [...toAssign, ...toUnassign]) {
+    try {
+      await client.toggleCardAssignment(accountSlug, cardNumber, userId);
+    } catch (error) {
+      reasons.set(userId, error instanceof Error ? error.message : String(error));
+    }
+  }
+  return reasons;
+}
+
+/**
+ * Describe the difference between the roster that was asked for and the one the
+ * card actually came back with.
+ *
+ * The toggles are never taken at their word. The endpoint toggles rather than
+ * sets, and the HTTP client retries every method on ambiguous transport failures
+ * (see the retry loop in `client/fizzy-client.ts`), so a POST that reached Fizzy
+ * but whose response was lost gets sent again and lands on the *opposite* state
+ * while reporting success. A second caller editing the same card between the
+ * read and the writes does the same thing. Neither is preventable from here, so
+ * the result is read back and anything that disagrees is reported.
+ *
+ * `roster` is `undefined` when the end state could not be established, in which
+ * case only failures seen directly are reported — an unverifiable result must
+ * not be dressed up as a confirmed one.
+ */
+function describeAssignmentGaps(
+  desired: string[],
+  roster: string[] | undefined,
+  reasons: Map<string, string>,
+  options: { replacesRoster: boolean }
+): string[] {
+  const because = (userId: string) => {
+    const reason = reasons.get(userId);
+    return reason ? ` (${reason})` : "";
+  };
+
+  if (!roster) {
+    return [...reasons].map(
+      ([userId, reason]) => `Assignment change for user ${userId} failed: ${reason}`
+    );
+  }
+
+  const warnings = desired
+    .filter((userId) => !roster.includes(userId))
+    .map((userId) => `User ${userId} was requested but is not assigned${because(userId)}`);
+
+  if (options.replacesRoster) {
+    warnings.push(
+      ...roster
+        .filter((userId) => !desired.includes(userId))
+        .map((userId) => `User ${userId} is still assigned${because(userId)}`)
+    );
+  }
+  return warnings;
+}
+
+/**
+ * The card number of a freshly created card, which every later assignment call
+ * is addressed by. Taken from the create response rather than a lookup, since
+ * `GET /:slug/cards/:id` itself resolves by number.
+ */
+function createdCardNumber(card: { number?: number; url?: string }): string | undefined {
+  if (card.number !== undefined && card.number !== null) return String(card.number);
+  return card.url?.match(/\/cards\/(\d+)/)?.[1];
 }
 
 /**
@@ -144,29 +273,141 @@ export const toolHandlers: Record<string, ToolHandler> = {
     return client.getCard(args.account_slug as string, args.card_id as string);
   },
 
+  // Assignments are applied *after* the card exists rather than in the create
+  // payload: the upstream controller permits only title/description/image/
+  // created_at/last_active_at, so an `assignee_ids` key in the card body is
+  // dropped by strong params and the card is created unassigned with no error
+  // anywhere in the response (issue #9).
   fizzy_create_card: async (client, args) => {
-    return client.createCard(args.account_slug as string, args.board_id as string, {
+    const accountSlug = args.account_slug as string;
+    const assigneeIds = parseAssigneeIds(args.assignee_ids);
+
+    const card = await client.createCard(accountSlug, args.board_id as string, {
       title: args.title as string,
       description: args.description as string,
       status: args.status as "draft" | "published" | undefined,
       column_id: args.column_id as string,
-      assignee_ids: args.assignee_ids as string[],
       tag_ids: args.tag_ids as string[],
       due_on: args.due_on as string,
     });
+
+    if (!assigneeIds || assigneeIds.length === 0) return card;
+
+    const cardNumber = createdCardNumber(card);
+    if (!cardNumber) {
+      return {
+        ...card,
+        assignment_warnings: [
+          "Card created, but its number could not be read from the response, " +
+          "so no assignments were applied. Use fizzy_toggle_card_assignment to assign users.",
+        ],
+      };
+    }
+
+    // A new card has no assignments at all, so the whole requested set is the
+    // diff — no need to read the roster first.
+    const reasons = await applyAssignmentDiff(client, accountSlug, cardNumber, assigneeIds, []);
+
+    // Re-read the card so `assignees` reflects the assignments just made. The
+    // create response is rendered before any of them exist, and returning it
+    // unchanged is what made the original failure invisible.
+    let assigned: FizzyCard;
+    try {
+      assigned = await client.getCard(accountSlug, cardNumber);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      return {
+        ...card,
+        assignment_warnings: [
+          ...describeAssignmentGaps(assigneeIds, undefined, reasons, { replacesRoster: false }),
+          `Assignments were applied but the card could not be re-read (${reason}), so ` +
+          "the 'assignees' field above is from before they were made and may be wrong.",
+        ],
+      };
+    }
+
+    const roster = assigneeRoster(assigned);
+    const warnings = describeAssignmentGaps(assigneeIds, roster, reasons, {
+      // Creating a card doesn't claim ownership of anyone else's assignment —
+      // a self-assignment landing alongside this call is not a failure.
+      replacesRoster: false,
+    });
+    if (!roster) {
+      // Over five assignees the API stops listing them, so a requested user that
+      // didn't take can no longer be spotted. Say so rather than let a
+      // warning-free response imply the whole set was confirmed.
+      warnings.unshift(
+        "The card reports more than 5 assignees, so the API no longer lists them all and " +
+        "the requested assignments could not be verified."
+      );
+    }
+    return warnings.length > 0 ? { ...assigned, assignment_warnings: warnings } : assigned;
   },
 
   fizzy_update_card: async (client, args) => {
-    await client.updateCard(args.account_slug as string, args.card_id as string, {
+    const accountSlug = args.account_slug as string;
+    const cardId = args.card_id as string;
+    const desiredAssignees = parseAssigneeIds(args.assignee_ids);
+
+    // `assignee_ids` is documented as a full replacement, and the only way to
+    // honour that against a toggle-based endpoint is to diff it against the
+    // current roster. Read that before mutating anything, so a card we cannot
+    // safely replace assignments on fails before its title changes.
+    let currentAssignees: string[] = [];
+    if (desiredAssignees) {
+      const existing = await client.getCard(accountSlug, cardId);
+      if (existing.has_more_assignees) {
+        throw new Error(
+          `Card ${cardId} has more than 5 assignees, and the API only reports the first 5. ` +
+          "Replacing the assignee list would leave the ones it doesn't report still assigned. " +
+          "Use fizzy_toggle_card_assignment to change this card's assignments individually."
+        );
+      }
+      currentAssignees = (existing.assignees ?? []).map((user) => user.id);
+    }
+
+    await client.updateCard(accountSlug, cardId, {
       title: args.title as string,
       description: args.description as string,
       status: args.status as "draft" | "published" | "archived" | undefined,
       column_id: args.column_id as string,
-      assignee_ids: args.assignee_ids as string[],
       tag_ids: args.tag_ids as string[],
       due_on: args.due_on as string,
     });
-    return `Card ${args.card_id} updated successfully`;
+
+    if (!desiredAssignees) return `Card ${cardId} updated successfully`;
+
+    const reasons = await applyAssignmentDiff(
+      client,
+      accountSlug,
+      cardId,
+      desiredAssignees,
+      currentAssignees
+    );
+
+    // Report the roster the card actually ends up with, not the one the toggles
+    // were supposed to produce — see describeAssignmentGaps for why they differ.
+    // This runs even when the diff was empty: "already correct" is a claim about
+    // the pre-flight snapshot, and the roster can have moved since.
+    let roster: string[] | undefined;
+    let readError: string | undefined;
+    try {
+      roster = assigneeRoster(await client.getCard(accountSlug, cardId));
+    } catch (error) {
+      readError = error instanceof Error ? error.message : String(error);
+    }
+
+    const warnings = describeAssignmentGaps(desiredAssignees, roster, reasons, {
+      replacesRoster: true,
+    });
+    const summary = roster
+      ? `Card ${cardId} updated successfully (assignees: ` +
+        `${roster.filter((id) => !currentAssignees.includes(id)).length} added, ` +
+        `${currentAssignees.filter((id) => !roster.includes(id)).length} removed)`
+      : `Card ${cardId} updated successfully, but the resulting assignee list could not be ` +
+        `verified (${readError ?? "the card now reports more than 5 assignees"})`;
+
+    return warnings.length > 0 ? `${summary}. ${warnings.join("; ")}` : summary;
   },
 
   fizzy_delete_card: async (client, args) => {

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -214,7 +214,9 @@ export const createCardSchema = z.object({
   ),
   assignee_ids: z.array(z.string()).optional().describe(
     "Array of user IDs to assign to this card. Assigned users receive notifications " +
-    "about card updates and are responsible for the work. Omit for unassigned cards."
+    "about card updates and are responsible for the work. Omit for unassigned cards. " +
+    "Users must be members of the card's board; ids that aren't are reported back in " +
+    "an 'assignment_warnings' field on the created card rather than failing the create."
   ),
   tag_ids: z.array(z.string()).optional().describe(
     "Array of tag IDs to categorize the card. Tags help with organization and filtering. " +
@@ -246,8 +248,12 @@ export const updateCardSchema = z.object({
   ),
   assignee_ids: z.array(z.string()).optional().describe(
     "New array of assignee user IDs. Omit to keep current assignments. " +
-    "⚠️ This replaces all assignees - it's not additive. " +
-    "Note: Use fizzy_toggle_card_assignment for adding/removing individual users."
+    "⚠️ This replaces all assignees - it's not additive. Pass [] to unassign everyone. " +
+    "Cards with more than 5 assignees are rejected, because the API reports only the " +
+    "first 5 and the rest cannot be replaced safely - use fizzy_toggle_card_assignment " +
+    "there, and for adding/removing individual users generally. " +
+    "The resulting assignee list is read back and reported, so check the response: it " +
+    "names any user that did not end up in the state you asked for."
   ),
   tag_ids: z.array(z.string()).optional().describe(
     "New array of tag IDs. Omit to keep current tags. " +

--- a/tests/tools/card-assignments.test.ts
+++ b/tests/tools/card-assignments.test.ts
@@ -344,6 +344,26 @@ describe("fizzy_update_card assignments", () => {
     );
   });
 
+  // Upstream's `params.expect(card: [...])` raises ParameterMissing on an empty
+  // hash, so an assignments-only update must not send a card payload at all —
+  // it would serialize to {"card":{}} and 400 before any assignment happens.
+  it("skips the card update entirely when only assignments change", async () => {
+    client.getCard
+      .mockResolvedValueOnce(withAssignees("u1"))
+      .mockResolvedValueOnce(withAssignees("u2"));
+
+    const result = await update({ assignee_ids: ["u2"] });
+
+    expect(client.updateCard).not.toHaveBeenCalled();
+    expect(client.toggleCardAssignment).toHaveBeenCalled();
+    expect(result).toBe("Card 14 updated successfully (assignees: 1 added, 1 removed)");
+  });
+
+  it("rejects an update that carries no changes at all", async () => {
+    await expect(update({})).rejects.toThrow("No changes given for card 14");
+    expect(client.updateCard).not.toHaveBeenCalled();
+  });
+
   // The card payload caps `assignees` at five, so a full replacement computed
   // from it would leave the unreported ones assigned.
   it("refuses to replace assignees when the API reports the list is truncated", async () => {

--- a/tests/tools/card-assignments.test.ts
+++ b/tests/tools/card-assignments.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Card assignment tests
+ *
+ * Upstream's CardsController permits only
+ * `[ :title, :description, :image, :created_at, :last_active_at ]`, so an
+ * `assignee_ids` key inside the card payload is dropped by Rails strong params
+ * and the card comes back unassigned with no error anywhere. These tests pin
+ * the behaviour that replaces it: assignments go through
+ * `POST /:slug/cards/:number/assignments` after the card exists, and the
+ * resulting roster is read back rather than inferred from the toggles.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FizzyClient } from "../../src/client/fizzy-client.js";
+import { executeToolHandler } from "../../src/tools/handlers.js";
+
+type ClientStub = {
+  createCard: ReturnType<typeof vi.fn>;
+  updateCard: ReturnType<typeof vi.fn>;
+  getCard: ReturnType<typeof vi.fn>;
+  toggleCardAssignment: ReturnType<typeof vi.fn>;
+};
+
+const CREATED = {
+  id: "card-abc",
+  number: 14,
+  title: "Card",
+  url: "https://app.fizzy.do/123456/cards/14",
+  assignees: [],
+};
+
+const user = (id: string) => ({ id, name: id });
+
+/** A card payload whose assignee roster is exactly `ids`. */
+const withAssignees = (...ids: string[]) => ({
+  ...CREATED,
+  assignees: ids.map(user),
+  has_more_assignees: false,
+});
+
+describe("fizzy_create_card assignments", () => {
+  let client: ClientStub;
+
+  beforeEach(() => {
+    client = {
+      createCard: vi.fn().mockResolvedValue(CREATED),
+      updateCard: vi.fn().mockResolvedValue(undefined),
+      getCard: vi.fn(),
+      toggleCardAssignment: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  const create = (args: Record<string, unknown>) =>
+    executeToolHandler(client as unknown as FizzyClient, "fizzy_create_card", {
+      account_slug: "123456",
+      board_id: "board-1",
+      title: "Card",
+      ...args,
+    });
+
+  it("never sends assignee_ids in the create payload", async () => {
+    client.getCard.mockResolvedValue(withAssignees("u1"));
+
+    await create({ assignee_ids: ["u1"] });
+
+    expect(client.createCard).toHaveBeenCalledWith(
+      "123456",
+      "board-1",
+      expect.not.objectContaining({ assignee_ids: expect.anything() })
+    );
+  });
+
+  it("assigns each user through the assignments endpoint", async () => {
+    client.getCard.mockResolvedValue(withAssignees("u1", "u2"));
+
+    const result = (await create({ assignee_ids: ["u1", "u2"] })) as Record<string, unknown>;
+
+    expect(client.toggleCardAssignment.mock.calls).toEqual([
+      ["123456", "14", "u1"],
+      ["123456", "14", "u2"],
+    ]);
+    // Re-read so the response shows the assignees that now exist; the create
+    // response is rendered before any of them do.
+    expect(client.getCard).toHaveBeenCalledWith("123456", "14");
+    expect(result.assignees).toEqual([user("u1"), user("u2")]);
+    expect(result.assignment_warnings).toBeUndefined();
+  });
+
+  it("toggles a repeated id only once", async () => {
+    client.getCard.mockResolvedValue(withAssignees("u1"));
+
+    await create({ assignee_ids: ["u1", "u1"] });
+
+    expect(client.toggleCardAssignment).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes no assignment calls and no extra fetch when assignee_ids is absent", async () => {
+    const result = await create({});
+
+    expect(client.toggleCardAssignment).not.toHaveBeenCalled();
+    expect(client.getCard).not.toHaveBeenCalled();
+    expect(result).toEqual(CREATED);
+  });
+
+  it("treats an empty array as no assignments", async () => {
+    await create({ assignee_ids: [] });
+
+    expect(client.toggleCardAssignment).not.toHaveBeenCalled();
+    expect(client.getCard).not.toHaveBeenCalled();
+  });
+
+  it("keeps the created card and reports the users it could not assign", async () => {
+    client.toggleCardAssignment
+      .mockRejectedValueOnce(new Error("Resource not found"))
+      .mockResolvedValueOnce(undefined);
+    client.getCard.mockResolvedValue(withAssignees("u2"));
+
+    const result = (await create({ assignee_ids: ["u1", "u2"] })) as Record<string, unknown>;
+
+    expect(result.id).toBe("card-abc");
+    expect(result.assignment_warnings).toEqual([
+      "User u1 was requested but is not assigned (Resource not found)",
+    ]);
+  });
+
+  // The endpoint toggles rather than sets, and the HTTP client retries POSTs on
+  // ambiguous transport failures — so a request that landed but whose response
+  // was lost is sent again and lands on the opposite state, reporting success.
+  it("reports a user the toggle claimed to assign but the card came back without", async () => {
+    client.getCard.mockResolvedValue(withAssignees("u2"));
+
+    const result = (await create({ assignee_ids: ["u1", "u2"] })) as Record<string, unknown>;
+
+    expect(client.toggleCardAssignment).toHaveBeenCalledTimes(2);
+    expect(result.assignment_warnings).toEqual([
+      "User u1 was requested but is not assigned",
+    ]);
+  });
+
+  it("does not treat someone else's assignment as a failure", async () => {
+    client.getCard.mockResolvedValue(withAssignees("u1", "someone-else"));
+
+    const result = (await create({ assignee_ids: ["u1"] })) as Record<string, unknown>;
+
+    expect(result.assignment_warnings).toBeUndefined();
+  });
+
+  // Over five assignees the card payload reports only the first five, so the
+  // requested set cannot be compared against it — only direct failures are known.
+  it("reports direct failures and the lost verification when the roster is truncated", async () => {
+    client.toggleCardAssignment.mockRejectedValueOnce(new Error("Resource not found"));
+    client.getCard.mockResolvedValue({
+      ...CREATED,
+      assignees: [user("u2"), user("u3"), user("u4"), user("u5"), user("u6")],
+      has_more_assignees: true,
+    });
+
+    const result = (await create({
+      assignee_ids: ["u1", "u2", "u3", "u4", "u5", "u6"],
+    })) as Record<string, unknown>;
+
+    expect(result.assignment_warnings).toEqual([
+      expect.stringContaining("could not be verified"),
+      "Assignment change for user u1 failed: Resource not found",
+    ]);
+  });
+
+  // Without this the response is warning-free while a requested user may be
+  // missing: the toggles all "succeeded", and the truncated roster cannot say
+  // otherwise. Silence would read as confirmation.
+  it("says the result is unverified when the roster is truncated and nothing failed", async () => {
+    client.getCard.mockResolvedValue({
+      ...CREATED,
+      assignees: [user("u1"), user("u2"), user("u3"), user("u4"), user("u5")],
+      has_more_assignees: true,
+    });
+
+    const result = (await create({
+      assignee_ids: ["u1", "u2", "u3", "u4", "u5", "u6"],
+    })) as Record<string, unknown>;
+
+    expect(result.assignment_warnings).toEqual([
+      expect.stringContaining("could not be verified"),
+    ]);
+  });
+
+  it("warns instead of throwing when the card cannot be re-read", async () => {
+    client.getCard.mockRejectedValue(new Error("boom"));
+
+    const result = (await create({ assignee_ids: ["u1"] })) as Record<string, unknown>;
+
+    expect(result.id).toBe("card-abc");
+    expect(result.assignment_warnings).toEqual([
+      expect.stringContaining("could not be re-read"),
+    ]);
+  });
+
+  it("falls back to the card URL when the response omits the number", async () => {
+    client.createCard.mockResolvedValue({ ...CREATED, number: undefined });
+    client.getCard.mockResolvedValue(withAssignees("u1"));
+
+    await create({ assignee_ids: ["u1"] });
+
+    expect(client.toggleCardAssignment).toHaveBeenCalledWith("123456", "14", "u1");
+  });
+
+  it("reports rather than silently skips when no card number can be found", async () => {
+    client.createCard.mockResolvedValue({ id: "card-abc", title: "Card" });
+
+    const result = (await create({ assignee_ids: ["u1"] })) as Record<string, unknown>;
+
+    expect(client.toggleCardAssignment).not.toHaveBeenCalled();
+    expect(result.assignment_warnings).toEqual([
+      expect.stringContaining("number could not be read"),
+    ]);
+  });
+
+  // The Cloudflare transport executes raw args without zod, so these have to be
+  // rejected in the handler rather than at the schema boundary.
+  it("rejects a non-array assignee_ids before creating anything", async () => {
+    await expect(create({ assignee_ids: "u1" })).rejects.toThrow(
+      "assignee_ids must be an array of user ID strings"
+    );
+    expect(client.createCard).not.toHaveBeenCalled();
+  });
+
+  it("rejects null rather than treating it as omitted, matching the zod schema", async () => {
+    await expect(create({ assignee_ids: null })).rejects.toThrow(
+      "assignee_ids must be an array of user ID strings"
+    );
+    expect(client.createCard).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-string entries in assignee_ids", async () => {
+    await expect(create({ assignee_ids: ["u1", 7] })).rejects.toThrow(
+      "assignee_ids must contain non-empty user ID strings"
+    );
+    expect(client.createCard).not.toHaveBeenCalled();
+  });
+
+  it("rejects blank entries in assignee_ids", async () => {
+    await expect(create({ assignee_ids: ["u1", "  "] })).rejects.toThrow(
+      "assignee_ids must contain non-empty user ID strings"
+    );
+    expect(client.createCard).not.toHaveBeenCalled();
+  });
+});
+
+describe("fizzy_update_card assignments", () => {
+  let client: ClientStub;
+
+  beforeEach(() => {
+    client = {
+      createCard: vi.fn(),
+      updateCard: vi.fn().mockResolvedValue(undefined),
+      // Default: the pre-flight read, then the verification read.
+      getCard: vi.fn().mockResolvedValue(withAssignees("u1", "u2")),
+      toggleCardAssignment: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  const update = (args: Record<string, unknown>) =>
+    executeToolHandler(client as unknown as FizzyClient, "fizzy_update_card", {
+      account_slug: "123456",
+      card_id: "14",
+      ...args,
+    });
+
+  it("toggles only the difference between current and desired assignees", async () => {
+    client.getCard
+      .mockResolvedValueOnce(withAssignees("u1", "u2"))
+      .mockResolvedValueOnce(withAssignees("u2", "u3"));
+
+    const result = await update({ assignee_ids: ["u2", "u3"] });
+
+    expect(client.toggleCardAssignment.mock.calls).toEqual([
+      ["123456", "14", "u3"], // added
+      ["123456", "14", "u1"], // removed
+    ]);
+    expect(result).toBe("Card 14 updated successfully (assignees: 1 added, 1 removed)");
+  });
+
+  it("unassigns everyone for an empty array", async () => {
+    client.getCard
+      .mockResolvedValueOnce(withAssignees("u1", "u2"))
+      .mockResolvedValueOnce(withAssignees());
+
+    const result = await update({ assignee_ids: [] });
+
+    expect(client.toggleCardAssignment.mock.calls).toEqual([
+      ["123456", "14", "u1"],
+      ["123456", "14", "u2"],
+    ]);
+    expect(result).toBe("Card 14 updated successfully (assignees: 0 added, 2 removed)");
+  });
+
+  it("toggles nothing when the requested roster is already the current one", async () => {
+    const result = await update({ assignee_ids: ["u2", "u1"] });
+
+    expect(client.toggleCardAssignment).not.toHaveBeenCalled();
+    expect(result).toBe("Card 14 updated successfully (assignees: 0 added, 0 removed)");
+  });
+
+  // "Already correct" is a claim about the pre-flight snapshot, so it gets
+  // verified like any other — the roster can have moved in between.
+  it("still verifies an empty diff, catching a roster that moved underneath it", async () => {
+    client.getCard
+      .mockResolvedValueOnce(withAssignees("u1"))
+      .mockResolvedValueOnce(withAssignees());
+
+    const result = (await update({ assignee_ids: ["u1"] })) as string;
+
+    expect(client.toggleCardAssignment).not.toHaveBeenCalled();
+    expect(client.getCard).toHaveBeenCalledTimes(2);
+    expect(result).toContain("User u1 was requested but is not assigned");
+  });
+
+  it("deduplicates repeated ids before diffing", async () => {
+    client.getCard
+      .mockResolvedValueOnce(withAssignees("u1"))
+      .mockResolvedValueOnce(withAssignees("u1", "u2"));
+
+    const result = await update({ assignee_ids: ["u1", "u2", "u2"] });
+
+    expect(client.toggleCardAssignment.mock.calls).toEqual([["123456", "14", "u2"]]);
+    expect(result).toBe("Card 14 updated successfully (assignees: 1 added, 0 removed)");
+  });
+
+  it("leaves assignments alone when assignee_ids is omitted", async () => {
+    const result = await update({ title: "New title" });
+
+    expect(client.getCard).not.toHaveBeenCalled();
+    expect(client.toggleCardAssignment).not.toHaveBeenCalled();
+    expect(result).toBe("Card 14 updated successfully");
+  });
+
+  it("never sends assignee_ids in the update payload", async () => {
+    await update({ title: "New title", assignee_ids: ["u1"] });
+
+    expect(client.updateCard).toHaveBeenCalledWith(
+      "123456",
+      "14",
+      expect.not.objectContaining({ assignee_ids: expect.anything() })
+    );
+  });
+
+  // The card payload caps `assignees` at five, so a full replacement computed
+  // from it would leave the unreported ones assigned.
+  it("refuses to replace assignees when the API reports the list is truncated", async () => {
+    client.getCard.mockResolvedValue({
+      ...CREATED,
+      assignees: [user("u1"), user("u2"), user("u3"), user("u4"), user("u5")],
+      has_more_assignees: true,
+    });
+
+    await expect(update({ title: "New title", assignee_ids: ["u1"] })).rejects.toThrow(
+      "more than 5 assignees"
+    );
+    // Read before write, so the rejected update changed nothing at all.
+    expect(client.updateCard).not.toHaveBeenCalled();
+    expect(client.toggleCardAssignment).not.toHaveBeenCalled();
+  });
+
+  it("reports assignment changes that failed", async () => {
+    client.toggleCardAssignment.mockRejectedValueOnce(new Error("Resource not found"));
+    client.getCard
+      .mockResolvedValueOnce(withAssignees("u1", "u2"))
+      .mockResolvedValueOnce(withAssignees("u1", "u2"));
+
+    const result = (await update({ assignee_ids: ["u1", "u2", "u3"] })) as string;
+
+    expect(result).toContain("assignees: 0 added, 0 removed");
+    expect(result).toContain("User u3 was requested but is not assigned (Resource not found)");
+  });
+
+  // A toggle retried after an ambiguous transport failure lands on the opposite
+  // state, and a second caller editing the card does the same. Both show up as a
+  // roster that disagrees with what was asked for.
+  it("reports a roster that disagrees with the request even when every toggle succeeded", async () => {
+    client.getCard
+      .mockResolvedValueOnce(withAssignees("u1"))
+      .mockResolvedValueOnce(withAssignees("u1"));
+
+    const result = (await update({ assignee_ids: ["u2"] })) as string;
+
+    expect(result).toContain("User u2 was requested but is not assigned");
+    expect(result).toContain("User u1 is still assigned");
+  });
+
+  it("reports that it could not verify when the read-back fails", async () => {
+    client.getCard
+      .mockResolvedValueOnce(withAssignees("u1"))
+      .mockRejectedValueOnce(new Error("boom"));
+
+    const result = (await update({ assignee_ids: ["u2"] })) as string;
+
+    expect(result).toContain("could not be verified (boom)");
+  });
+
+  it("reports that it could not verify when the new roster exceeds the reported limit", async () => {
+    client.getCard.mockResolvedValueOnce(withAssignees("u1")).mockResolvedValueOnce({
+      ...CREATED,
+      assignees: [user("u1"), user("u2"), user("u3"), user("u4"), user("u5")],
+      has_more_assignees: true,
+    });
+
+    const result = (await update({
+      assignee_ids: ["u1", "u2", "u3", "u4", "u5", "u6"],
+    })) as string;
+
+    expect(result).toContain("could not be verified");
+    expect(result).toContain("more than 5 assignees");
+  });
+
+  it("rejects malformed assignee_ids before touching the card", async () => {
+    for (const bad of [null, "u1", ["u1", 7], ["u1", ""]]) {
+      client.getCard.mockClear();
+      client.updateCard.mockClear();
+
+      await expect(update({ assignee_ids: bad })).rejects.toThrow(/assignee_ids must/);
+      expect(client.getCard).not.toHaveBeenCalled();
+      expect(client.updateCard).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/tests/tools/tool-execution.test.ts
+++ b/tests/tools/tool-execution.test.ts
@@ -248,7 +248,6 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
         status: "published",
         column_id: "col1",
         due_on: "2024-12-31",
-        assignee_ids: ["user1", "user2"],
         tag_ids: ["tag1"],
       });
 


### PR DESCRIPTION
Fixes #9.

`fizzy_create_card` accepted `assignee_ids` and put it in the card payload. The card was created correctly and came back with `"assignees": []` — no error, nothing to react to — so the caller had to notice and re-assign by hand.

## Why it silently did nothing

Upstream `CardsController#card_params` permits five fields:

```ruby
params.expect(card: [ :title, :description, :image, :created_at, :last_active_at ])
```

`assignee_ids` isn't one of them, so Rails strong params dropped it on create *and* update. Assignment is only reachable through `POST /:account_slug/cards/:card_number/assignments`, which the client already wraps as `toggleCardAssignment` — the tool just never called it.

## The fix

- **`fizzy_create_card`** creates the card, assigns each requested user through the assignments endpoint, then re-reads the card so the returned `assignees` reflects what actually exists. The create response is rendered before any assignment exists, and returning it unchanged is what made the original failure invisible.
- **`fizzy_update_card`** honours its documented replace-all semantics by diffing the requested roster against the current one and toggling only the difference. It reads the card first and refuses *before mutating anything* when `has_more_assignees` is set: the API caps `assignees` at five (`_card.json.jbuilder` renders `card.assignees.limit(5)`), so a replacement computed from a truncated list would leave the hidden assignees attached while reporting a clean replace.
- **`assignee_ids` is gone from `CreateCardRequest`/`UpdateCardRequest`**, since those types are serialized straight into the HTTP body and it was never a valid field there.

## The result is verified, not assumed

The assignments endpoint *toggles* rather than sets, and the HTTP client retries every method on ambiguous transport failures (`requestWithMeta`). So a POST that reached Fizzy but whose response was lost gets sent again and lands on the opposite state — while reporting success. A second caller editing the same card between the read and the writes does the same thing.

Neither is preventable from the tool layer, so the roster is read back after the toggles and compared against what was requested. Anything that disagrees is reported: as `assignment_warnings` on the created card, or in the update's result message. When the end state genuinely can't be established — the read failed, or the card now reports more than five assignees — that is said plainly rather than dressed up as a confirmed success.

This is deliberately "verify and report", not "converge": there is no automatic corrective pass, because retrying against a live editor is a fight the tool shouldn't pick. Callers get an accurate account and can act on it.

Argument validation for `assignee_ids` runs in the handler, because the Cloudflare transport executes raw args without zod (#17). `null` is rejected rather than treated as omission, matching what the schema does on the validated path.

## Scope

Callers that don't pass `assignee_ids` are unaffected: same request, same response, no extra round-trips.

`column_id`, `tag_ids` and `status` are dropped by the same strong-params filter and are **not** fixed here — filed as #44. `due_on` is the same class and already tracked in #18.

## Verified against the live API

Run against a real account, not just mocks — this class of bug is invisible to them, and the run earned its keep by catching a regression the tests missed (an assignments-only update serialized to `{"card":{}}`, which upstream rejects with 400; fixed in the second commit).

| Step | Result |
|---|---|
| Create with `assignee_ids: [user]` | card returned with that user in `assignees`, no `assignment_warnings` |
| Update with `assignee_ids: []` | `assignees: 0 added, 1 removed`; re-read confirms empty |
| Update with `assignee_ids: [user]` | `assignees: 1 added, 0 removed` |
| Create with a nonexistent user id | card still created, `assignment_warnings` names the user and the 404 |

The same create through the currently deployed build returns `"assignees": []`, reproducing #9.

Test cards were deleted afterwards.
