### PR TITLE
feat(tools): add search_mode="all" so get_cards can require every search word

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ npx fizzy-mcp --transport http --port 3000
 ### Cards (6)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_cards` | List cards with optional filters (board, indexed_by, column, assignees, tags, search); `fields="summary"` returns a much smaller payload for browsing |
+| `fizzy_get_cards` | List cards with optional filters (board, indexed_by, column, assignees, tags, search); `search_mode="all"` requires every usable search word instead of any; `fields="summary"` returns a much smaller payload for browsing |
 | `fizzy_get_pins` | List the current user's pinned cards (not paginated, max 100); prefer `fields="summary"` |
 | `fizzy_get_card` | Get card details including description, assignees, tags |
 | `fizzy_create_card` | Create a new card with title, description, status, column, assignees, tags, due date |

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -132,6 +132,9 @@ export const TOOL_DEFINITIONS = {
       description:
         "Get a page of cards in an account with optional filtering by board, indexed_by (e.g., 'golden' for priority cards), " +
         "column, assignees, tags, or search terms. " +
+        "search OR-matches its words by default; set search_mode='all' to require every usable word " +
+        "(stopwords and words under 3 characters are dropped and listed in ignored_search_terms), " +
+        "which is the mode to use when checking whether a card already exists. " +
         "Use board_id to scope results to a specific board and column_id to scope to a workflow column. " +
         "Results are PAGINATED with a server-controlled, variable page size, so never compute a page count " +
         "from the length of one page. " +

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -16,6 +16,7 @@ import {
   type FizzyCard,
 } from "../client/types.js";
 import { resolveCardNumber } from "../utils/card-resolver.js";
+import { splitSearchTerms, type SearchTerms } from "../utils/search-terms.js";
 import { attachmentHtml, resolveAttachment } from "../utils/attachments.js";
 import {
   parseFieldsMode,
@@ -54,6 +55,16 @@ function getColumnColorValue(color?: string): string | undefined {
  * because LLM clients routinely send "2"; the stdio path rejects those upstream,
  * and being lenient here costs nothing.
  */
+// The Cloudflare transport executes raw args without zod validation, so an
+// unknown mode must fail loudly here rather than silently fall back to "any".
+function parseSearchMode(value: unknown): "any" | "all" {
+  if (value === undefined || value === "any") return "any";
+  if (value === "all") return "all";
+  throw new Error(
+    `Invalid search_mode: ${JSON.stringify(value)}. Expected "any" or "all".`
+  );
+}
+
 function parsePage(value: unknown): number | undefined {
   if (value === undefined) return undefined;
   if (typeof value === "number" && Number.isSafeInteger(value) && value >= 1) {
@@ -248,17 +259,43 @@ export const toolHandlers: Record<string, ToolHandler> = {
       );
     }
     const fieldsMode = parseFieldsMode(args.fields);
+    const searchMode = parseSearchMode(args.search_mode);
+    // Upstream ANDs separate terms[] elements and ORs the words inside one, so
+    // "all" sends one element per usable word; "any" keeps the single element.
+    let searchTerms: SearchTerms | undefined;
+    let terms: string[] | undefined;
+    if (searchMode === "all" && typeof args.search === "string") {
+      // An empty or all-stopword search must fail visibly here: falling through
+      // would list every card, which is the opposite of "every word must match".
+      searchTerms = splitSearchTerms(args.search);
+      if (searchTerms.terms.length === 0) {
+        const reason = searchTerms.ignored.length > 0
+          ? `: every word is a full-text stopword or shorter than 3 characters (${searchTerms.ignored.join(", ")})`
+          : "";
+        throw new Error(
+          `search_mode "all" found no searchable word in ${JSON.stringify(args.search)}${reason}. ` +
+          `Use a longer or more distinctive word.`
+        );
+      }
+      terms = searchTerms.terms;
+    } else if (args.search) {
+      terms = [args.search as string];
+    }
     const options: CardListOptions = {
       board_ids: args.board_id ? [args.board_id as string] : undefined,
       column_ids: args.column_id ? [args.column_id as string] : undefined,
-      terms: args.search ? [args.search as string] : undefined,
+      terms,
       indexed_by: args.indexed_by as CardListOptions["indexed_by"],
       assignee_ids: args.assignee_ids as string[] | undefined,
       tag_ids: args.tag_ids as string[] | undefined,
       page: parsePage(args.page),
     };
     const result = await client.getCards(args.account_slug as string, options);
-    if (fieldsMode === "full") return result;
+    // Only search_mode="all" adds fields; the default response shape is unchanged.
+    const searchFields = searchTerms
+      ? { search_terms: searchTerms.terms, ignored_search_terms: searchTerms.ignored }
+      : {};
+    if (fieldsMode === "full") return { ...result, ...searchFields };
     return {
       cards: result.cards.map((card) =>
         summarizeCard(card as unknown as Record<string, unknown>)
@@ -267,6 +304,7 @@ export const toolHandlers: Record<string, ToolHandler> = {
       total_count: result.total_count,
       has_more: result.has_more,
       next_page: result.next_page,
+      ...searchFields,
     };
   },
 

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -174,9 +174,19 @@ export const getCardsSchema = z.object({
     "and punctuation (hyphens included), stems the words, and OR-matches them; results are ordered " +
     "by last activity, not relevance. There is no phrase or exact-match syntax, and quotes are ignored. " +
     "A multi-word or hyphenated query is therefore a broad recall query: total_count > 0 does not " +
-    "prove the exact string exists. For an existence check, search a single distinctive alphanumeric " +
-    "token and confirm the match in the returned cards. " +
+    "prove the exact string exists. For an existence check, set search_mode to 'all' or search a " +
+    "single distinctive alphanumeric token, and confirm the match in the returned cards. " +
     "Omit to return all cards (subject to other filters)."
+  ),
+  search_mode: z.enum(["any", "all"]).optional().describe(
+    "How the words of `search` combine. 'any' (default) sends the whole string as one term, which " +
+    "Fizzy OR-matches word by word. 'all' splits it on whitespace and punctuation and requires every " +
+    "usable word to match, which makes search usable as an existence check before creating a card " +
+    "(still confirm the match in the returned cards: words are stemmed, not matched exactly). In 'all' " +
+    "mode, words shorter than 3 characters and MySQL full-text stopwords (the, to, with, for, ...) are " +
+    "dropped before the request because on their own they match nothing and would empty the result; " +
+    "the response then includes search_terms (sent) and ignored_search_terms (dropped). " +
+    "Errors if no usable word remains. Has no effect without `search`."
   ),
   // Use .min(1) rather than .positive(): both mean "page >= 1" for an integer, but
   // .positive() is an *exclusive* bound, which zod-to-json-schema renders as the

--- a/src/utils/search-terms.ts
+++ b/src/utils/search-terms.ts
@@ -1,0 +1,55 @@
+/**
+ * Splits a `search` string into the separate `terms[]` elements that make
+ * `fizzy_get_cards` require every word (search_mode="all").
+ *
+ * Upstream `Filter#cards` ANDs separate `terms[]` elements but OR-matches the
+ * words inside one element, so sending one element per word turns the API's
+ * broad recall query into an every-word-must-match query.
+ *
+ * Two classes of word must be dropped first. Fizzy's hosted backend is MySQL
+ * with the InnoDB full-text defaults, and an element that consists solely of a
+ * built-in stopword or of a word shorter than `innodb_ft_min_token_size` (3)
+ * matches nothing at all, which would zero the whole AND. Verified live on
+ * 2026-09-02: "the", "to", "with", "for" and "ab" each return 0 cards on their
+ * own, while "and" (not on the list) returns every card.
+ */
+
+/** InnoDB's built-in full-text stopword list (INNODB_FT_DEFAULT_STOPWORD). */
+export const INNODB_STOPWORDS: ReadonlySet<string> = new Set([
+  "a", "about", "an", "are", "as", "at", "be", "by", "com", "de", "en", "for",
+  "from", "how", "i", "in", "is", "it", "la", "of", "on", "or", "that", "the",
+  "this", "to", "was", "what", "when", "where", "who", "will", "with", "und", "www",
+]);
+
+/** InnoDB's default `innodb_ft_min_token_size`. */
+export const MIN_SEARCH_TOKEN_LENGTH = 3;
+
+export interface SearchTerms {
+  /** Words sent to the API, one `terms[]` element each, in input order. */
+  terms: string[];
+  /** Words dropped because the full-text index cannot match them. */
+  ignored: string[];
+}
+
+export function splitSearchTerms(search: string): SearchTerms {
+  // Mirror the upstream pipeline: Search::Query#sanitize turns every character
+  // outside Ruby's ASCII \w ([A-Za-z0-9_]) except `"` into a space, and
+  // Search::Stemmer then replaces the quotes too before the MATCH, so the words
+  // the index actually sees are the [A-Za-z0-9_] runs.
+  const words = search.split(/[^A-Za-z0-9_]+/).filter((word) => word.length > 0);
+  const terms: string[] = [];
+  const ignored: string[] = [];
+  const seen = new Set<string>();
+  for (const word of words) {
+    // Matching is case-insensitive upstream, so "Card" and "card" are one term.
+    const key = word.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (key.length < MIN_SEARCH_TOKEN_LENGTH || INNODB_STOPWORDS.has(key)) {
+      ignored.push(word);
+    } else {
+      terms.push(word);
+    }
+  }
+  return { terms, ignored };
+}

--- a/tests/tools/tool-execution.test.ts
+++ b/tests/tools/tool-execution.test.ts
@@ -626,6 +626,119 @@ describe("Tool Execution Tests (via FizzyClient)", () => {
       });
     });
 
+    it("search_mode='all' sends one terms[] element per usable word and reports what it dropped", async () => {
+      const mockClient = {
+        getCards: vi.fn().mockResolvedValue({
+          cards: [], page: 1, total_count: 0, has_more: false, next_page: null,
+        }),
+      };
+
+      const result = await toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+        search: "prodmon-data-analyst cannot find the package",
+        search_mode: "all",
+      });
+
+      expect(mockClient.getCards.mock.calls[0][1].terms).toEqual([
+        "prodmon", "data", "analyst", "cannot", "find", "package",
+      ]);
+      expect(result).toMatchObject({
+        search_terms: ["prodmon", "data", "analyst", "cannot", "find", "package"],
+        ignored_search_terms: ["the"],
+      });
+    });
+
+    it("search_mode='all' adds the search fields to the summary projection too", async () => {
+      const mockClient = {
+        getCards: vi.fn().mockResolvedValue({
+          cards: [], page: 1, total_count: 0, has_more: false, next_page: null,
+        }),
+      };
+
+      const result = await toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+        search: "nunjucks",
+        search_mode: "all",
+        fields: "summary",
+      });
+
+      expect(result).toEqual({
+        cards: [], page: 1, total_count: 0, has_more: false, next_page: null,
+        search_terms: ["nunjucks"],
+        ignored_search_terms: [],
+      });
+    });
+
+    it("search_mode='any' (and the default) keeps the single terms[] element and adds no fields", async () => {
+      const payload = { cards: [], page: 1, total_count: 0, has_more: false, next_page: null };
+      const mockClient = { getCards: vi.fn().mockResolvedValue(payload) };
+
+      const result = await toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+        search: "urgent task",
+        search_mode: "any",
+      });
+
+      expect(mockClient.getCards.mock.calls[0][1].terms).toEqual(["urgent task"]);
+      expect(result).toEqual(payload);
+    });
+
+    it("omitted search_mode keeps the default summary response shape", async () => {
+      const mockClient = {
+        getCards: vi.fn().mockResolvedValue({
+          cards: [], page: 1, total_count: 0, has_more: false, next_page: null,
+        }),
+      };
+
+      const result = await toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+        account_slug: "123",
+        search: "urgent task",
+        fields: "summary",
+      });
+
+      expect(mockClient.getCards.mock.calls[0][1].terms).toEqual(["urgent task"]);
+      expect(result).toEqual({ cards: [], page: 1, total_count: 0, has_more: false, next_page: null });
+    });
+
+    it("search_mode='all' rejects an empty search instead of listing every card", async () => {
+      const mockClient = { getCards: vi.fn() };
+
+      await expect(
+        toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          search: "",
+          search_mode: "all",
+        })
+      ).rejects.toThrow(/no searchable word in ""/);
+      expect(mockClient.getCards).not.toHaveBeenCalled();
+    });
+
+    it("search_mode='all' rejects a search with no usable word instead of silently returning nothing", async () => {
+      const mockClient = { getCards: vi.fn() };
+
+      await expect(
+        toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          search: "to the ab",
+          search_mode: "all",
+        })
+      ).rejects.toThrow(/no searchable word/);
+      expect(mockClient.getCards).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown search_mode (the Cloudflare path skips zod validation)", async () => {
+      const mockClient = { getCards: vi.fn() };
+
+      await expect(
+        toolHandlers.fizzy_get_cards(mockClient as unknown as FizzyClient, {
+          account_slug: "123",
+          search: "nunjucks",
+          search_mode: "phrase",
+        })
+      ).rejects.toThrow(/Invalid search_mode/);
+      expect(mockClient.getCards).not.toHaveBeenCalled();
+    });
+
     it("passes a requested page through to the client", async () => {
       const mockClient = { getCards: vi.fn().mockResolvedValue({ cards: [] }) };
 

--- a/tests/utils/search-terms.test.ts
+++ b/tests/utils/search-terms.test.ts
@@ -1,0 +1,44 @@
+import { splitSearchTerms, INNODB_STOPWORDS, MIN_SEARCH_TOKEN_LENGTH } from "../../src/utils/search-terms.js";
+
+describe("splitSearchTerms", () => {
+  it("splits on whitespace and punctuation the way upstream Search::Query#sanitize does", () => {
+    expect(splitSearchTerms("prodmon-data-analyst cannot.find/package nunjucks")).toEqual({
+      terms: ["prodmon", "data", "analyst", "cannot", "find", "package", "nunjucks"],
+      ignored: [],
+    });
+  });
+
+  it("splits on double quotes, as the upstream stemmer strips them before matching", () => {
+    expect(splitSearchTerms('"foo bar" baz"qux').terms).toEqual(["foo", "bar", "baz", "qux"]);
+  });
+
+  it("keeps underscores and digits inside a word", () => {
+    expect(splitSearchTerms("reporter_source 2026").terms).toEqual(["reporter_source", "2026"]);
+  });
+
+  it("drops InnoDB stopwords and words shorter than the minimum token size, reporting them", () => {
+    expect(splitSearchTerms("the api to ab with bug")).toEqual({
+      terms: ["api", "bug"],
+      ignored: ["the", "to", "ab", "with"],
+    });
+  });
+
+  it("deduplicates case-insensitively, keeping the first spelling", () => {
+    expect(splitSearchTerms("Card card CARD error")).toEqual({
+      terms: ["Card", "error"],
+      ignored: [],
+    });
+  });
+
+  it("returns no terms for punctuation-only or stopword-only input", () => {
+    expect(splitSearchTerms("--- ...")).toEqual({ terms: [], ignored: [] });
+    expect(splitSearchTerms("the a to")).toEqual({ terms: [], ignored: ["the", "a", "to"] });
+  });
+
+  it("treats every stopword in the list as ignorable", () => {
+    for (const word of INNODB_STOPWORDS) {
+      expect(splitSearchTerms(word).terms).toEqual([]);
+    }
+    expect(MIN_SEARCH_TOKEN_LENGTH).toBe(3);
+  });
+});

--- a/tsconfig.cloudflare.json
+++ b/tsconfig.cloudflare.json
@@ -28,7 +28,8 @@
     "src/utils/base64.ts",
     "src/utils/file-source.ts",
     "src/utils/md5.ts",
-    "src/utils/projections.ts"
+    "src/utils/projections.ts",
+    "src/utils/search-terms.ts"
   ],
   "exclude": ["node_modules", "dist", "tests"]
 }


