### PR TITLE
fix(tools): document that get_cards search OR-matches tokens and is not an existence check

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -245,6 +245,9 @@ export interface FizzyIdentity {
 export type CardFilterOptions = {
   board_ids?: string[];
   column_ids?: string[];
+  // Each element is sanitized upstream (non-word chars except `"` become spaces), stemmed
+  // (which also strips the quotes), and OR-matched word by word in MySQL boolean mode;
+  // separate elements are ANDed. Results follow the filter's sort order, not relevance.
   terms?: string[];
   indexed_by?: "all" | "closed" | "not_now" | "stalled" | "postponing_soon" | "golden";
   assignee_ids?: string[];

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -170,7 +170,12 @@ export const getCardsSchema = z.object({
     "Omit to include cards regardless of tags."
   ),
   search: z.string().optional().describe(
-    "Text search to filter cards by content. Multi-word input is matched as a single search term. " +
+    "Text search over card titles, descriptions and comments. Fizzy splits the input on whitespace " +
+    "and punctuation (hyphens included), stems the words, and OR-matches them; results are ordered " +
+    "by last activity, not relevance. There is no phrase or exact-match syntax, and quotes are ignored. " +
+    "A multi-word or hyphenated query is therefore a broad recall query: total_count > 0 does not " +
+    "prove the exact string exists. For an existence check, search a single distinctive alphanumeric " +
+    "token and confirm the match in the returned cards. " +
     "Omit to return all cards (subject to other filters)."
   ),
   // Use .min(1) rather than .positive(): both mean "page >= 1" for an integer, but


### PR DESCRIPTION
## Summary

Fixes #48.

`fizzy_get_cards`'s `search` description said multi-word input "is matched as a single search term", which reads as a phrase/AND guarantee. The upstream API does the opposite. Verified against `basecamp/fizzy` source:

- `Search::Query#sanitize` replaces every non-word character except `"` with a space, so hyphens become word breaks.
- `Search::Stemmer.stem` then strips the remaining quotes, downcases and stems each word.
- `Search::Record::Trilogy#matching` runs `+account<id> +(word1 word2 ...)` in MySQL boolean mode, which OR-matches the words inside the group.
- `Filter#cards` orders by `sorted_by` (default `latest` = `last_active_at desc`), and `for_query` adds no ordering, so results are **not** relevance-ranked.
- Comments are indexed with the card's `card_id`, so search covers titles, descriptions and comments.

So a hyphenated key present on no card matches most of a board through its common words, and an agent doing search-before-create dedup reads `total_count > 0` as "already tracked". The issue's two open questions are both answered no: results are not ranked, and there is no quoting or exact-match syntax to expose because the stemmer removes the quotes before the `MATCH`.

## Changes

- `src/tools/schemas.ts` — `search` description now states the tokenization and OR semantics, that ordering is by last activity, that quotes are ignored, that a non-zero `total_count` is not evidence a string exists, and points existence checks at a single distinctive token.
- `src/client/types.ts` — comment on `CardListOptions.terms` recording the per-element OR / cross-element AND contract.

Wire format is unchanged (`terms: [search]`). Documentation-only, no behaviour change.

## Notes

- Self-hosted SQLite backends (FTS5) AND implicitly and honour quoted phrases, so semantics differ from app.fizzy.do; the description documents the hosted behaviour.
- Upstream ANDs separate `terms[]` elements, so an opt-in "every token must match" mode is possible. Filed as #49 with the InnoDB stopword / min-token-length caveats that need a live check first.

## Testing

- `vitest run tests/tools`: 207 passed.
- `tsc --noEmit`: clean.
- No test asserted the old description text.