### PR TITLE
fix(security): scope loopback CORS grants to the configured origin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ npm run start:http    # Streamable HTTP transport (port 3000)
 - `FIZZY_ACCESS_TOKEN` — required for stdio transport
 - `FIZZY_BASE_URL` — API base URL (default: `https://app.fizzy.do`)
 - `MCP_TRANSPORT` — default transport (default: `stdio`)
-- `MCP_ALLOWED_ORIGINS` — CORS origins (default: `*`)
+- `MCP_ALLOWED_ORIGINS` — CORS origins (default: `*`); matched exactly, except that a portless loopback entry matches any port on the same scheme and hostname (`utils/origin.ts`)
 - `MCP_AUTH_TOKEN` — optional client bearer token
 - `LOG_LEVEL` — `debug`/`info`/`warn`/`error` (default: `info`)
 

--- a/README.md
+++ b/README.md
@@ -463,6 +463,11 @@ When using HTTP or SSE transports, additional security options are available:
 | `MCP_AUTH_TOKEN` | No | — | Optional bearer token for Client Authentication (authenticates MCP clients connecting to this server) |
 | `MCP_BIND_ALL_INTERFACES` | No | `false` | Set to `true` to bind to 0.0.0.0 instead of localhost |
 
+Origins are matched exactly. The one convenience is loopback: an entry written
+without a port (`http://localhost`) matches any port on that same scheme and
+hostname, while an entry that pins a port (`http://localhost:3000`) matches only
+that port — and never a different loopback hostname or scheme.
+
 **Multi-User Support:**
 
 SSE and HTTP transports support multiple users simultaneously:

--- a/docs/CLOUDFLARE.md
+++ b/docs/CLOUDFLARE.md
@@ -140,6 +140,11 @@ Configure in `wrangler.jsonc`:
 | `ENABLE_RATE_LIMIT` | No | `true` | Enable/disable rate limiting |
 | `ENABLE_CACHE` | No | `true` | Enable/disable KV caching |
 
+Origins are matched exactly. The one convenience is loopback: an entry written
+without a port (`http://localhost`) matches any port on that same scheme and
+hostname, while an entry that pins a port (`http://localhost:3000`) matches only
+that port — and never a different loopback hostname or scheme.
+
 ### Authentication Model (Multi-User)
 
 **The server does NOT store any Fizzy tokens.** Each client provides their own token:

--- a/src/cloudflare/index.ts
+++ b/src/cloudflare/index.ts
@@ -24,10 +24,11 @@
  * @see https://modelcontextprotocol.io/
  */
 
-import type { Env, ExecutionContext, SecurityResult, HealthResponse } from "./types.js";
+import type { Env, ExecutionContext, HealthResponse } from "./types.js";
 import { SERVER_VERSION } from "./types.js";
 import { RateLimiter, createLogger, createAnalytics, type LogLevel } from "./utils/index.js";
 import { buildWorkerErrorEnvelope } from "./utils/worker-errors.js";
+import { validateSecurity } from "./security.js";
 
 // Re-export Durable Object classes for Wrangler
 export { McpSessionDO } from "./mcp-session.js";
@@ -45,56 +46,6 @@ function extractFizzyToken(request: Request): string | null {
   }
   
   return null;