### PR DESCRIPTION
## Summary

Fixes #49.

Adds an opt-in `search_mode` to `fizzy_get_cards`. The default (`"any"`, or omitted) is unchanged: the whole `search` string goes out as one `terms[]` element, which the Fizzy API OR-matches word by word (#48). `search_mode="all"` splits the string on whitespace and punctuation, the same way upstream `Search::Query#sanitize` does, and sends one `terms[]` element per word. Upstream `Filter#cards` ANDs separate elements, so every word must match. That makes `search` usable as an existence check before creating a card.

## Why the drop rules

app.fizzy.do runs MySQL with the InnoDB full-text defaults. A `terms[]` element that is only a built-in stopword, or shorter than `innodb_ft_min_token_size` (3), matches nothing at all, so ANDing it in would empty every result. Verified live against the API on 2026-09-02:

| lone `terms[]` element | `x-total-count` |
|---|---|
| `and` (not on the InnoDB list) | 339 (every card) |
| `the`, `to`, `for`, `with`, `com`, `und`, `www` | 0 |
| `a`, `ab`, `zz` | 0 |
| `api`, `bug` (three letters) | 128, 152 |
| `card` / `cards` / `CARD` | 77 each (stemmed, case-insensitive) |

So `"all"` mode drops those words before the request, dedupes case-insensitively, and reports what it sent and dropped in two new response fields, `search_terms` and `ignored_search_terms`, present only in that mode. If nothing usable remains (including an empty string) it throws a clear error rather than returning zero cards or every card silently.

## Changes

- `src/utils/search-terms.ts` — new tokenizer with the InnoDB stopword list and minimum token length; added to the Cloudflare tsconfig include.
- `src/tools/schemas.ts` — `search_mode` enum; `search` description now points existence checks at it.
- `src/tools/handlers.ts` — validates `search_mode` in the handler too (the Cloudflare path skips zod), builds the `terms[]` array, and appends the two fields only in `"all"` mode for both `fields` projections.
- `src/tools/definitions.ts`, `README.md` — mention the mode.
- Tests: unit tests for the tokenizer and handler tests covering the split, the drops, the summary projection, the unchanged default path, the no-usable-word error, and an invalid mode.

## Testing

- Unit suite: 700 passed; the 5 failures are the known pre-existing port-3100 transport flakes.
- `tsc --noEmit` and `typecheck:cf`: clean.
- Live smoke test of the built branch against app.fizzy.do: the hyphenated key from #48 (`prodmon-data-analyst-cannot-find-package-nunjucks`) returns 303 cards in `"any"` mode and 0 in `"all"` mode; `"reporterSource the api"` in `"all"` mode returns 12 cards with `the` listed as ignored; the default path's response keys are unchanged.

## Notes

- The AND is over stems, not exact words, so it is still not a phrase match. The description says so.
- Self-hosted SQLite backends (FTS5) already AND implicitly inside one element; `"all"` mode there is redundant but harmless.
