### PR TITLE
chore(ci): add Dependabot version updates and a dependency-review check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  # npm dependencies. Minor and patch bumps are grouped into a single weekly PR;
+  # majors arrive as individual PRs so breaking changes get reviewed on their own.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Workflow actions are SHA-pinned, so without this they silently go stale.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,32 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Fails this check when a PR introduces a runtime dependency carrying a
+      # known advisory -- the gap Dependabot cannot cover, since it only reacts
+      # after a vulnerable dependency is already on main. Results land in the
+      # job summary; no pull-requests: write is needed, so fork PRs work
+      # unchanged.
+      - name: Review dependencies
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate


### PR DESCRIPTION
Rounds out the repository's supply-chain coverage. Two files, no source changes.

## Dependabot version updates (`.github/dependabot.yml`)

Dependabot was enabled for security updates only, so ordinary dependency drift never surfaced. That gap is sharpest for the SHA-pinned actions in `ci.yml`: a pinned digest never reports itself as outdated, so without this the pins quietly rot.

Weekly, for npm and github-actions. Minor and patch bumps are grouped into one PR per ecosystem so routine churn stays reviewable; majors arrive as individual PRs to be looked at on their own. `open-pull-requests-limit: 5` is per ecosystem and counts PRs, so the rollup consumes one slot — and it does not apply to security updates, which continue to bypass the limit.

## Dependency review (`.github/workflows/dependency-review.yml`)

Dependabot is reactive: it can only clean up a vulnerable dependency once it is already on `main`. That matters here because merging to `main` releases to production. This job covers the other direction, failing when a PR would *introduce* a runtime dependency carrying a known advisory at moderate severity or above.

- Triggers on `pull_request`, not `pull_request_target`, so it never runs privileged against untrusted code.
- `permissions: contents: read`, and no PR comment, so it needs no write scope and works unchanged for fork PRs under the read-only token.
- `fail-on-severity: moderate` with the action's default `runtime` scope, so devDependencies do not gate merges.
- `actions/dependency-review-action` is GitHub-owned and full-SHA pinned, matching the repository's Actions policy (`github_owned_allowed: true`, `sha_pinning_required: true`).

The new check is advisory until `dependency-review` is added to the "Require CI" ruleset. That is a follow-up once this run proves the context name.

## Also enabled outside this PR (repository settings)

- **CodeQL code scanning** — default setup, extended query suite, `javascript-typescript` + `actions`, weekly. The initial scan completed and produced three pre-existing alerts, triaged in #53.
- **Secret scanning AI detection** — the one secret-scanning toggle still off.

## Verification

Both files parse as YAML. No source, build, or test surface is touched, so `ci` passing is the relevant signal; this PR's own `dependency-review` run is the first live exercise of the new job.