-}
-
-/**
- * Validate request security (Origin validation)
- */
-function validateSecurity(request: Request, env: Env): SecurityResult {
-  const origin = request.headers.get("Origin");
-  
-  // Parse allowed origins from env
-  const allowedOriginsStr = env.MCP_ALLOWED_ORIGINS || "*";
-  const allowedOrigins = allowedOriginsStr === "*" 
-    ? ["*"] 
-    : allowedOriginsStr.split(",").map(o => o.trim());
-
-  // Validate Origin header
-  if (origin && !allowedOrigins.includes("*")) {
-    const isAllowed = allowedOrigins.some(allowed => {
-      if (allowed === origin) return true;
-      // Check localhost variants with any port
-      try {
-        const originUrl = new URL(origin);
-        const allowedUrl = new URL(allowed);
-        return originUrl.hostname === allowedUrl.hostname && 
-               originUrl.protocol === allowedUrl.protocol;
-      } catch {
-        return false;
-      }
-    });
-
-    if (!isAllowed) {
-      return {
-        allowed: false,
-        statusCode: 403,
-        error: "Origin not allowed",
-        corsOrigin: allowedOrigins[0],
-      };
-    }
-  }
-
-  // Determine CORS origin
-  let corsOrigin: string;
-  if (allowedOrigins.includes("*")) {
-    corsOrigin = "*";
-  } else if (origin && allowedOrigins.includes(origin)) {
-    corsOrigin = origin;
-  } else {
-    corsOrigin = allowedOrigins[0] || "*";
-  }
-
-  return { allowed: true, corsOrigin };
 }
 
 /**

--- a/src/cloudflare/security.ts
+++ b/src/cloudflare/security.ts
@@ -1,0 +1,50 @@
+/**
+ * Request security validation for the Cloudflare Worker
+ *
+ * Kept out of `index.ts` so tests can exercise the real implementation: that
+ * module re-exports the Durable Object classes and pulls in Workers-only
+ * globals, which a Node test runner cannot import.
+ *
+ * Origin matching itself lives in `utils/origin.ts` and is shared with the Node
+ * transports, so both deployments enforce one rule.
+ */
+
+import type { Env, SecurityResult } from "./types.js";
+import { isOriginAllowed } from "../utils/origin.js";
+
+/**
+ * Validate request security (Origin validation)
+ */
+export function validateSecurity(request: Request, env: Env): SecurityResult {
+  const origin = request.headers.get("Origin");
+
+  // Parse allowed origins from env
+  const allowedOriginsStr = env.MCP_ALLOWED_ORIGINS || "*";
+  const allowedOrigins = allowedOriginsStr === "*"
+    ? ["*"]
+    : allowedOriginsStr.split(",").map(o => o.trim());
+
+  // Validate Origin header (same allowlist rules as the Node transports)
+  if (origin && !isOriginAllowed(origin, allowedOrigins)) {
+    return {
+      allowed: false,
+      statusCode: 403,
+      error: "Origin not allowed",
+      corsOrigin: allowedOrigins[0],
+    };
+  }
+
+  // Determine CORS origin
+  let corsOrigin: string;
+  if (allowedOrigins.includes("*")) {
+    corsOrigin = "*";
+  } else if (origin && isOriginAllowed(origin, allowedOrigins)) {
+    // Echo back the caller's origin, not just a verbatim allowlist entry, so a
+    // request allowed by the portless-loopback rule gets a usable CORS header.
+    corsOrigin = origin;
+  } else {
+    corsOrigin = allowedOrigins[0] || "*";
+  }
+
+  return { allowed: true, corsOrigin };
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -12,12 +12,23 @@ const LOG_LEVELS: Record<LogLevel, number> = {
   error: 3,
 };
 
+/**
+ * Escape CR/LF in caller-supplied text so a message can never forge extra log
+ * lines. Each record is a single line; `data` is safe already because
+ * `JSON.stringify` escapes newlines inside the values it serialises.
+ */
+function escapeNewlines(value: string): string {
+  return value.replace(/\n/g, "\\n").replace(/\r/g, "\\r");
+}
+
 class Logger {
   private level: LogLevel;
   private prefix: string;
 
   constructor(prefix = "fizzy-mcp") {
-    this.prefix = prefix;
+    // Escaped here too so the one-record-per-line guarantee holds structurally,
+    // not just for the prefixes this repo happens to pass.
+    this.prefix = escapeNewlines(prefix);
     this.level = (process.env.LOG_LEVEL as LogLevel) || "info";
   }
 
@@ -28,7 +39,7 @@ class Logger {
   private formatMessage(level: LogLevel, message: string, data?: unknown): string {
     const timestamp = new Date().toISOString();
     const dataStr = data ? ` ${JSON.stringify(data)}` : "";
-    return `[${timestamp}] [${this.prefix}] [${level.toUpperCase()}] ${message}${dataStr}`;
+    return `[${timestamp}] [${this.prefix}] [${level.toUpperCase()}] ${escapeNewlines(message)}${dataStr}`;
   }
 
   debug(message: string, data?: unknown): void {

--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -1,0 +1,111 @@
+/**
+ * Origin allowlist matching
+ *
+ * Shared by the Node transports (`utils/security.ts`) and the Cloudflare Worker
+ * (`cloudflare/index.ts`) so both enforce the same rule. A matched origin is
+ * reflected into `Access-Control-Allow-Origin` alongside
+ * `Access-Control-Allow-Credentials: true`, so anything this function allows
+ * gets a credentialed CORS grant.
+ *
+ * Rules, in order:
+ * 1. `"*"` anywhere in the allowlist allows every origin.
+ * 2. An entry that equals the Origin header, or that parses to the same origin
+ *    (scheme, host and port), is allowed.
+ * 3. A loopback entry written without a port (`http://localhost`) allows any
+ *    port on that same scheme and hostname. An entry that pins a port
+ *    (`http://localhost:3000`) allows only that port.
+ *
+ * Rule 3 used to be much broader: a single localhost entry matched every
+ * localhost variant on every port and scheme, so allowing
+ * `http://localhost:3000` also granted `https://127.0.0.1:9999`. On a server
+ * that binds to loopback by default, other local processes are a realistic
+ * origin of attack, so the grant is now limited to what was configured.
+ */
+
+/** Hostnames eligible for the portless wildcard in rule 3. */
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
+
+function parseOrigin(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether an allowlist entry pins a specific port.
+ *
+ * Both answers come from the URL parser, never from reading the raw string:
+ * `URL` accepts non-canonical spellings such as `https:/localhost:3000`, and a
+ * hand-rolled scan of those would see no port while the matcher below sees one,
+ * turning a pinned entry back into an any-port grant.
+ *
+ * The parser alone is not enough either, because it erases a scheme's default
+ * port — `new URL("http://localhost:80").port` is `""`. A default port is
+ * recovered by re-parsing the entry under a scheme that has no default.
+ */
+function hasExplicitPort(entry: string, parsed: URL): boolean {
+  if (parsed.port !== "") {
+    return true;
+  }
+
+  // Feed the probe what the parser itself saw, or the two disagree and a pinned
+  // entry is misread as portless: `URL` deletes tabs and line breaks anywhere in
+  // the input, and treats backslashes as slashes for special schemes (it reads
+  // `http:\\localhost:80` as `http://localhost`), while the probe scheme does
+  // neither.
+  const canonical = entry
+    .trim()
+    .replace(/[\t\n\r]/g, "")
+    .replace(/\\/g, "/")
+    .replace(/^[^:]+:\/*/, "probe://");
+
+  const probe = parseOrigin(canonical);
+  return probe !== null && probe.port !== "";
+}
+
+/**
+ * Check whether an Origin header value is covered by the configured allowlist.
+ */
+export function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
+  // Wildcard allows all
+  if (allowedOrigins.includes("*")) {
+    return true;
+  }
+
+  // Exact match
+  if (allowedOrigins.includes(origin)) {
+    return true;
+  }
+
+  const originUrl = parseOrigin(origin);
+  if (!originUrl) {
+    return false;
+  }
+
+  const originIsLoopback = LOOPBACK_HOSTNAMES.has(originUrl.hostname);
+
+  return allowedOrigins.some(allowed => {
+    const allowedUrl = parseOrigin(allowed);
+    if (!allowedUrl) {
+      return false;
+    }
+
+    // Same origin once both sides are normalised (case, trailing slash, default
+    // port). Opaque origins serialise to the string "null", which would make
+    // every non-special scheme match every other, so they only ever match
+    // verbatim above.
+    if (originUrl.origin !== "null" && originUrl.origin === allowedUrl.origin) {
+      return true;
+    }
+
+    // Portless loopback entry: any port, but the same scheme and hostname.
+    return (
+      originIsLoopback &&
+      !hasExplicitPort(allowed, allowedUrl) &&
+      allowedUrl.protocol === originUrl.protocol &&
+      allowedUrl.hostname === originUrl.hostname
+    );
+  });
+}

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -19,6 +19,7 @@
 
 import { IncomingMessage, ServerResponse } from "node:http";
 import { logger } from "./logger.js";
+import { isOriginAllowed } from "./origin.js";
 
 const log = logger.child("security");
 
@@ -106,60 +107,6 @@ export function resolveSecurityOptions(options: SecurityOptions = {}): SecurityO
     localhostOnly: options.localhostOnly ?? envOptions.localhostOnly ?? true,
     skipHealthCheck: options.skipHealthCheck ?? true,
   };
-}
-
-/**
- * Localhost origins (used when specific localhost origins are configured)
- */
-const LOCALHOST_ORIGINS = [
-  "http://localhost",
-  "http://127.0.0.1",
-  "https://localhost",
-  "https://127.0.0.1",
-];
-
-/**
- * Check if an origin matches the allowed patterns
- * Supports exact match and localhost with any port
- */
-function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
-  // Wildcard allows all
-  if (allowedOrigins.includes("*")) {
-    return true;
-  }
-  
-  // Exact match
-  if (allowedOrigins.includes(origin)) {
-    return true;
-  }
-  
-  // Check localhost with any port
-  try {
-    const url = new URL(origin);
-    const hostWithoutPort = `${url.protocol}//${url.hostname}`;
-    
-    // Check if it's a localhost variant
-    if (LOCALHOST_ORIGINS.includes(hostWithoutPort)) {
-      // Check if base localhost origin is in allowed list
-      return allowedOrigins.some(allowed => {
-        if (LOCALHOST_ORIGINS.includes(allowed)) {
-          return true;
-        }
-        try {
-          const allowedUrl = new URL(allowed);
-          return allowedUrl.hostname === url.hostname && 
-                 allowedUrl.protocol === url.protocol;
-        } catch {
-          return false;
-        }
-      });
-    }
-  } catch {
-    // Invalid URL
-    return false;
-  }
-  
-  return false;
 }
 
 /**

--- a/tests/cloudflare/worker.test.ts
+++ b/tests/cloudflare/worker.test.ts
@@ -12,6 +12,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { validateSecurity } from "../../src/cloudflare/security.js";
+import type { Env as WorkerEnv } from "../../src/cloudflare/types.js";
 
 // Mock types for testing (we can't import actual Cloudflare types in Node.js tests)
 interface MockEnv {
@@ -27,53 +29,38 @@ interface MockEnv {
   };
 }
 
-// Import the security validation logic inline for testing
-// (In production, this would be imported from the worker)
-function validateSecurity(request: Request, env: MockEnv): {
+// The Worker's real origin validation, imported from src/cloudflare/security.ts.
+//
+// The suites below that pass MCP_AUTH_TOKEN use validateSecurityWithProposedAuth
+// instead: src/cloudflare/ never reads MCP_AUTH_TOKEN, so the Worker performs no
+// client authentication and those cases describe behaviour that does not exist
+// yet. They are kept as the specification for that gap, not as coverage of it.
+// Tracked in https://github.com/Fabric-Pro/fizzy-mcp/issues/64.
+function validateSecurityWithProposedAuth(request: Request, env: MockEnv): {
   allowed: boolean;
   statusCode?: number;
   error?: string;
   corsOrigin?: string;
 } {
-  const origin = request.headers.get("Origin");
-  
-  const allowedOriginsStr = env.MCP_ALLOWED_ORIGINS || "*";
-  const allowedOrigins = allowedOriginsStr === "*" 
-    ? ["*"] 
-    : allowedOriginsStr.split(",").map(o => o.trim());
-
-  if (origin && !allowedOrigins.includes("*")) {
-    const isAllowed = allowedOrigins.some(allowed => {
-      if (allowed === origin) return true;
-      try {
-        const originUrl = new URL(origin);
-        const allowedUrl = new URL(allowed);
-        return originUrl.hostname === allowedUrl.hostname && 
-               originUrl.protocol === allowedUrl.protocol;
-      } catch {
-        return false;
-      }
-    });
-
-    if (!isAllowed) {
-      return {
-        allowed: false,
-        statusCode: 403,
-        error: "Origin not allowed",
-        corsOrigin: allowedOrigins[0],
-      };
-    }
+  const originResult = validateSecurity(request, env as unknown as WorkerEnv);
+  if (!originResult.allowed) {
+    return originResult;
   }
 
   if (env.MCP_AUTH_TOKEN) {
     const authHeader = request.headers.get("Authorization");
-    
+    // Auth failures keep the CORS origin the origin check already decided, so
+    // this specification never describes a response more permissive than the
+    // deployed policy (echoing a caller origin under a wildcard allowlist would
+    // pair Access-Control-Allow-Credentials with an unvetted origin).
+    const corsOrigin = originResult.corsOrigin;
+
     if (!authHeader) {
       return {
         allowed: false,
         statusCode: 401,
         error: "Client authentication required",
-        corsOrigin: origin || "*",
+        corsOrigin,
       };
     }
 
@@ -82,31 +69,21 @@ function validateSecurity(request: Request, env: MockEnv): {
         allowed: false,
         statusCode: 401,
         error: "Invalid authentication format. Expected: Bearer <token>",
-        corsOrigin: origin || "*",
+        corsOrigin,
       };
     }
 
-    const token = authHeader.slice(7);
-    if (token !== env.MCP_AUTH_TOKEN) {
+    if (authHeader.slice(7) !== env.MCP_AUTH_TOKEN) {
       return {
         allowed: false,
         statusCode: 401,
         error: "Invalid authentication token",
-        corsOrigin: origin || "*",
+        corsOrigin,
       };
     }
   }
 
-  let corsOrigin: string;
-  if (allowedOrigins.includes("*")) {
-    corsOrigin = "*";
-  } else if (origin && allowedOrigins.includes(origin)) {
-    corsOrigin = origin;
-  } else {
-    corsOrigin = allowedOrigins[0] || "*";
-  }
-
-  return { allowed: true, corsOrigin };
+  return originResult;
 }
 
 describe("Worker Security Validation", () => {
@@ -179,7 +156,19 @@ describe("Worker Security Validation", () => {
       expect(result.corsOrigin).toBe("https://second.com");
     });
 
-    it("should match localhost with different ports", () => {
+    it("should match any localhost port when the entry has no port", () => {
+      const request = new Request("https://example.com/mcp", {
+        headers: { Origin: "http://localhost:3000" },
+      });
+      const env = { ...baseEnv, MCP_ALLOWED_ORIGINS: "http://localhost" };
+      
+      const result = validateSecurity(request, env);
+      
+      expect(result.allowed).toBe(true);
+      expect(result.corsOrigin).toBe("http://localhost:3000");
+    });
+
+    it("should reject other localhost ports when the entry pins a port", () => {
       const request = new Request("https://example.com/mcp", {
         headers: { Origin: "http://localhost:3000" },
       });
@@ -187,7 +176,20 @@ describe("Worker Security Validation", () => {
       
       const result = validateSecurity(request, env);
       
-      expect(result.allowed).toBe(true);
+      expect(result.allowed).toBe(false);
+      expect(result.statusCode).toBe(403);
+    });
+
+    it("should reject another port on an allowed public host", () => {
+      const request = new Request("https://example.com/mcp", {
+        headers: { Origin: "https://myapp.com:8443" },
+      });
+      const env = { ...baseEnv, MCP_ALLOWED_ORIGINS: "https://myapp.com" };
+      
+      const result = validateSecurity(request, env);
+      
+      expect(result.allowed).toBe(false);
+      expect(result.statusCode).toBe(403);
     });
   });
 
@@ -196,7 +198,7 @@ describe("Worker Security Validation", () => {
       const request = new Request("https://example.com/mcp");
       const env = { ...baseEnv };
       
-      const result = validateSecurity(request, env);
+      const result = validateSecurityWithProposedAuth(request, env);
       
       expect(result.allowed).toBe(true);
     });
@@ -205,7 +207,7 @@ describe("Worker Security Validation", () => {
       const request = new Request("https://example.com/mcp");
       const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
       
-      const result = validateSecurity(request, env);
+      const result = validateSecurityWithProposedAuth(request, env);
       
       expect(result.allowed).toBe(false);
       expect(result.statusCode).toBe(401);
@@ -218,7 +220,7 @@ describe("Worker Security Validation", () => {
       });
       const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
       
-      const result = validateSecurity(request, env);
+      const result = validateSecurityWithProposedAuth(request, env);
       
       expect(result.allowed).toBe(false);
       expect(result.statusCode).toBe(401);
@@ -231,7 +233,7 @@ describe("Worker Security Validation", () => {
       });
       const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
       
-      const result = validateSecurity(request, env);
+      const result = validateSecurityWithProposedAuth(request, env);
       
       expect(result.allowed).toBe(false);
       expect(result.statusCode).toBe(401);
@@ -244,7 +246,7 @@ describe("Worker Security Validation", () => {
       });
       const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
       
-      const result = validateSecurity(request, env);
+      const result = validateSecurityWithProposedAuth(request, env);
       
       expect(result.allowed).toBe(true);
     });
@@ -264,7 +266,7 @@ describe("Worker Security Validation", () => {
         MCP_AUTH_TOKEN: "secret",
       };
       
-      const result = validateSecurity(request, env);
+      const result = validateSecurityWithProposedAuth(request, env);
       
       expect(result.allowed).toBe(true);
       expect(result.corsOrigin).toBe("https://allowed.com");
@@ -283,7 +285,7 @@ describe("Worker Security Validation", () => {
         MCP_AUTH_TOKEN: "secret",
       };
       
-      const result = validateSecurity(request, env);
+      const result = validateSecurityWithProposedAuth(request, env);
       
       expect(result.allowed).toBe(false);
       expect(result.statusCode).toBe(403);
@@ -302,7 +304,7 @@ describe("Worker Security Validation", () => {
         MCP_AUTH_TOKEN: "secret",
       };
       
-      const result = validateSecurity(request, env);
+      const result = validateSecurityWithProposedAuth(request, env);
       
       expect(result.allowed).toBe(false);
       expect(result.statusCode).toBe(401);

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Logger } from "../../src/utils/logger.js";
+
+function captureStderr(fn: () => void): string[] {
+  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    fn();
+    return spy.mock.calls.map(call => String(call[0]));
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe("Logger", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes one line per call", () => {
+    const log = new Logger("test");
+    log.setLevel("debug");
+
+    const lines = captureStderr(() => log.info("hello"));
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("[test] [INFO] hello");
+  });
+
+  it("escapes newlines in the message so a caller cannot forge log lines", () => {
+    const log = new Logger("test");
+    log.setLevel("debug");
+    const forged = "rejected\n[2020-01-01T00:00:00.000Z] [test] [INFO] all clear";
+
+    const lines = captureStderr(() => log.warn(forged));
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toContain("\n");
+    expect(lines[0]).toContain("rejected\\n[2020-01-01");
+  });
+
+  it("escapes carriage returns, which can overwrite a rendered line", () => {
+    const log = new Logger("test");
+
+    const lines = captureStderr(() => log.error("bad\r\nspoofed"));
+
+    expect(lines[0]).not.toMatch(/[\r\n]/);
+    expect(lines[0]).toContain("bad\\r\\nspoofed");
+  });
+
+  it("escapes newlines in the prefix as well as the message", () => {
+    const log = new Logger("test\n[forged] [test] [INFO] all clear");
+
+    const lines = captureStderr(() => log.info("real"));
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toMatch(/[\r\n]/);
+  });
+
+  it("escapes newlines in a child sub-prefix", () => {
+    const log = new Logger("test").child("sub\nforged");
+
+    const lines = captureStderr(() => log.info("real"));
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toMatch(/[\r\n]/);
+  });
+
+  it("keeps structured data on the same line", () => {
+    const log = new Logger("test");
+
+    const lines = captureStderr(() => log.info("origin rejected", { origin: "a\nb" }));
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toMatch(/[\r\n]/);
+    expect(lines[0]).toContain('{"origin":"a\\nb"}');
+  });
+
+  it("respects the configured level", () => {
+    const log = new Logger("test");
+    log.setLevel("warn");
+
+    const lines = captureStderr(() => {
+      log.debug("skipped");
+      log.info("skipped");
+      log.warn("kept");
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("kept");
+  });
+
+  it("gives child loggers a sub-prefix and the parent level", () => {
+    const parent = new Logger("test");
+    parent.setLevel("debug");
+    const child = parent.child("security");
+
+    const lines = captureStderr(() => child.debug("checking"));
+
+    expect(lines[0]).toContain("[test:security] [DEBUG] checking");
+  });
+});

--- a/tests/utils/origin.test.ts
+++ b/tests/utils/origin.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { isOriginAllowed } from "../../src/utils/origin.js";
+
+describe("isOriginAllowed", () => {
+  describe("wildcard", () => {
+    it("allows any origin", () => {
+      expect(isOriginAllowed("https://evil.com", ["*"])).toBe(true);
+      expect(isOriginAllowed("http://localhost:9999", ["*"])).toBe(true);
+    });
+
+    it("allows any origin when combined with specific entries", () => {
+      expect(isOriginAllowed("https://evil.com", ["https://myapp.com", "*"])).toBe(true);
+    });
+  });
+
+  describe("exact entries", () => {
+    it("allows an origin that matches an entry verbatim", () => {
+      expect(isOriginAllowed("https://myapp.com", ["https://myapp.com"])).toBe(true);
+    });
+
+    it("allows an origin that matches an entry after normalisation", () => {
+      // Trailing slash, casing and a default port are all formatting noise.
+      expect(isOriginAllowed("https://myapp.com", ["https://myapp.com/"])).toBe(true);
+      expect(isOriginAllowed("https://myapp.com", ["https://MyApp.com"])).toBe(true);
+      expect(isOriginAllowed("https://myapp.com", ["https://myapp.com:443"])).toBe(true);
+    });
+
+    it("rejects an origin that is not in the allowlist", () => {
+      expect(isOriginAllowed("https://evil.com", ["https://myapp.com"])).toBe(false);
+    });
+
+    it("rejects a different port on a non-loopback host", () => {
+      expect(isOriginAllowed("https://myapp.com:8443", ["https://myapp.com"])).toBe(false);
+    });
+
+    it("rejects a subdomain of an allowed host", () => {
+      expect(isOriginAllowed("https://evil.myapp.com", ["https://myapp.com"])).toBe(false);
+    });
+  });
+
+  describe("portless loopback entries", () => {
+    it("allows any port on the configured scheme and hostname", () => {
+      expect(isOriginAllowed("http://localhost:8080", ["http://localhost"])).toBe(true);
+      expect(isOriginAllowed("http://127.0.0.1:8080", ["http://127.0.0.1"])).toBe(true);
+    });
+
+    it("does not cross to another loopback hostname", () => {
+      expect(isOriginAllowed("http://127.0.0.1:8080", ["http://localhost"])).toBe(false);
+      expect(isOriginAllowed("http://localhost:8080", ["http://127.0.0.1"])).toBe(false);
+    });
+
+    it("does not cross to another scheme", () => {
+      expect(isOriginAllowed("https://localhost:8080", ["http://localhost"])).toBe(false);
+    });
+  });
+
+  describe("loopback entries that pin a port", () => {
+    it("allows only that port", () => {
+      expect(isOriginAllowed("http://localhost:3000", ["http://localhost:3000"])).toBe(true);
+      expect(isOriginAllowed("http://localhost:9999", ["http://localhost:3000"])).toBe(false);
+    });
+
+    it("does not grant other loopback variants", () => {
+      const allowlist = ["http://localhost:3000"];
+      expect(isOriginAllowed("https://127.0.0.1:9999", allowlist)).toBe(false);
+      expect(isOriginAllowed("http://127.0.0.1:3000", allowlist)).toBe(false);
+      expect(isOriginAllowed("https://localhost:3000", allowlist)).toBe(false);
+    });
+
+    it("treats a default port as pinned rather than as a wildcard", () => {
+      // URL erases :80, so this only works if the raw entry is inspected.
+      expect(isOriginAllowed("http://localhost:9999", ["http://localhost:80"])).toBe(false);
+      expect(isOriginAllowed("http://localhost", ["http://localhost:80"])).toBe(true);
+    });
+
+    it("reads the port out of non-canonical entries the URL parser still accepts", () => {
+      // `new URL("https:/localhost:3000")` yields port 3000, so the entry is
+      // pinned even though it is written with one slash instead of two.
+      expect(isOriginAllowed("https://localhost:9999", ["https:/localhost:3000"])).toBe(false);
+      expect(isOriginAllowed("https://localhost:9999", ["https:///localhost:3000"])).toBe(false);
+      expect(isOriginAllowed("https://localhost:3000", ["https:/localhost:3000"])).toBe(true);
+    });
+
+    it("reads a default port written with backslashes", () => {
+      // `URL` treats backslashes as slashes for special schemes, so
+      // "http:\\localhost:80" is the host localhost on its default port.
+      expect(isOriginAllowed("http://localhost:9999", ["http:\\\\localhost:80"])).toBe(false);
+      expect(isOriginAllowed("https://localhost:9999", ["https:\\\\localhost:443"])).toBe(false);
+      expect(isOriginAllowed("http://localhost", ["http:\\\\localhost:80"])).toBe(true);
+    });
+
+    it("reads a default port written with tabs or line breaks in the entry", () => {
+      // `URL` deletes these characters before parsing, so the entry is the host
+      // localhost on its default port however oddly it is spelled.
+      expect(isOriginAllowed("http://localhost:9999", ["http:\t//localhost:80"])).toBe(false);
+      expect(isOriginAllowed("http://localhost:9999", ["http:/\n/localhost:80"])).toBe(false);
+    });
+
+    it("does not read a password ending in digits as a port", () => {
+      // The ":80" here is userinfo, so no port is pinned and the entry stays a
+      // portless wildcard.
+      expect(isOriginAllowed("http://localhost:9999", ["http://user:80@localhost"])).toBe(true);
+    });
+
+    it("treats a non-canonical portless entry as a wildcard, as written", () => {
+      expect(isOriginAllowed("http://localhost:9999", ["http:/localhost"])).toBe(true);
+    });
+
+    it("still honours a portless entry listed alongside a pinned one", () => {
+      expect(isOriginAllowed("http://localhost:9999", ["http://localhost:3000", "http://localhost"]))
+        .toBe(true);
+    });
+  });
+
+  describe("malformed and opaque origins", () => {
+    it("rejects an unparseable origin", () => {
+      expect(isOriginAllowed("not a url", ["http://localhost"])).toBe(false);
+      expect(isOriginAllowed("null", ["http://localhost"])).toBe(false);
+    });
+
+    it("ignores unparseable allowlist entries", () => {
+      expect(isOriginAllowed("http://localhost:8080", ["", "not a url", "http://localhost"]))
+        .toBe(true);
+      expect(isOriginAllowed("http://localhost:8080", ["not a url"])).toBe(false);
+    });
+
+    it("does not let opaque origins match each other", () => {
+      // Both serialise to the origin "null"; only a verbatim entry should match.
+      expect(isOriginAllowed("chrome-extension://abc", ["chrome-extension://xyz"])).toBe(false);
+      expect(isOriginAllowed("chrome-extension://abc", ["chrome-extension://abc"])).toBe(true);
+    });
+
+    it("does not read IPv6 colons as a port", () => {
+      expect(isOriginAllowed("http://[::1]:3000", ["http://[::1]:3000"])).toBe(true);
+      expect(isOriginAllowed("http://[::1]:9999", ["http://[::1]:3000"])).toBe(false);
+    });
+
+    it("rejects everything when the allowlist is empty", () => {
+      expect(isOriginAllowed("http://localhost:3000", [])).toBe(false);
+    });
+  });
+});

--- a/tests/utils/security.test.ts
+++ b/tests/utils/security.test.ts
@@ -125,6 +125,28 @@ describe("Security Utilities", () => {
         
         expect(result.allowed).toBe(true);
       });
+
+      it("should reject other localhost ports when a port is configured", async () => {
+        const req = createMockRequest("GET", { origin: "http://localhost:9999" });
+        const options: SecurityOptions = {
+          allowedOrigins: ["http://localhost:3000"],
+        };
+        const result = await validateRequestSecurity(req, options, 3000);
+        
+        expect(result.allowed).toBe(false);
+        expect(result.statusCode).toBe(403);
+      });
+
+      it("should reject other loopback variants when localhost is configured", async () => {
+        const req = createMockRequest("GET", { origin: "https://127.0.0.1:8080" });
+        const options: SecurityOptions = {
+          allowedOrigins: ["http://localhost"],
+        };
+        const result = await validateRequestSecurity(req, options, 3000);
+        
+        expect(result.allowed).toBe(false);
+        expect(result.statusCode).toBe(403);
+      });
     });
 
     describe("Client Authentication", () => {

--- a/tsconfig.cloudflare.json
+++ b/tsconfig.cloudflare.json
@@ -28,6 +28,7 @@
     "src/utils/base64.ts",
     "src/utils/file-source.ts",
     "src/utils/md5.ts",
+    "src/utils/origin.ts",
     "src/utils/projections.ts",
     "src/utils/search-terms.ts"
   ],


### PR DESCRIPTION
Triages the three CodeQL alerts from the initial code scan. Both underlying issues are fixed; the third alert needs a written dismissal (see below).

## The CORS grant was wider than "localhost with any port"

`isOriginAllowed` special-cased loopback so that *any* localhost entry in the allowlist matched *every* localhost variant, on every port and scheme. Configuring `http://localhost:3000` therefore also handed `https://127.0.0.1:9999` a credentialed CORS grant. The default allowlist is `["*"]`, so this only ever affected deliberately-restricted configurations — but those are exactly the ones that asked for a boundary, and the server binds to loopback by default, which puts other local processes in the threat model.

The rule is now:

| Allowlist entry | `http://localhost:3000` | `http://localhost:9999` | `https://127.0.0.1:9999` |
|---|---|---|---|
| `http://localhost` | allow | allow | **deny** (was allow) |
| `http://localhost:3000` | allow | **deny** (was allow) | **deny** (was allow) |

A portless loopback entry keeps matching any port on the same scheme and hostname — that is the documented convenience, and the only part of the old behavior operators rely on.

### Why the port check is not a one-liner

`URL` erases a scheme's default port, so `new URL("http://localhost:80").port` is `""` — indistinguishable from a genuinely portless entry. That information survives only in the raw string. But reading the raw string invites the opposite failure: the parser accepts spellings the matcher and a hand-rolled scan read *differently* (`https:/localhost:3000`, `http:\\localhost:80`, `"http:\t//localhost:80"`), and any such disagreement silently downgrades a pinned entry back to an any-port wildcard.

`hasExplicitPort` therefore normalises the entry the way the parser does — deleting tab/LF/CR, treating backslashes as slashes — and re-parses it under a scheme that has no default port. A differential check over both directions (default-port spellings that must read as pinned, portless spellings that must not) found no remaining divergence.

## One matcher for both deployments

The Cloudflare Worker carried its own copy that ignored the port for *every* host, not just loopback, so `https://myapp.com` matched `https://myapp.com:8443`. Both now call `src/utils/origin.ts`.

`validateSecurity` also moved out of `src/cloudflare/index.ts` into `src/cloudflare/security.ts`, because `tests/cloudflare/worker.test.ts` was asserting against a local reimplementation and could not catch a regression in the Worker itself. The origin tests now import the real function — verified by mutation: reverting the CORS echo to the old exact-only form fails a test.

The Worker also echoed `allowedOrigins[0]` instead of the caller's origin whenever a request was allowed by the loose rule, so the header did not match the requesting origin. It now echoes the validated origin.

## Log injection

`formatMessage` escapes CR/LF in the message, so one record stays one line. The prefix is escaped as well; every prefix in the repo is a hardcoded literal today, so that closes a latent path rather than a live one. Structured `data` was already safe — `JSON.stringify` escapes newlines inside serialised values.

## Alert dispositions

- `js/log-injection` (2 alerts) — fixed here; they should close on the next scan.
- `js/cors-misconfiguration-for-credentials` — the underlying breadth is fixed, but the alert flags the request-header → `Access-Control-Allow-Origin` + credentials dataflow itself, which remains by design for a validated allowlist. It needs a dismissal with the reasoning recorded once this lands.

## Follow-up filed

#64 — the Worker reads `MCP_AUTH_TOKEN` nowhere in `src/cloudflare/`, so it performs no client authentication despite `docs/CLOUDFLARE.md` documenting the variable. The worker test's bearer-token suites were passing against their own mock; they now call a clearly-named `validateSecurityWithProposedAuth` helper labelled as a specification for that gap rather than coverage of it.

## Verification

`npm test` 742 passed · `npm run test:cloudflare` 120 passed · `npm run typecheck`, `npm run typecheck:cf` and `npm run build` clean. (`npm run lint` cannot run in this environment — `eslint: command not found`, pre-existing.)

Fixes #53