### PR TITLE
fix(tools): fetch every page of boards, tags, users and comments; expose page on notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ npx fizzy-mcp --transport http --port 3000
 ### Boards (5)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_boards` | List all boards in an account |
+| `fizzy_get_boards` | List all boards in an account (complete list; every upstream page is fetched server-side) |
 | `fizzy_get_board` | Get details of a specific board |
 | `fizzy_create_board` | Create a new board |
 | `fizzy_update_board` | Update a board's name |
@@ -552,7 +552,7 @@ npx fizzy-mcp --transport http --port 3000
 ### Comments (5)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_card_comments` | List comments on a card; `fields="summary"` drops the duplicated HTML body and repeated card/creator detail |
+| `fizzy_get_card_comments` | List comments on a card (complete thread; every upstream page is fetched server-side); `fields="summary"` drops the duplicated HTML body and repeated card/creator detail |
 | `fizzy_get_comment` | Get a specific comment |
 | `fizzy_create_comment` | Add a comment to a card (supports HTML) |
 | `fizzy_update_comment` | Update a comment |
@@ -585,12 +585,12 @@ npx fizzy-mcp --transport http --port 3000
 ### Tags (1)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_tags` | List all tags in an account |
+| `fizzy_get_tags` | List all tags in an account (complete list; every upstream page is fetched server-side) |
 
 ### Users (4)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_users` | List users in an account |
+| `fizzy_get_users` | List users in an account (complete roster; every upstream page is fetched server-side) |
 | `fizzy_get_user` | Get user details |
 | `fizzy_update_user` | Update user's display name |
 | `fizzy_deactivate_user` | Deactivate a user |
@@ -598,7 +598,7 @@ npx fizzy-mcp --transport http --port 3000
 ### Notifications (4)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_notifications` | List notifications for current user; `fields="summary"` shrinks the embedded card and creator objects |
+| `fizzy_get_notifications` | List notifications for current user: default returns up to 100 unread plus the latest page of read ones, `page=2,3,...` walks older read-only history; `fields="summary"` shrinks the embedded card and creator objects |
 | `fizzy_mark_notification_read` | Mark notification as read |
 | `fizzy_mark_notification_unread` | Mark notification as unread |
 | `fizzy_mark_all_notifications_read` | Mark all notifications as read |

--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -28,6 +28,7 @@ import type {
   UpdateStepRequest,
   CardListOptions,
   CardsPage,
+  NotificationListOptions,
   DirectUploadBlobRequest,
   FizzyDirectUpload,
   FileUpload,
@@ -74,6 +75,19 @@ export interface FizzyClientConfig {
 }
 
 export class FizzyClient {
+  /**
+   * Hard stop for {@link requestAllPages}.
+   *
+   * With upstream's geared page sizes (15, 30, 50, then 100) twenty pages is
+   * 1,795 items — far more than any of the aggregated collections holds in
+   * practice, and small enough to stay well inside the Cloudflare Workers
+   * per-invocation subrequest limit, which a single tool call shares with
+   * everything else it does. The cap exists because upstream keeps advertising
+   * rel="next" past the end of a collection: without it a server that never
+   * stops saying "next" turns one tool call into an unbounded request loop.
+   */
+  private static readonly MAX_AGGREGATED_PAGES = 20;
+
   private accessToken: string;
   private baseUrl: string;
   private timeout: number;
@@ -471,6 +485,58 @@ export class FizzyClient {
   }
 
   /**
+   * Fetch every page of a paginated list endpoint and concatenate them.
+   *
+   * Page 1 is requested with `basePath` untouched — no `page` param — so a
+   * single-page collection produces exactly the request the client made before
+   * pagination was followed at all, and an endpoint that turns out not to be
+   * paginated (no headers) still costs one request.
+   *
+   * Walking stops at the first of: a page with no rel="next" link, an empty
+   * page (upstream advertises a next link past the end of a collection, so the
+   * link alone is not a reliable terminator), or
+   * {@link FizzyClient.MAX_AGGREGATED_PAGES}. Hitting the cap is logged and
+   * returns what was collected rather than throwing: a truncated list is worth
+   * more to the caller than an error, and the warning is what makes the
+   * truncation visible.
+   */
+  private async requestAllPages<T>(basePath: string): Promise<T[]> {
+    const collected: T[] = [];
+
+    for (let page = 1; ; page++) {
+      const path =
+        page === 1
+          ? basePath
+          : `${basePath}${basePath.includes("?") ? "&" : "?"}page=${page}`;
+
+      const { data, meta } = await this.requestWithMeta<T[]>(
+        "GET",
+        path,
+        undefined,
+        (response) => this.parsePaginationMeta(response)
+      );
+
+      const items = Array.isArray(data) ? data : [];
+      for (const item of items) collected.push(item);
+
+      // No metadata at all means the response carried no pagination headers,
+      // which is the same signal `getCards` treats as "there is no page 2".
+      const pagination = meta as
+        | { totalCount: number | null; hasMore: boolean }
+        | undefined;
+      if (!pagination?.hasMore || items.length === 0) return collected;
+
+      if (page >= FizzyClient.MAX_AGGREGATED_PAGES) {
+        this.log.warn(
+          `Stopped at the ${FizzyClient.MAX_AGGREGATED_PAGES}-page cap for ${basePath}; ` +
+            `returning ${collected.length} items, which may be incomplete`
+        );
+        return collected;
+      }
+    }
+  }
+
+  /**
    * Read geared_pagination metadata off a list response.
    *
    * Returns undefined when neither header is present, which is the signal the
@@ -592,13 +658,16 @@ export class FizzyClient {
   // ============ Boards ============
 
   /**
-   * Get all boards in an account
+   * Get all boards in an account.
+   *
+   * The endpoint is paginated upstream, so every page is fetched and
+   * concatenated — the result is the complete list, not the first page.
    * @endpoint GET /:account_slug/boards
    * @see https://github.com/basecamp/fizzy/blob/main/docs/API.md#get-account_slugboards
    */
   async getBoards(accountSlug: string): Promise<FizzyBoard[]> {
     const slug = this.normalizeSlug(accountSlug);
-    return this.request<FizzyBoard[]>("GET", `/${slug}/boards`);
+    return this.requestAllPages<FizzyBoard>(`/${slug}/boards`);
   }
 
   /**
@@ -934,7 +1003,11 @@ export class FizzyClient {
   // ============ Comments ============
 
   /**
-   * Get all comments on a card
+   * Get all comments on a card.
+   *
+   * The endpoint is paginated upstream, so every page is fetched and
+   * concatenated — the result is the complete thread in chronological order,
+   * not the first page of it.
    * @endpoint GET /:account_slug/cards/:card_number/comments
    * @see https://github.com/basecamp/fizzy/blob/main/docs/API.md#get-account_slugcardscard_numbercomments
    */
@@ -943,8 +1016,7 @@ export class FizzyClient {
     cardNumber: string
   ): Promise<FizzyComment[]> {
     const slug = this.normalizeSlug(accountSlug);
-    return this.request<FizzyComment[]>(
-      "GET",
+    return this.requestAllPages<FizzyComment>(
       `/${slug}/cards/${cardNumber}/comments`
     );
   }
@@ -1241,13 +1313,16 @@ export class FizzyClient {
   // ============ Tags ============
 
   /**
-   * Get all tags in an account
+   * Get all tags in an account.
+   *
+   * The endpoint is paginated upstream, so every page is fetched and
+   * concatenated — the result is the complete list, not the first page.
    * @endpoint GET /:account_slug/tags
    * @see https://github.com/basecamp/fizzy/blob/main/docs/API.md#get-account_slugtags
    */
   async getTags(accountSlug: string): Promise<FizzyTag[]> {
     const slug = this.normalizeSlug(accountSlug);
-    return this.request<FizzyTag[]>("GET", `/${slug}/tags`);
+    return this.requestAllPages<FizzyTag>(`/${slug}/tags`);
   }
 
   // Note: POST/DELETE /:account_slug/tags endpoints return 404
@@ -1256,13 +1331,16 @@ export class FizzyClient {
   // ============ Users ============
 
   /**
-   * Get all active users in an account
+   * Get all active users in an account.
+   *
+   * The endpoint is paginated upstream, so every page is fetched and
+   * concatenated — the result is the complete roster, not the first page.
    * @endpoint GET /:account_slug/users
    * @see https://github.com/basecamp/fizzy/blob/main/docs/API.md#get-account_slugusers
    */
   async getUsers(accountSlug: string): Promise<FizzyUser[]> {
     const slug = this.normalizeSlug(accountSlug);
-    return this.request<FizzyUser[]>("GET", `/${slug}/users`);
+    return this.requestAllPages<FizzyUser>(`/${slug}/users`);
   }
 
   /**
@@ -1304,16 +1382,43 @@ export class FizzyClient {
   // ============ Notifications ============
 
   /**
-   * Get all notifications for the current user
+   * Get one page of notifications for the current user.
+   *
+   * Deliberately NOT aggregated like the other lists, because this endpoint's
+   * pages are not slices of one collection. `NotificationsController#index`
+   * renders `(@unread || []) + @page.records`, and only populates `@unread`
+   * (up to 100 unread notifications) when the request carries no `page` param.
+   * So the page-less request returns unread items followed by the most recent
+   * read ones, while any `?page=N` returns read notifications only. Read
+   * notifications accumulate for the life of the account, which is why walking
+   * every page here would be both unbounded and wrong.
+   *
+   * Omitting `page` — or passing 1 — issues the page-less request, exactly as
+   * before. Pages 2 and up walk backwards through already-read history.
    * @endpoint GET /:account_slug/notifications
    * @see https://github.com/basecamp/fizzy/blob/main/docs/API.md#get-account_slugnotifications
    */
-  async getNotifications(accountSlug: string): Promise<FizzyNotification[]> {
+  async getNotifications(
+    accountSlug: string,
+    options?: NotificationListOptions
+  ): Promise<FizzyNotification[]> {
     const slug = this.normalizeSlug(accountSlug);
-    return this.request<FizzyNotification[]>(
-      "GET",
-      `/${slug}/notifications`
-    );
+    const requestedPage = options?.page ?? 1;
+
+    // The tool layer validates `page` separately; this defends direct client
+    // callers, the same way getCards does.
+    if (!Number.isSafeInteger(requestedPage) || requestedPage < 1) {
+      throw new Error("page must be a positive integer (1-based)");
+    }
+
+    // Page 1 must stay page-less: `?page=1` is not the same request upstream,
+    // it drops every unread notification from the response.
+    const path =
+      requestedPage === 1
+        ? `/${slug}/notifications`
+        : `/${slug}/notifications?page=${requestedPage}`;
+
+    return this.request<FizzyNotification[]>("GET", path);
   }
 
   /**

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -255,6 +255,10 @@ export type CardFilterOptions = {
 // pagination param (1-based), not a filter.
 export type CardListOptions = CardFilterOptions & { page?: number };
 
+// Options accepted by getNotifications. `page` is the upstream pagination param;
+// see getNotifications for why this endpoint exposes one instead of aggregating.
+export type NotificationListOptions = { page?: number };
+
 // One page of GET /:account_slug/cards. The endpoint is paginated upstream
 // (geared_pagination in offset mode) with a server-controlled, variable page size.
 export interface CardsPage {

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -65,7 +65,9 @@ export const TOOL_DEFINITIONS = {
       title: "List Boards",
       description:
         "Get all boards in a Fizzy account. Returns board details including IDs, names, descriptions, and URLs. " +
-        "Use this to discover available boards before working with cards.",
+        "Use this to discover available boards before working with cards. " +
+        "The result is the complete list: every upstream page is fetched server-side, so there is no page " +
+        "parameter and nothing further to request.",
       schema: schemas.getBoardsSchema,
       annotations: {
         readOnlyHint: true,
@@ -391,6 +393,8 @@ export const TOOL_DEFINITIONS = {
       description:
         "Get all comments on a card in chronological order. Returns comment text (HTML), authors, timestamps, " +
         "and reaction counts. Use this to review discussion and feedback on a card. " +
+        "The result is the complete thread: every upstream page is fetched server-side, so there is no page " +
+        "parameter and nothing further to request. " +
         "Use fields='summary' to drop the duplicated HTML body and the repeated per-comment card/creator " +
         "detail — comment text itself is never truncated in either mode.",
       schema: schemas.getCardCommentsSchema,
@@ -613,7 +617,9 @@ export const TOOL_DEFINITIONS = {
       title: "List Tags",
       description:
         "Get all tags used in an account. Tags are labels for categorizing and organizing cards. " +
-        "Returns tag IDs, titles, and usage counts across cards.",
+        "Returns tag IDs, titles, and usage counts across cards. " +
+        "The result is the complete list: every upstream page is fetched server-side, so there is no page " +
+        "parameter and nothing further to request.",
       schema: schemas.getTagsSchema,
       annotations: {
         readOnlyHint: true,
@@ -629,7 +635,9 @@ export const TOOL_DEFINITIONS = {
       title: "List Users",
       description:
         "Get all active users in an account. Returns user IDs, names, emails, and access levels. " +
-        "Use this to discover available users for card assignments.",
+        "Use this to discover available users for card assignments. " +
+        "The result is the complete roster: every upstream page is fetched server-side, so there is no page " +
+        "parameter and nothing further to request.",
       schema: schemas.getUsersSchema,
       annotations: {
         readOnlyHint: true,
@@ -679,8 +687,14 @@ export const TOOL_DEFINITIONS = {
       name: "fizzy_get_notifications",
       title: "List Notifications",
       description:
-        "Get all notifications for the current user in an account. Returns notification content, " +
+        "Get notifications for the current user in an account. Returns notification content, " +
         "read/unread status, timestamps, and related cards or comments. " +
+        "By default (page omitted) returns up to 100 unread notifications followed by the most recent page " +
+        "of already-read ones — this is what you want for 'what needs my attention'. " +
+        "Pages 2 and up contain ONLY older, already-read notifications; no unread notification ever appears " +
+        "there. To walk back through history, call with page=2, then 3, and so on until the array comes back " +
+        "empty. Page size is server-controlled and variable, so never derive counts or remaining history from " +
+        "the length of a page. " +
         "Use fields='summary' to shrink the embedded card and creator objects down to their key " +
         "identifying fields — typically several times smaller than the full payload.",
       schema: schemas.getNotificationsSchema,

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -46,14 +46,15 @@ function getColumnColorValue(color?: string): string | undefined {
 }
 
 /**
- * Validate the optional 1-based `page` argument of fizzy_get_cards.
+ * Validate the optional 1-based `page` argument shared by fizzy_get_cards and
+ * fizzy_get_notifications.
  *
  * Like the unsupported-filter guard below, this has to run here because the
  * Cloudflare transport executes raw args without zod. Digit strings are accepted
  * because LLM clients routinely send "2"; the stdio path rejects those upstream,
  * and being lenient here costs nothing.
  */
-function parseCardsPage(value: unknown): number | undefined {
+function parsePage(value: unknown): number | undefined {
   if (value === undefined) return undefined;
   if (typeof value === "number" && Number.isSafeInteger(value) && value >= 1) {
     return value;
@@ -254,7 +255,7 @@ export const toolHandlers: Record<string, ToolHandler> = {
       indexed_by: args.indexed_by as CardListOptions["indexed_by"],
       assignee_ids: args.assignee_ids as string[] | undefined,
       tag_ids: args.tag_ids as string[] | undefined,
-      page: parseCardsPage(args.page),
+      page: parsePage(args.page),
     };
     const result = await client.getCards(args.account_slug as string, options);
     if (fieldsMode === "full") return result;
@@ -712,7 +713,14 @@ export const toolHandlers: Record<string, ToolHandler> = {
   // ============ Notification Tools ============
   fizzy_get_notifications: async (client, args) => {
     const fieldsMode = parseFieldsMode(args.fields);
-    const notifications = await client.getNotifications(args.account_slug as string);
+    // Omitted means the client is called exactly as before, with no options
+    // object at all: that selects the page-less upstream request, the only one
+    // that returns unread items.
+    const page = parsePage(args.page);
+    const notifications =
+      page === undefined
+        ? await client.getNotifications(args.account_slug as string)
+        : await client.getNotifications(args.account_slug as string, { page });
     if (fieldsMode === "full") return notifications;
     return notifications.map((notification) =>
       summarizeNotification(notification as unknown as Record<string, unknown>)

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -385,6 +385,17 @@ export const deactivateUserSchema = z.object({
 // Notification schemas
 export const getNotificationsSchema = z.object({
   account_slug: accountSlugSchema,
+  // Same .min(1) reasoning as getCardsSchema.page: .positive() is an exclusive
+  // bound, which zod-to-json-schema renders as draft-04 `exclusiveMinimum: true`
+  // and makes the whole tool list unusable for strict clients.
+  page: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER).optional().describe(
+    "Page of already-read notification history to fetch (1-based). Omit (or pass 1) for the " +
+    "default response: up to 100 unread notifications followed by the most recent page of read " +
+    "ones. Pages 2 and up contain ONLY older, already-read notifications - no unread ones ever " +
+    "appear there. Page size is server-controlled and variable, so never infer counts or how " +
+    "much history is left from how many items a page returns; walk with page=2, 3, ... until " +
+    "the array comes back empty."
+  ),
   fields: fieldsSchema,
 });
 

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -4,7 +4,7 @@
  *
  * Validation lives here rather than in the Zod schema, for two reasons: the
  * Cloudflare transport executes raw arguments without Zod at all — the same
- * reason `parseCardsPage` in tools/handlers.ts validates by hand — and the
+ * reason `parsePage` in tools/handlers.ts validates by hand — and the
  * either/or rules cannot be expressed as Zod refinements without turning the
  * schema into a ZodEffects, which `McpServer.registerTool` publishes to stdio
  * clients as an empty property list. So this is the only place they live.

--- a/src/utils/projections.ts
+++ b/src/utils/projections.ts
@@ -28,7 +28,7 @@ export type FieldsMode = "summary" | "full";
  *
  * This has to exist (not just live in the zod schema) because the Cloudflare
  * transport executes raw args with no zod validation — mirrors the reasoning
- * behind `parseCardsPage` in tools/handlers.ts, and for the same reason: a
+ * behind `parsePage` in tools/handlers.ts, and for the same reason: a
  * bad value must fail loudly here rather than silently falling through to
  * `"full"` on one transport and a zod error on the other.
  */

--- a/tests/client/fizzy-client.test.ts
+++ b/tests/client/fizzy-client.test.ts
@@ -87,6 +87,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { FizzyClient } from "../../src/client/fizzy-client.js";
+import { logger, type LogLevel } from "../../src/utils/logger.js";
 import {
   FizzyAuthError,
   FizzyNotFoundError,
@@ -958,6 +959,304 @@ describe("FizzyClient", () => {
         next_page: 2,
       });
     });
+  });
+
+  /**
+   * List aggregation
+   *
+   * GET /:slug/boards, /:slug/tags, /:slug/users and
+   * /:slug/cards/:number/comments are all paginated upstream with the same
+   * geared_pagination gearing as cards (15, 30, 50, then 100 per page), but
+   * they return bare arrays with no page envelope, so callers had no way to ask
+   * for page 2 and no way to tell they had only been given page 1. These
+   * methods now walk the Link header until it stops advertising rel="next".
+   */
+  describe("List aggregation across pages", () => {
+    const pageResponse = (
+      items: unknown[],
+      headerValues: Record<string, string> = {}
+    ) => {
+      const headers = new Headers();
+      for (const [name, value] of Object.entries(headerValues)) {
+        headers.set(name, value);
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers,
+        json: async () => items,
+      };
+    };
+
+    const nextLink = (page: number) => ({
+      Link: `<https://app.fizzy.do/123/boards?page=${page}>; rel="next"`,
+    });
+
+    it("follows rel=next across pages and concatenates them in order", async () => {
+      mockFetch
+        .mockResolvedValueOnce(pageResponse([{ id: "b1" }, { id: "b2" }], nextLink(2)))
+        .mockResolvedValueOnce(pageResponse([{ id: "b3" }], nextLink(3)))
+        .mockResolvedValueOnce(pageResponse([{ id: "b4" }]));
+
+      const result = await client.getBoards("123");
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(result).toEqual([{ id: "b1" }, { id: "b2" }, { id: "b3" }, { id: "b4" }]);
+    });
+
+    it("requests page 1 with no page param and later pages with one", async () => {
+      mockFetch
+        .mockResolvedValueOnce(pageResponse([{ id: "b1" }], nextLink(2)))
+        .mockResolvedValueOnce(pageResponse([{ id: "b2" }], nextLink(3)))
+        .mockResolvedValueOnce(pageResponse([{ id: "b3" }]));
+
+      await client.getBoards("123");
+
+      expect(mockFetch.mock.calls[0][0]).toBe("https://app.fizzy.do/123/boards");
+      expect(mockFetch.mock.calls[1][0]).toBe("https://app.fizzy.do/123/boards?page=2");
+      expect(mockFetch.mock.calls[2][0]).toBe("https://app.fizzy.do/123/boards?page=3");
+    });
+
+    it("stops after a page whose Link header has no rel=next", async () => {
+      mockFetch.mockResolvedValueOnce(
+        pageResponse([{ id: "b1" }], {
+          Link: '<https://app.fizzy.do/123/boards?page=1>; rel="prev"',
+          "X-Total-Count": "1",
+        })
+      );
+
+      const result = await client.getBoards("123");
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([{ id: "b1" }]);
+    });
+
+    it("stops on an empty page even when the Link header still advertises a next one", async () => {
+      // Upstream keeps emitting rel="next" past the end of the collection, so
+      // the empty page is the only reliable terminator on that path.
+      mockFetch
+        .mockResolvedValueOnce(pageResponse([{ id: "b1" }], nextLink(2)))
+        .mockResolvedValueOnce(pageResponse([], nextLink(3)));
+
+      const result = await client.getBoards("123");
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([{ id: "b1" }]);
+    });
+
+    it("makes a single request when the response carries no pagination headers", async () => {
+      // Absent metadata has to mean "one page", which is what keeps every
+      // pre-existing single-response test (and mock) behaving as before.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [{ id: "b1" }],
+      });
+
+      const result = await client.getBoards("123");
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([{ id: "b1" }]);
+    });
+
+    it("stops at the page cap and warns instead of walking forever", async () => {
+      // A next link on every page (which is what a server bug, or a collection
+      // growing faster than we read it, looks like) must not turn one tool call
+      // into unbounded subrequests - Cloudflare Workers cap those per invocation.
+      for (let page = 1; page <= 40; page++) {
+        mockFetch.mockResolvedValueOnce(
+          pageResponse([{ id: `b${page}` }], nextLink(page + 1))
+        );
+      }
+
+      const previousLevel = (process.env.LOG_LEVEL as LogLevel) || "info";
+      logger.setLevel("warn");
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      let result: unknown[];
+      let warnings: string[];
+      try {
+        // The child logger copies the level at construction time.
+        const cappedClient = new FizzyClient({
+          accessToken: "test-token",
+          baseUrl: "https://app.fizzy.do",
+          maxRetries: 0,
+        });
+        result = await cappedClient.getBoards("123");
+      } finally {
+        // Read the calls before restoring: mockRestore() discards them.
+        warnings = consoleErrorSpy.mock.calls.map((call) => String(call[0]));
+        consoleErrorSpy.mockRestore();
+        logger.setLevel(previousLevel);
+      }
+
+      expect(mockFetch).toHaveBeenCalledTimes(20);
+      expect(result!).toHaveLength(20);
+      expect(warnings!.some((line) => line.includes("page cap"))).toBe(true);
+    });
+
+    it("appends page to a path that already carries a query string", async () => {
+      // None of the aggregated endpoints takes filters today, so this exercises
+      // the helper directly: the separator has to already be right for the first
+      // one that does, and a "?page=2" glued onto an existing query silently
+      // returns page 1 forever.
+      const walk = (
+        client as unknown as {
+          requestAllPages: (path: string) => Promise<unknown[]>;
+        }
+      ).requestAllPages.bind(client);
+
+      mockFetch
+        .mockResolvedValueOnce(pageResponse([{ id: "t1" }], nextLink(2)))
+        .mockResolvedValueOnce(pageResponse([{ id: "t2" }]));
+
+      const result = await walk("/123/tags?q=bug");
+
+      expect(mockFetch.mock.calls[0][0]).toBe("https://app.fizzy.do/123/tags?q=bug");
+      expect(mockFetch.mock.calls[1][0]).toBe(
+        "https://app.fizzy.do/123/tags?q=bug&page=2"
+      );
+      expect(result).toEqual([{ id: "t1" }, { id: "t2" }]);
+    });
+
+    it("keeps walking after a 304 whose cached metadata advertises a next page", async () => {
+      // Page 1 is the page most likely to be served from the ETag cache, and a
+      // 304 that arrives without pagination headers falls back to the metadata
+      // stored with the body - which still has to drive the walk.
+      mockFetch
+        .mockResolvedValueOnce(
+          pageResponse([{ id: "b1" }], { ETag: 'W/"boards1"', ...nextLink(2) })
+        )
+        .mockResolvedValueOnce(pageResponse([{ id: "b2" }]));
+
+      await client.getBoards("123");
+      mockFetch.mockClear();
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 304,
+          headers: new Headers({ ETag: 'W/"boards1"' }),
+        })
+        .mockResolvedValueOnce(pageResponse([{ id: "b2" }]));
+
+      const result = await client.getBoards("123");
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[0][1].headers["If-None-Match"]).toBe('W/"boards1"');
+      expect(result).toEqual([{ id: "b1" }, { id: "b2" }]);
+    });
+
+    it("aggregates tags", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          pageResponse([{ id: "t1" }], {
+            Link: '<https://app.fizzy.do/123/tags?page=2>; rel="next"',
+          })
+        )
+        .mockResolvedValueOnce(pageResponse([{ id: "t2" }]));
+
+      expect(await client.getTags("123")).toEqual([{ id: "t1" }, { id: "t2" }]);
+      expect(mockFetch.mock.calls[1][0]).toBe("https://app.fizzy.do/123/tags?page=2");
+    });
+
+    it("aggregates users", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          pageResponse([{ id: "u1" }], {
+            Link: '<https://app.fizzy.do/123/users?page=2>; rel="next"',
+          })
+        )
+        .mockResolvedValueOnce(pageResponse([{ id: "u2" }]));
+
+      expect(await client.getUsers("123")).toEqual([{ id: "u1" }, { id: "u2" }]);
+      expect(mockFetch.mock.calls[1][0]).toBe("https://app.fizzy.do/123/users?page=2");
+    });
+
+    it("aggregates card comments", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          pageResponse([{ id: "c1" }], {
+            Link: '<https://app.fizzy.do/123/cards/42/comments?page=2>; rel="next"',
+          })
+        )
+        .mockResolvedValueOnce(pageResponse([{ id: "c2" }]));
+
+      expect(await client.getCardComments("123", "42")).toEqual([
+        { id: "c1" },
+        { id: "c2" },
+      ]);
+      expect(mockFetch.mock.calls[1][0]).toBe(
+        "https://app.fizzy.do/123/cards/42/comments?page=2"
+      );
+    });
+  });
+
+  /**
+   * Notifications pagination
+   *
+   * NotificationsController#index renders `(@unread || []) + @page.records`, and
+   * only populates @unread when the request carries no `page` param. So paging
+   * this endpoint is not "more of the same list": page 2 onwards is read-only
+   * history, and aggregating it would grow without bound as notifications are
+   * read. Hence an explicit `page` rather than the walk the other lists get.
+   */
+  describe("Notifications pagination", () => {
+    const listResponse = (items: unknown[], headerValues: Record<string, string> = {}) => {
+      const headers = new Headers();
+      for (const [name, value] of Object.entries(headerValues)) {
+        headers.set(name, value);
+      }
+      return { ok: true, status: 200, headers, json: async () => items };
+    };
+
+    it("requests the bare path when no page is given", async () => {
+      mockFetch.mockResolvedValueOnce(listResponse([{ id: "n1" }]));
+
+      await client.getNotifications("123");
+
+      expect(mockFetch.mock.calls[0][0]).toBe("https://app.fizzy.do/123/notifications");
+    });
+
+    it("requests the bare path for page 1, so the unread block is still returned", async () => {
+      mockFetch.mockResolvedValueOnce(listResponse([{ id: "n1" }]));
+
+      await client.getNotifications("123", { page: 1 });
+
+      expect(mockFetch.mock.calls[0][0]).toBe("https://app.fizzy.do/123/notifications");
+    });
+
+    it("requests ?page=N for later pages", async () => {
+      mockFetch.mockResolvedValueOnce(listResponse([{ id: "n9" }]));
+
+      await client.getNotifications("123", { page: 3 });
+
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        "https://app.fizzy.do/123/notifications?page=3"
+      );
+    });
+
+    it("does not aggregate, even when the response advertises a next page", async () => {
+      mockFetch.mockResolvedValueOnce(
+        listResponse([{ id: "n1" }], {
+          Link: '<https://app.fizzy.do/123/notifications?page=2>; rel="next"',
+        })
+      );
+
+      const result = await client.getNotifications("123");
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([{ id: "n1" }]);
+    });
+
+    it.each([0, -1, 1.5, Number.NaN, 1e100])(
+      "rejects page %p without making a request",
+      async (page) => {
+        await expect(client.getNotifications("123", { page })).rejects.toThrow(
+          /page must be a positive integer/
+        );
+        expect(mockFetch).not.toHaveBeenCalled();
+      }
+    );
   });
 
   /**

--- a/tests/tools/tool-execution.test.ts
+++ b/tests/tools/tool-execution.test.ts
@@ -873,6 +873,56 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
       expect(mockClient.getNotifications).not.toHaveBeenCalled();
     });
 
+    it("passes a notifications page through to the client", async () => {
+      const mockClient = { getNotifications: vi.fn().mockResolvedValue([]) };
+
+      await toolHandlers.fizzy_get_notifications(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+        page: 3,
+      });
+
+      expect(mockClient.getNotifications.mock.calls[0][1]).toEqual({ page: 3 });
+    });
+
+    it("calls the client with no options at all when page is not given", async () => {
+      // The page-less call is the pre-existing one and the only one that returns
+      // unread items, so an omitted page must not turn into an options object.
+      const mockClient = { getNotifications: vi.fn().mockResolvedValue([]) };
+
+      await toolHandlers.fizzy_get_notifications(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+      });
+
+      expect(mockClient.getNotifications).toHaveBeenCalledTimes(1);
+      expect(mockClient.getNotifications.mock.calls[0]).toEqual(["123"]);
+    });
+
+    it("coerces a digit-string notifications page", async () => {
+      const mockClient = { getNotifications: vi.fn().mockResolvedValue([]) };
+
+      await toolHandlers.fizzy_get_notifications(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+        page: "2",
+      });
+
+      expect(mockClient.getNotifications.mock.calls[0][1]).toEqual({ page: 2 });
+    });
+
+    it.each([0, -1, 1.5, "abc"])(
+      "rejects notifications page %p without calling the client",
+      async (page) => {
+        const mockClient = { getNotifications: vi.fn().mockResolvedValue([]) };
+
+        await expect(
+          toolHandlers.fizzy_get_notifications(mockClient as unknown as FizzyClient, {
+            account_slug: "123",
+            page,
+          })
+        ).rejects.toThrow("page must be a positive integer (1-based), e.g. 2");
+        expect(mockClient.getNotifications).not.toHaveBeenCalled();
+      }
+    );
+
     it("rejects a bogus fields value on fizzy_get_pins without calling the client", async () => {
       const mockClient = { getPins: vi.fn().mockResolvedValue([]) };
 


### PR DESCRIPTION
## Problem

Every Fizzy list endpoint is paginated by geared_pagination (page sizes 15, 30, 50, then 100), but only `fizzy_get_cards` read the `Link`/`X-Total-Count` headers. Boards, tags, users, card comments and notifications returned the bare first page and silently dropped everything past it. A card with more than 15 comments looked like a 15-comment card; an account with more than 15 users or boards looked like it had exactly 15.

## Approach

Rather than switching these tools to the page envelope `fizzy_get_cards` uses, which would change the response shape every existing caller receives, the fix keeps every default response shape exactly as it was:

- **Boards, tags, users, card comments** now fetch every upstream page inside the client and return the complete list as the same bare array. Page 1 is requested with the untouched URL, so callers, ETag cache entries and existing mocks behave identically when there is no `Link` header. The walk stops on a page without `rel="next"`, on an empty page (upstream still advertises a next link past the end of a collection), or at a 20-page cap that logs a warning and returns what was collected.
- **Notifications** are not aggregated. Upstream returns up to 100 unread notifications plus the first page of read ones only when the request carries no `page` parameter at all; any `?page=N`, including `page=1`, returns already-read notifications only, and those accumulate for the life of the account. So `fizzy_get_notifications` gains an opt-in `page` argument: omitted or `1` issues the page-less request exactly as before, `2` and up walk back through read history until the array comes back empty. The argument is validated in the shared handler because the Cloudflare transport runs handlers with unvalidated args.
- **Columns** are unchanged. `Boards::ColumnsController#index` renders `@board.columns.sorted` with no pagination call, so the issue's inclusion of columns was mistaken.

Tool descriptions and the README tool tables describe the new behaviour, including the notifications quirk, so an LLM caller does not derive counts from a page's length or expect a `page` parameter where there is none.

## Tests

- Client: multi-page concatenation and ordering, page 1 sent without a `page` parameter and later pages with one, stop on no `rel="next"`, stop on an empty page that still advertises a next link, the 20-page cap and its warning, query-string separator handling, headerless single request, and a 304 on page 1 whose cached pagination metadata still drives the walk; per-method coverage for tags, users and comments; notification page paths and rejection of invalid pages.
- Tools: `fizzy_get_notifications` passes a page through, coerces digit strings, calls the client with no options when the page is omitted, and rejects invalid pages before touching the client.

`npm test` (694), `npm run test:cloudflare` (118), `npm run typecheck`, `npm run typecheck:cf` and `npm run build` all pass.

Fixes #28