### PR TITLE
fix(security): enforce MCP_AUTH_TOKEN on the Cloudflare Worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ npm run start:http    # Streamable HTTP transport (port 3000)
 - `FIZZY_BASE_URL` — API base URL (default: `https://app.fizzy.do`)
 - `MCP_TRANSPORT` — default transport (default: `stdio`)
 - `MCP_ALLOWED_ORIGINS` — CORS origins (default: `*`); matched exactly, except that a portless loopback entry matches any port on the same scheme and hostname (`utils/origin.ts`)
-- `MCP_AUTH_TOKEN` — optional client bearer token
+- `MCP_AUTH_TOKEN` — optional server-level client-auth token; clients send it bare in the `X-MCP-Auth-Token` header (`utils/client-auth.ts`), kept off `Authorization` because that carries the per-user Fizzy token. Node transports also still accept `Authorization: Bearer <token>` as a fallback; the Worker does not
 - `LOG_LEVEL` — `debug`/`info`/`warn`/`error` (default: `info`)
 
 ## Code Conventions

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Supports HTTP transport only:
 - Multiple users can connect simultaneously
 - Each session is isolated with its own FizzyClient instance
 - Sessions timeout after 30 minutes of inactivity
-- Optional server-level authentication via `MCP_AUTH_TOKEN` environment variable
+- Optional server-level authentication via `MCP_AUTH_TOKEN` environment variable (clients send it in the `X-MCP-Auth-Token` header)
 
 ## Prerequisites
 
@@ -460,7 +460,7 @@ When using HTTP or SSE transports, additional security options are available:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MCP_ALLOWED_ORIGINS` | No | `*` | Allowed CORS origins (comma-separated or `*` for all) |
-| `MCP_AUTH_TOKEN` | No | — | Optional bearer token for Client Authentication (authenticates MCP clients connecting to this server) |
+| `MCP_AUTH_TOKEN` | No | — | Optional shared token for Client Authentication (authenticates MCP clients connecting to this server). Clients send it bare in the `X-MCP-Auth-Token` header; `Authorization: Bearer <token>` is still accepted for compatibility but collides with the per-user Fizzy token |
 | `MCP_BIND_ALL_INTERFACES` | No | `false` | Set to `true` to bind to 0.0.0.0 instead of localhost |
 
 Origins are matched exactly. The one convenience is loopback: an entry written
@@ -491,7 +491,8 @@ npx fizzy-mcp --transport http --port 3000
 MCP_ALLOWED_ORIGINS="http://localhost:3000,https://myapp.com" \
 npx fizzy-mcp --transport http --port 3000
 
-# Enable Client Authentication (require MCP clients to provide a bearer token)
+# Enable Client Authentication (require MCP clients to present a shared token)
+# Clients then send it as: X-MCP-Auth-Token: my-secret-token
 MCP_AUTH_TOKEN="my-secret-token" \
 npx fizzy-mcp --transport http --port 3000
 
@@ -503,8 +504,19 @@ npx fizzy-mcp --transport http --port 3000
 ```
 
 > ⚠️ **Authentication Types:**
-> - **User Authentication** (via `Authorization` header): Required for SSE/HTTP transports. Each user provides their own Fizzy Personal Access Token.
-> - **Client Authentication** (`MCP_AUTH_TOKEN`): Optional. Authenticates MCP clients (like IDE extensions) connecting to this server.
+> - **User Authentication** (via `Authorization` header): Required for SSE/HTTP transports. Each user provides their own Fizzy Personal Access Token. On the Cloudflare Worker, `Authorization` is *only* ever read as this token; the Node transports also read it as the client token in the compatibility mode described below, which is why that mode should not be used for new deployments.
+> - **Client Authentication** (`MCP_AUTH_TOKEN`, via the `X-MCP-Auth-Token` header): Optional. Authenticates MCP clients (like IDE extensions) connecting to this server. Sent as the bare token, with no `Bearer ` prefix, so it never competes with the Fizzy token above:
+>
+>   ```json
+>   {
+>     "headers": {
+>       "Authorization": "Bearer YOUR_FIZZY_PERSONAL_ACCESS_TOKEN",
+>       "X-MCP-Auth-Token": "YOUR_MCP_AUTH_TOKEN"
+>     }
+>   }
+>   ```
+>
+>   For compatibility, the Node HTTP/SSE transports also still accept the client token as `Authorization: Bearer <MCP_AUTH_TOKEN>` when no `X-MCP-Auth-Token` header is present. That mode consumes the header the per-user Fizzy token needs, so don't use it for new deployments. The Cloudflare Worker accepts `X-MCP-Auth-Token` only.
 >
 > **Note:** For stdio transport, use `FIZZY_ACCESS_TOKEN` environment variable (single-user mode for CLI/IDE integrations).
 

--- a/docs/CLOUDFLARE.md
+++ b/docs/CLOUDFLARE.md
@@ -450,11 +450,50 @@ Authorization: Bearer <fizzy-personal-access-token>
    - Authenticates requests to Fizzy API
    - Provides complete session isolation between users
 
-2. **Client Authentication** (`MCP_AUTH_TOKEN`):
+2. **Client Authentication** (`MCP_AUTH_TOKEN`, via the `X-MCP-Auth-Token` header):
    - **Optional** but recommended for public deployments
-   - Requires MCP clients (like IDE extensions) to provide a server-level bearer token
+   - Requires MCP clients (like IDE extensions) to present a server-level shared token
    - Prevents unauthorized MCP clients from connecting to your server
-   - Independent of user authentication
+   - Independent of user authentication — the two layers use different headers,
+     which is what makes them usable at the same time
+   - Sent as the **bare token**, with no `Bearer ` prefix:
+
+     ```
+     X-MCP-Auth-Token: <mcp-auth-token>
+     ```
+
+   - The Worker accepts this header only. Putting the client token on
+     `Authorization` would collide with the per-user Fizzy token above and be
+     rejected as a missing client token.
+
+Both headers together, in a client config:
+
+```json
+{
+  "mcpServers": {
+    "fizzy": {
+      "url": "https://fizzy-mcp.your-subdomain.workers.dev/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_FIZZY_PERSONAL_ACCESS_TOKEN",
+        "X-MCP-Auth-Token": "YOUR_MCP_AUTH_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Set the token as a secret, never as a plaintext `vars` entry — `wrangler.jsonc`
+is committed:
+
+```bash
+wrangler secret put MCP_AUTH_TOKEN
+```
+
+> **Node HTTP/SSE deployments** accept the same `X-MCP-Auth-Token` header, and
+> that is the recommended way to configure them. They also still accept
+> `Authorization: Bearer <MCP_AUTH_TOKEN>` for backwards compatibility, but that
+> mode consumes the header the per-user Fizzy token needs, so do not use it for
+> new deployments.
 
 ### CORS Configuration
 
@@ -479,7 +518,7 @@ The deployment automatically includes security headers on all responses:
 
 ### Best Practices
 
-1. **Always set `MCP_AUTH_TOKEN`** for public deployments
+1. **Always set `MCP_AUTH_TOKEN`** for public deployments — via `wrangler secret put MCP_AUTH_TOKEN`, and have clients send it on `X-MCP-Auth-Token`
 2. **Restrict `MCP_ALLOWED_ORIGINS`** to known clients
 3. **Use read-only Fizzy tokens** if write access isn't needed
 4. **Monitor access logs** via Cloudflare Dashboard
@@ -593,9 +632,32 @@ Get your token from [app.fizzy.do](https://app.fizzy.do) → Profile → API →
 
 ### "Client authentication required"
 
-**Cause**: Server has `MCP_AUTH_TOKEN` configured but client didn't provide it.
+**Cause**: Server has `MCP_AUTH_TOKEN` configured but the client sent no
+`X-MCP-Auth-Token` header. Sending the client token on `Authorization` instead
+produces this same error — that header is read as your per-user Fizzy token, so
+the Worker sees no client token at all.
 
-**Solution**: This is different from user authentication. If the server requires client authentication, contact the server administrator for the MCP auth token.
+**Solution**: This is different from user authentication. Send the client token
+in its own header, alongside your Fizzy token:
+
+```json
+{
+  "headers": {
+    "Authorization": "Bearer YOUR_FIZZY_PERSONAL_ACCESS_TOKEN",
+    "X-MCP-Auth-Token": "YOUR_MCP_AUTH_TOKEN"
+  }
+}
+```
+
+If you don't have the MCP auth token, contact the server administrator.
+
+### "Invalid client authentication token"
+
+**Cause**: The `X-MCP-Auth-Token` header was sent but doesn't match the server's
+`MCP_AUTH_TOKEN`.
+
+**Solution**: Check the value with the server administrator. Note that it is the
+bare token — no `Bearer ` prefix, unlike the `Authorization` header.
 
 ### "Origin not allowed"
 

--- a/src/cloudflare/headers.ts
+++ b/src/cloudflare/headers.ts
@@ -1,0 +1,51 @@
+/**
+ * Response header helpers for the Cloudflare Worker
+ *
+ * Kept out of `index.ts` for the same reason `security.ts` is: that module
+ * re-exports the Durable Object classes and pulls in Workers-only globals, so a
+ * Node test runner cannot import it. Living here, these are exercised by the
+ * real tests rather than by a copy of themselves — the CORS allowlist below is
+ * exactly the kind of thing a reimplemented test would keep passing on after
+ * the production copy drifted.
+ */
+
+import { CLIENT_AUTH_HEADER } from "../utils/client-auth.js";
+
+/**
+ * Set CORS headers on response
+ *
+ * @see https://developers.cloudflare.com/workers/examples/cors-header-proxy/
+ */
+export function setCorsHeaders(headers: Headers, corsOrigin: string): void {
+  headers.set("Access-Control-Allow-Origin", corsOrigin);
+  headers.set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+  // X-MCP-Auth-Token must be listed or browsers strip the client-auth header
+  // from cross-origin requests, and the Worker sees no token at all.
+  headers.set(
+    "Access-Control-Allow-Headers",
+    `Content-Type, Authorization, mcp-session-id, ${CLIENT_AUTH_HEADER}`
+  );
+  headers.set("Access-Control-Expose-Headers", "mcp-session-id");
+  headers.set("Access-Control-Max-Age", "86400"); // 24 hours - reduces preflight requests
+
+  if (corsOrigin !== "*") {
+    headers.set("Access-Control-Allow-Credentials", "true");
+  }
+}
+
+/**
+ * Set security headers on response
+ *
+ * @see https://developers.cloudflare.com/workers/examples/security-headers/
+ */
+export function setSecurityHeaders(headers: Headers): void {
+  // Prevent MIME type sniffing
+  headers.set("X-Content-Type-Options", "nosniff");
+
+  // Prevent clickjacking by disallowing embedding in iframes
+  headers.set("X-Frame-Options", "DENY");
+
+  // Additional security headers for best practices
+  headers.set("X-XSS-Protection", "1; mode=block");
+  headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+}

--- a/src/cloudflare/index.ts
+++ b/src/cloudflare/index.ts
@@ -7,7 +7,7 @@
  * - HTTP Streamable transport (/mcp endpoint)
  * - Health checks (/health endpoint)
  * - CORS preflight requests
- * - Security validation (Origin)
+ * - Security validation (Origin, optional client auth via X-MCP-Auth-Token)
  * - Multi-user authentication via Authorization header
  * - Session routing via Durable Objects
  * - Rate limiting (optional, via RATE_LIMITER binding)
@@ -19,6 +19,12 @@
  * - Token is sent via Authorization: Bearer <fizzy-token> header
  * - The server does NOT store any Fizzy tokens
  * - Each request is authenticated against the Fizzy API using the client's token
+ *
+ * Client Authentication (optional, MCP_AUTH_TOKEN):
+ * - A server-level shared secret gating which clients may connect at all
+ * - Sent bare on X-MCP-Auth-Token, deliberately NOT on Authorization, which is
+ *   already the per-user Fizzy token — see utils/client-auth.ts
+ * - Enforced in validateSecurity(); /health and OPTIONS stay exempt below
  * 
  * @see https://developers.cloudflare.com/workers/
  * @see https://modelcontextprotocol.io/
@@ -29,6 +35,7 @@ import { SERVER_VERSION } from "./types.js";
 import { RateLimiter, createLogger, createAnalytics, type LogLevel } from "./utils/index.js";
 import { buildWorkerErrorEnvelope } from "./utils/worker-errors.js";
 import { validateSecurity } from "./security.js";
+import { setCorsHeaders, setSecurityHeaders } from "./headers.js";
 
 // Re-export Durable Object classes for Wrangler
 export { McpSessionDO } from "./mcp-session.js";
@@ -46,40 +53,6 @@ function extractFizzyToken(request: Request): string | null {
   }
   
   return null;
-}
-
-/**
- * Set CORS headers on response
- *
- * @see https://developers.cloudflare.com/workers/examples/cors-header-proxy/
- */
-function setCorsHeaders(headers: Headers, corsOrigin: string): void {
-  headers.set("Access-Control-Allow-Origin", corsOrigin);
-  headers.set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-  headers.set("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-session-id");
-  headers.set("Access-Control-Expose-Headers", "mcp-session-id");
-  headers.set("Access-Control-Max-Age", "86400"); // 24 hours - reduces preflight requests
-
-  if (corsOrigin !== "*") {
-    headers.set("Access-Control-Allow-Credentials", "true");
-  }
-}
-
-/**
- * Set security headers on response
- *
- * @see https://developers.cloudflare.com/workers/examples/security-headers/
- */
-function setSecurityHeaders(headers: Headers): void {
-  // Prevent MIME type sniffing
-  headers.set("X-Content-Type-Options", "nosniff");
-
-  // Prevent clickjacking by disallowing embedding in iframes
-  headers.set("X-Frame-Options", "DENY");
-
-  // Additional security headers for best practices
-  headers.set("X-XSS-Protection", "1; mode=block");
-  headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
 }
 
 /**
@@ -258,6 +231,11 @@ export default {
       }
 
       // Handle health check (skip security for monitoring)
+      //
+      // `allowed` is deliberately ignored: validateSecurity is called only for
+      // the CORS origin it computes. /health must answer uptime monitors that
+      // hold no client token, which is also what the Node transports do by
+      // default (`skipHealthCheck: true` in utils/security.ts).
       if (path === "/health" && request.method === "GET") {
         const security = validateSecurity(request, env);
         return handleHealth(security.corsOrigin || "*", env);
@@ -267,6 +245,12 @@ export default {
       const security = validateSecurity(request, env);
 
       // Handle CORS preflight
+      //
+      // This returns *before* the `security.allowed` check below, and must keep
+      // doing so. Browsers send no custom headers on a preflight, so a request
+      // that would be perfectly authenticated arrives here with no
+      // X-MCP-Auth-Token; failing it would break every browser client before it
+      // ever got to send the real request.
       if (request.method === "OPTIONS") {
         return handleOptions(security.corsOrigin || "*");
       }

--- a/src/cloudflare/mcp-session.ts
+++ b/src/cloudflare/mcp-session.ts
@@ -41,6 +41,7 @@ import {
   type McpToolDefinition,
 } from "../tools/json-schema.js";
 import { executeToolHandler } from "../tools/handlers.js";
+import { CLIENT_AUTH_HEADER } from "../utils/client-auth.js";
 
 /**
  * Session timeout in milliseconds (30 minutes)
@@ -425,7 +426,7 @@ export class McpSessionDO extends DurableObject<Env> {
       headers: {
         "Access-Control-Allow-Origin": origin,
         "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type, Authorization, mcp-session-id",
+        "Access-Control-Allow-Headers": `Content-Type, Authorization, mcp-session-id, ${CLIENT_AUTH_HEADER}`,
         "Access-Control-Max-Age": "86400",
       },
     });

--- a/src/cloudflare/security.ts
+++ b/src/cloudflare/security.ts
@@ -6,14 +6,21 @@
  * globals, which a Node test runner cannot import.
  *
  * Origin matching itself lives in `utils/origin.ts` and is shared with the Node
- * transports, so both deployments enforce one rule.
+ * transports, so both deployments enforce one rule. Client authentication is
+ * shared the same way, via `utils/client-auth.ts`.
  */
 
 import type { Env, SecurityResult } from "./types.js";
 import { isOriginAllowed } from "../utils/origin.js";
+import {
+  CLIENT_AUTH_HEADER,
+  CLIENT_AUTH_INVALID_ERROR,
+  CLIENT_AUTH_REQUIRED_ERROR,
+  timingSafeEqualString,
+} from "../utils/client-auth.js";
 
 /**
- * Validate request security (Origin validation)
+ * Validate request security (Origin validation, then client authentication)
  */
 export function validateSecurity(request: Request, env: Env): SecurityResult {
   const origin = request.headers.get("Origin");
@@ -34,7 +41,12 @@ export function validateSecurity(request: Request, env: Env): SecurityResult {
     };
   }
 
-  // Determine CORS origin
+  // Determine CORS origin. Computed before the auth check so a 401 can carry it
+  // too — without it a browser cannot read the error body and the client sees an
+  // opaque network failure instead of "your token is wrong". It is the same
+  // value the success path returns, never a more permissive one: echoing the
+  // caller's origin on a request the allowlist has not vetted would pair
+  // Access-Control-Allow-Credentials with an arbitrary origin.
   let corsOrigin: string;
   if (allowedOrigins.includes("*")) {
     corsOrigin = "*";
@@ -44,6 +56,34 @@ export function validateSecurity(request: Request, env: Env): SecurityResult {
     corsOrigin = origin;
   } else {
     corsOrigin = allowedOrigins[0] || "*";
+  }
+
+  // Validate client authentication, when the operator configured a token.
+  //
+  // The token arrives on its own header, bare, because `Authorization` is
+  // already spoken for: `extractFizzyToken` in index.ts reads it as the caller's
+  // Fizzy Personal Access Token. Enforcing client auth there would make the two
+  // layers mutually exclusive rather than independent. See utils/client-auth.ts.
+  if (env.MCP_AUTH_TOKEN) {
+    const clientToken = request.headers.get(CLIENT_AUTH_HEADER);
+
+    if (!clientToken) {
+      return {
+        allowed: false,
+        statusCode: 401,
+        error: CLIENT_AUTH_REQUIRED_ERROR,
+        corsOrigin,
+      };
+    }
+
+    if (!timingSafeEqualString(clientToken, env.MCP_AUTH_TOKEN)) {
+      return {
+        allowed: false,
+        statusCode: 401,
+        error: CLIENT_AUTH_INVALID_ERROR,
+        corsOrigin,
+      };
+    }
   }
 
   return { allowed: true, corsOrigin };

--- a/src/cloudflare/types.ts
+++ b/src/cloudflare/types.ts
@@ -43,6 +43,24 @@ export interface Env {
   MCP_ALLOWED_ORIGINS?: string;
 
   /**
+   * Client authentication token — a server-level shared secret gating which
+   * clients may connect at all. Clients present it in the `X-MCP-Auth-Token`
+   * header, as the bare value with no `Bearer ` prefix.
+   *
+   * This is NOT the per-user Fizzy Personal Access Token: that stays on
+   * `Authorization: Bearer <fizzy-pat>` and authenticates the caller against
+   * the Fizzy API. The two layers are independent precisely because they use
+   * different headers.
+   *
+   * Set it with `wrangler secret put MCP_AUTH_TOKEN`, never as a plaintext
+   * `vars` entry — `wrangler.jsonc` is committed, and a secret in it is a
+   * secret in the repository.
+   *
+   * Default: unset (no client authentication)
+   */
+  MCP_AUTH_TOKEN?: string;
+
+  /**
    * Rate limit: requests per minute per user
    * Default: 100
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,10 @@ Environment Variables:
 
 Security (HTTP/SSE transports):
   MCP_ALLOWED_ORIGINS     Allowed CORS origins (comma-separated, or "*" for all)
-  MCP_AUTH_TOKEN          Bearer token for client authentication (optional)
+  MCP_AUTH_TOKEN          Shared token for client authentication (optional).
+                          Clients send it bare in the X-MCP-Auth-Token header;
+                          Authorization: Bearer <token> still works but collides
+                          with the per-user Fizzy token on that same header.
   MCP_BIND_ALL_INTERFACES Set to "true" to bind to 0.0.0.0 (not recommended)
 
 Multi-User Support (HTTP/SSE):

--- a/src/utils/client-auth.ts
+++ b/src/utils/client-auth.ts
@@ -1,0 +1,81 @@
+/**
+ * Client authentication (`MCP_AUTH_TOKEN`)
+ *
+ * Shared by the Node transports (`utils/security.ts`) and the Cloudflare Worker
+ * (`cloudflare/security.ts`) so both deployments name the same header and
+ * report the same errors.
+ *
+ * `MCP_AUTH_TOKEN` is a *server-level* shared secret that decides which clients
+ * may connect at all. It is not the per-user Fizzy Personal Access Token, which
+ * travels on `Authorization: Bearer <fizzy-pat>` and authenticates the caller
+ * against the Fizzy API.
+ *
+ * Those two layers only stay independent if they use different headers, so
+ * client auth gets a dedicated one: `X-MCP-Auth-Token`, carrying the bare token
+ * with no `Bearer ` prefix. Putting it on `Authorization` instead would make the
+ * layers mutually exclusive — the Worker reads that header as the Fizzy PAT
+ * (`cloudflare/index.ts`), so every client sending its own PAT would be
+ * rejected as an invalid client token. The Node transports have exactly that
+ * collision today; they keep accepting `Authorization: Bearer <MCP_AUTH_TOKEN>`
+ * for compatibility, but the dedicated header takes precedence there and is the
+ * only mode the Worker accepts.
+ */
+
+/** Header carrying the client-auth token (bare value, no `Bearer ` prefix). */
+export const CLIENT_AUTH_HEADER = "X-MCP-Auth-Token";
+
+/**
+ * Lowercased spelling of {@link CLIENT_AUTH_HEADER}.
+ *
+ * Node's `IncomingMessage.headers` is keyed by lowercased name, unlike the
+ * Fetch `Headers` object the Worker uses, which is case-insensitive.
+ */
+export const CLIENT_AUTH_HEADER_LOWER = "x-mcp-auth-token";
+
+/** No client token was presented while `MCP_AUTH_TOKEN` is configured. */
+export const CLIENT_AUTH_REQUIRED_ERROR = "Client authentication required";
+
+/**
+ * A client token was presented in a shape this server cannot read.
+ *
+ * Only reachable through the Node transports' legacy `Authorization` fallback —
+ * the dedicated header carries a bare value, so there is no format to get wrong.
+ */
+export const CLIENT_AUTH_FORMAT_ERROR =
+  "Invalid client authentication format. Expected: Bearer <token>";
+
+/** A client token was presented but does not match `MCP_AUTH_TOKEN`. */
+export const CLIENT_AUTH_INVALID_ERROR = "Invalid client authentication token";
+
+/**
+ * Compare two strings without short-circuiting on the first differing byte.
+ *
+ * `TextEncoder` is a global in both Node 18+ and Workers, so this works in both
+ * deployments — unlike `crypto.timingSafeEqual` (Node only) or
+ * `crypto.subtle.timingSafeEqual` (Workers only), which is why neither is used.
+ *
+ * Two honest caveats. This is best-effort, not a constant-time guarantee: a JIT
+ * is free to reorder or vectorise the loop, and JS gives no way to pin that
+ * down. And length is not hidden — a mismatch returns before the loop, so the
+ * length of the configured token is still observable. It is nonetheless
+ * strictly better than `!==`, which leaks the matching prefix length and so
+ * lets an attacker recover the token byte by byte.
+ */
+export function timingSafeEqualString(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+
+  if (aBytes.length !== bBytes.length) {
+    return false;
+  }
+
+  // Accumulate every difference before deciding, so the loop always runs the
+  // full length of the input rather than stopping at the first mismatch.
+  let diff = 0;
+  for (let i = 0; i < aBytes.length; i++) {
+    diff |= aBytes[i]! ^ bBytes[i]!;
+  }
+
+  return diff === 0;
+}

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -10,16 +10,26 @@
  *
  * Note: Client Authentication (MCP_AUTH_TOKEN) is separate from User Authentication.
  * User Authentication uses per-user Fizzy tokens sent via Authorization header.
+ * Client Authentication belongs on its own header, X-MCP-Auth-Token, so the two
+ * layers do not fight over Authorization; see utils/client-auth.ts.
  *
  * Environment Variables:
  * - MCP_ALLOWED_ORIGINS: Comma-separated list of allowed origins (or "*" for all)
- * - MCP_AUTH_TOKEN: Bearer token for MCP client authentication
+ * - MCP_AUTH_TOKEN: Token for MCP client authentication, sent on X-MCP-Auth-Token
  * - MCP_BIND_ALL_INTERFACES: Set to "true" to bind to 0.0.0.0
  */
 
 import { IncomingMessage, ServerResponse } from "node:http";
 import { logger } from "./logger.js";
 import { isOriginAllowed } from "./origin.js";
+import {
+  CLIENT_AUTH_FORMAT_ERROR,
+  CLIENT_AUTH_HEADER,
+  CLIENT_AUTH_HEADER_LOWER,
+  CLIENT_AUTH_INVALID_ERROR,
+  CLIENT_AUTH_REQUIRED_ERROR,
+  timingSafeEqualString,
+} from "./client-auth.js";
 
 const log = logger.child("security");
 
@@ -36,8 +46,12 @@ export interface SecurityOptions {
   allowedOrigins?: string[];
   
   /**
-   * Bearer token for Client Authentication
-   * If set, MCP clients must include Authorization: Bearer <token> header
+   * Shared token for Client Authentication
+   * If set, MCP clients must send it in the X-MCP-Auth-Token header (bare
+   * value, no "Bearer " prefix). Authorization: Bearer <token> is still
+   * accepted as a fallback for existing deployments, but it collides with the
+   * per-user Fizzy token on that same header, so new deployments should use
+   * X-MCP-Auth-Token.
    * This is separate from User Authentication (FIZZY_ACCESS_TOKEN) which
    * authenticates the user with the Fizzy API
    * Can also be configured via MCP_AUTH_TOKEN environment variable
@@ -152,38 +166,72 @@ export async function validateRequestSecurity(
     log.debug("Request without Origin header (likely non-browser client)");
   }
   
-  // 2. Validate Client Authentication (Bearer token)
+  // 2. Validate Client Authentication (MCP_AUTH_TOKEN)
   // This authenticates the MCP client connecting to this server
   // (separate from User Authentication via FIZZY_ACCESS_TOKEN for the Fizzy API)
-  if (resolved.authToken) {
-    const authHeader = req.headers.authorization;
-    
-    if (!authHeader) {
-      log.warn("Missing Authorization header for client authentication");
-      return {
-        allowed: false,
-        statusCode: 401,
-        error: "Client authentication required",
-      };
-    }
-    
-    if (!authHeader.startsWith("Bearer ")) {
-      log.warn("Invalid Authorization header format for client authentication");
-      return {
-        allowed: false,
-        statusCode: 401,
-        error: "Invalid client authentication format. Expected: Bearer <token>",
-      };
-    }
-    
-    const token = authHeader.slice(7); // Remove "Bearer "
-    if (token !== resolved.authToken) {
-      log.warn("Invalid client authentication token");
-      return {
-        allowed: false,
-        statusCode: 401,
-        error: "Invalid client authentication token",
-      };
+  //
+  // Preferred: the dedicated `X-MCP-Auth-Token` header, carrying the bare token.
+  // It is what the Cloudflare Worker accepts, and it is the only way the two
+  // layers are genuinely independent — `Authorization` is also read as the
+  // caller's per-user Fizzy token by `extractFizzyToken` below, so a deployment
+  // that spends it on the client token cannot also do per-user auth.
+  //
+  // Fallback: `Authorization: Bearer <token>`, unchanged, because existing
+  // deployments send it that way. New deployments should not adopt it.
+  //
+  // Preflight is exempt. A browser sends no custom headers and no Authorization
+  // on an OPTIONS preflight, so an otherwise perfectly authenticated client
+  // arrives here carrying nothing; rejecting it would fail the request before
+  // the browser ever got to send the real one, making client authentication
+  // unusable from a browser entirely. Answering the preflight discloses only
+  // which headers are permitted, and the request it clears is still fully
+  // authenticated when it arrives. The Worker is exempt for the same reason
+  // (see the OPTIONS branch in cloudflare/index.ts). Origin validation above
+  // still applies to preflights.
+  if (resolved.authToken && req.method !== "OPTIONS") {
+    const headerToken = req.headers[CLIENT_AUTH_HEADER_LOWER];
+
+    // A duplicated header arrives as an array. That is ambiguous, so it falls
+    // through to the Authorization path rather than being read as a pass.
+    if (typeof headerToken === "string" && headerToken !== "") {
+      if (!timingSafeEqualString(headerToken, resolved.authToken)) {
+        log.warn(`Invalid client authentication token on ${CLIENT_AUTH_HEADER}`);
+        return {
+          allowed: false,
+          statusCode: 401,
+          error: CLIENT_AUTH_INVALID_ERROR,
+        };
+      }
+    } else {
+      const authHeader = req.headers.authorization;
+
+      if (!authHeader) {
+        log.warn("Missing Authorization header for client authentication");
+        return {
+          allowed: false,
+          statusCode: 401,
+          error: CLIENT_AUTH_REQUIRED_ERROR,
+        };
+      }
+
+      if (!authHeader.startsWith("Bearer ")) {
+        log.warn("Invalid Authorization header format for client authentication");
+        return {
+          allowed: false,
+          statusCode: 401,
+          error: CLIENT_AUTH_FORMAT_ERROR,
+        };
+      }
+
+      const token = authHeader.slice(7); // Remove "Bearer "
+      if (!timingSafeEqualString(token, resolved.authToken)) {
+        log.warn("Invalid client authentication token");
+        return {
+          allowed: false,
+          statusCode: 401,
+          error: CLIENT_AUTH_INVALID_ERROR,
+        };
+      }
     }
   }
   
@@ -244,7 +292,10 @@ export function setSecureCorsHeaders(
 ): void {
   res.setHeader("Access-Control-Allow-Origin", corsOrigin);
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-session-id");
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    `Content-Type, Authorization, mcp-session-id, ${CLIENT_AUTH_HEADER}`
+  );
   
   if (exposedHeaders.length > 0) {
     res.setHeader("Access-Control-Expose-Headers", exposedHeaders.join(", "));

--- a/tests/cloudflare/worker.test.ts
+++ b/tests/cloudflare/worker.test.ts
@@ -13,7 +13,8 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { validateSecurity } from "../../src/cloudflare/security.js";
-import type { Env as WorkerEnv } from "../../src/cloudflare/types.js";
+import { CLIENT_AUTH_HEADER } from "../../src/utils/client-auth.js";
+import { setCorsHeaders, setSecurityHeaders } from "../../src/cloudflare/headers.js";
 
 // Mock types for testing (we can't import actual Cloudflare types in Node.js tests)
 interface MockEnv {
@@ -27,63 +28,6 @@ interface MockEnv {
       fetch: (request: Request) => Promise<Response>;
     };
   };
-}
-
-// The Worker's real origin validation, imported from src/cloudflare/security.ts.
-//
-// The suites below that pass MCP_AUTH_TOKEN use validateSecurityWithProposedAuth
-// instead: src/cloudflare/ never reads MCP_AUTH_TOKEN, so the Worker performs no
-// client authentication and those cases describe behaviour that does not exist
-// yet. They are kept as the specification for that gap, not as coverage of it.
-// Tracked in https://github.com/Fabric-Pro/fizzy-mcp/issues/64.
-function validateSecurityWithProposedAuth(request: Request, env: MockEnv): {
-  allowed: boolean;
-  statusCode?: number;
-  error?: string;
-  corsOrigin?: string;
-} {
-  const originResult = validateSecurity(request, env as unknown as WorkerEnv);
-  if (!originResult.allowed) {
-    return originResult;
-  }
-
-  if (env.MCP_AUTH_TOKEN) {
-    const authHeader = request.headers.get("Authorization");
-    // Auth failures keep the CORS origin the origin check already decided, so
-    // this specification never describes a response more permissive than the
-    // deployed policy (echoing a caller origin under a wildcard allowlist would
-    // pair Access-Control-Allow-Credentials with an unvetted origin).
-    const corsOrigin = originResult.corsOrigin;
-
-    if (!authHeader) {
-      return {
-        allowed: false,
-        statusCode: 401,
-        error: "Client authentication required",
-        corsOrigin,
-      };
-    }
-
-    if (!authHeader.startsWith("Bearer ")) {
-      return {
-        allowed: false,
-        statusCode: 401,
-        error: "Invalid authentication format. Expected: Bearer <token>",
-        corsOrigin,
-      };
-    }
-
-    if (authHeader.slice(7) !== env.MCP_AUTH_TOKEN) {
-      return {
-        allowed: false,
-        statusCode: 401,
-        error: "Invalid authentication token",
-        corsOrigin,
-      };
-    }
-  }
-
-  return originResult;
 }
 
 describe("Worker Security Validation", () => {
@@ -193,61 +137,90 @@ describe("Worker Security Validation", () => {
     });
   });
 
-  describe("Bearer Token Authentication", () => {
-    it("should allow requests without auth when MCP_AUTH_TOKEN not set", () => {
+  describe("Client Authentication", () => {
+    it("should allow requests without a client token when MCP_AUTH_TOKEN is not set", () => {
       const request = new Request("https://example.com/mcp");
       const env = { ...baseEnv };
-      
-      const result = validateSecurityWithProposedAuth(request, env);
-      
+
+      const result = validateSecurity(request, env);
+
       expect(result.allowed).toBe(true);
     });
 
-    it("should require auth when MCP_AUTH_TOKEN is set", () => {
+    it("should require the client token when MCP_AUTH_TOKEN is set", () => {
       const request = new Request("https://example.com/mcp");
       const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
-      
-      const result = validateSecurityWithProposedAuth(request, env);
-      
+
+      const result = validateSecurity(request, env);
+
       expect(result.allowed).toBe(false);
       expect(result.statusCode).toBe(401);
       expect(result.error).toBe("Client authentication required");
     });
 
-    it("should reject invalid auth format", () => {
+    it("should reject an empty client token header", () => {
       const request = new Request("https://example.com/mcp", {
-        headers: { Authorization: "Basic abc123" },
+        headers: { [CLIENT_AUTH_HEADER]: "" },
       });
       const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
-      
-      const result = validateSecurityWithProposedAuth(request, env);
-      
+
+      const result = validateSecurity(request, env);
+
       expect(result.allowed).toBe(false);
       expect(result.statusCode).toBe(401);
-      expect(result.error).toContain("Invalid authentication format");
+      expect(result.error).toBe("Client authentication required");
     });
 
-    it("should reject wrong token", () => {
-      const request = new Request("https://example.com/mcp", {
-        headers: { Authorization: "Bearer wrong-token" },
-      });
-      const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
-      
-      const result = validateSecurityWithProposedAuth(request, env);
-      
-      expect(result.allowed).toBe(false);
-      expect(result.statusCode).toBe(401);
-      expect(result.error).toBe("Invalid authentication token");
-    });
-
-    it("should allow correct token", () => {
+    // The whole point of the dedicated header: Authorization belongs to the
+    // per-user Fizzy token, so a client token sent there is not client auth.
+    it("should reject a client token presented on Authorization", () => {
       const request = new Request("https://example.com/mcp", {
         headers: { Authorization: "Bearer secret" },
       });
       const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
-      
-      const result = validateSecurityWithProposedAuth(request, env);
-      
+
+      const result = validateSecurity(request, env);
+
+      expect(result.allowed).toBe(false);
+      expect(result.statusCode).toBe(401);
+      expect(result.error).toBe("Client authentication required");
+    });
+
+    it("should reject wrong token", () => {
+      const request = new Request("https://example.com/mcp", {
+        headers: { [CLIENT_AUTH_HEADER]: "wrong-token" },
+      });
+      const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
+
+      const result = validateSecurity(request, env);
+
+      expect(result.allowed).toBe(false);
+      expect(result.statusCode).toBe(401);
+      expect(result.error).toBe("Invalid client authentication token");
+    });
+
+    it("should allow correct token", () => {
+      const request = new Request("https://example.com/mcp", {
+        headers: { [CLIENT_AUTH_HEADER]: "secret" },
+      });
+      const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
+
+      const result = validateSecurity(request, env);
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should allow a client token alongside a different Fizzy token on Authorization", () => {
+      const request = new Request("https://example.com/mcp", {
+        headers: {
+          [CLIENT_AUTH_HEADER]: "secret",
+          Authorization: "Bearer user-fizzy-pat",
+        },
+      });
+      const env = { ...baseEnv, MCP_AUTH_TOKEN: "secret" };
+
+      const result = validateSecurity(request, env);
+
       expect(result.allowed).toBe(true);
     });
   });
@@ -257,7 +230,7 @@ describe("Worker Security Validation", () => {
       const request = new Request("https://example.com/mcp", {
         headers: {
           Origin: "https://allowed.com",
-          Authorization: "Bearer secret",
+          [CLIENT_AUTH_HEADER]: "secret",
         },
       });
       const env = {
@@ -265,9 +238,9 @@ describe("Worker Security Validation", () => {
         MCP_ALLOWED_ORIGINS: "https://allowed.com",
         MCP_AUTH_TOKEN: "secret",
       };
-      
-      const result = validateSecurityWithProposedAuth(request, env);
-      
+
+      const result = validateSecurity(request, env);
+
       expect(result.allowed).toBe(true);
       expect(result.corsOrigin).toBe("https://allowed.com");
     });
@@ -276,7 +249,7 @@ describe("Worker Security Validation", () => {
       const request = new Request("https://example.com/mcp", {
         headers: {
           Origin: "https://wrong.com",
-          Authorization: "Bearer secret",
+          [CLIENT_AUTH_HEADER]: "secret",
         },
       });
       const env = {
@@ -284,9 +257,9 @@ describe("Worker Security Validation", () => {
         MCP_ALLOWED_ORIGINS: "https://allowed.com",
         MCP_AUTH_TOKEN: "secret",
       };
-      
-      const result = validateSecurityWithProposedAuth(request, env);
-      
+
+      const result = validateSecurity(request, env);
+
       expect(result.allowed).toBe(false);
       expect(result.statusCode).toBe(403);
     });
@@ -295,7 +268,7 @@ describe("Worker Security Validation", () => {
       const request = new Request("https://example.com/mcp", {
         headers: {
           Origin: "https://allowed.com",
-          Authorization: "Bearer wrong",
+          [CLIENT_AUTH_HEADER]: "wrong",
         },
       });
       const env = {
@@ -303,27 +276,38 @@ describe("Worker Security Validation", () => {
         MCP_ALLOWED_ORIGINS: "https://allowed.com",
         MCP_AUTH_TOKEN: "secret",
       };
-      
-      const result = validateSecurityWithProposedAuth(request, env);
-      
+
+      const result = validateSecurity(request, env);
+
       expect(result.allowed).toBe(false);
       expect(result.statusCode).toBe(401);
+    });
+
+    // A 401 without a usable Allow-Origin reads as an opaque network error in
+    // the browser, so the auth failure must carry the same CORS origin the
+    // success path would have returned — and never a more permissive one.
+    it("should return the allowed CORS origin on a 401", () => {
+      const request = new Request("https://example.com/mcp", {
+        headers: {
+          Origin: "https://allowed.com",
+          [CLIENT_AUTH_HEADER]: "wrong",
+        },
+      });
+      const env = {
+        ...baseEnv,
+        MCP_ALLOWED_ORIGINS: "https://allowed.com",
+        MCP_AUTH_TOKEN: "secret",
+      };
+
+      const result = validateSecurity(request, env);
+
+      expect(result.statusCode).toBe(401);
+      expect(result.corsOrigin).toBe("https://allowed.com");
     });
   });
 });
 
 describe("CORS Headers", () => {
-  function setCorsHeaders(headers: Headers, corsOrigin: string): void {
-    headers.set("Access-Control-Allow-Origin", corsOrigin);
-    headers.set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-    headers.set("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-session-id");
-    headers.set("Access-Control-Expose-Headers", "mcp-session-id");
-    
-    if (corsOrigin !== "*") {
-      headers.set("Access-Control-Allow-Credentials", "true");
-    }
-  }
-
   it("should set all required CORS headers", () => {
     const headers = new Headers();
     setCorsHeaders(headers, "https://example.com");
@@ -331,6 +315,7 @@ describe("CORS Headers", () => {
     expect(headers.get("Access-Control-Allow-Origin")).toBe("https://example.com");
     expect(headers.get("Access-Control-Allow-Methods")).toContain("POST");
     expect(headers.get("Access-Control-Allow-Headers")).toContain("mcp-session-id");
+    expect(headers.get("Access-Control-Allow-Headers")).toContain(CLIENT_AUTH_HEADER);
     expect(headers.get("Access-Control-Expose-Headers")).toContain("mcp-session-id");
     expect(headers.get("Access-Control-Allow-Credentials")).toBe("true");
   });
@@ -374,37 +359,33 @@ describe("Session ID Handling", () => {
 });
 
 describe("Security Headers", () => {
-  it("should include X-Content-Type-Options header", () => {
+  // These assert the Worker's real setSecurityHeaders, not a copy of it, so a
+  // header dropped from production actually fails the suite.
+  function applied(): Headers {
     const headers = new Headers();
-    headers.set("X-Content-Type-Options", "nosniff");
+    setSecurityHeaders(headers);
+    return headers;
+  }
 
-    expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
+  it("should include X-Content-Type-Options header", () => {
+    expect(applied().get("X-Content-Type-Options")).toBe("nosniff");
   });
 
   it("should include X-Frame-Options header", () => {
-    const headers = new Headers();
-    headers.set("X-Frame-Options", "DENY");
-
-    expect(headers.get("X-Frame-Options")).toBe("DENY");
+    expect(applied().get("X-Frame-Options")).toBe("DENY");
   });
 
   it("should include X-XSS-Protection header", () => {
-    const headers = new Headers();
-    headers.set("X-XSS-Protection", "1; mode=block");
-
-    expect(headers.get("X-XSS-Protection")).toBe("1; mode=block");
+    expect(applied().get("X-XSS-Protection")).toBe("1; mode=block");
   });
 
   it("should include Referrer-Policy header", () => {
-    const headers = new Headers();
-    headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
-
-    expect(headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    expect(applied().get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
   });
 
   it("should include Access-Control-Max-Age header", () => {
     const headers = new Headers();
-    headers.set("Access-Control-Max-Age", "86400");
+    setCorsHeaders(headers, "*");
 
     expect(headers.get("Access-Control-Max-Age")).toBe("86400");
   });
@@ -444,30 +425,29 @@ describe("Environment Validation", () => {
 describe("CORS Enhancements", () => {
   it("should include Access-Control-Max-Age for preflight caching", () => {
     const headers = new Headers();
-    headers.set("Access-Control-Allow-Origin", "*");
-    headers.set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-    headers.set("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-session-id");
-    headers.set("Access-Control-Expose-Headers", "mcp-session-id");
-    headers.set("Access-Control-Max-Age", "86400");
+    setCorsHeaders(headers, "*");
 
     expect(headers.get("Access-Control-Max-Age")).toBe("86400");
   });
 
   it("should set credentials flag for non-wildcard origins", () => {
     const headers = new Headers();
-    const corsOrigin = "https://cursor.sh";
-
-    headers.set("Access-Control-Allow-Origin", corsOrigin);
-    headers.set("Access-Control-Allow-Credentials", "true");
+    setCorsHeaders(headers, "https://cursor.sh");
 
     expect(headers.get("Access-Control-Allow-Credentials")).toBe("true");
   });
 
   it("should not set credentials flag for wildcard origin", () => {
     const headers = new Headers();
-    headers.set("Access-Control-Allow-Origin", "*");
+    setCorsHeaders(headers, "*");
 
     expect(headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
-});
 
+  it("should advertise the client-auth header so browsers do not strip it", () => {
+    const headers = new Headers();
+    setCorsHeaders(headers, "https://cursor.sh");
+
+    expect(headers.get("Access-Control-Allow-Headers")).toContain(CLIENT_AUTH_HEADER);
+  });
+});

--- a/tests/transports/http-edge-cases.test.ts
+++ b/tests/transports/http-edge-cases.test.ts
@@ -352,7 +352,7 @@ describe("HTTP Transport - Edge Cases", () => {
       expect(res._statusCode).toBe(204);
       expect(res.setHeader).toHaveBeenCalledWith(
         "Access-Control-Allow-Headers",
-        "Content-Type, Authorization, mcp-session-id"
+        "Content-Type, Authorization, mcp-session-id, X-MCP-Auth-Token"
       );
     });
 

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -156,7 +156,7 @@ describe("HTTP Transport", () => {
       );
       expect(res.setHeader).toHaveBeenCalledWith(
         "Access-Control-Allow-Headers",
-        "Content-Type, Authorization, mcp-session-id"
+        "Content-Type, Authorization, mcp-session-id, X-MCP-Auth-Token"
       );
       expect(res.setHeader).toHaveBeenCalledWith(
         "Access-Control-Expose-Headers",

--- a/tests/transports/sse.test.ts
+++ b/tests/transports/sse.test.ts
@@ -143,7 +143,7 @@ describe("SSE Transport", () => {
       );
       expect(res.setHeader).toHaveBeenCalledWith(
         "Access-Control-Allow-Headers",
-        "Content-Type, Authorization, mcp-session-id"
+        "Content-Type, Authorization, mcp-session-id, X-MCP-Auth-Token"
       );
     });
 

--- a/tests/utils/client-auth.test.ts
+++ b/tests/utils/client-auth.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the shared client-authentication helpers
+ *
+ * The comparison used to gate `MCP_AUTH_TOKEN` on both deployments, so its
+ * behaviour has to be exactly that of `===` — the non-short-circuiting part is
+ * unobservable from outside, but a wrong answer is an auth bypass.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  CLIENT_AUTH_HEADER,
+  CLIENT_AUTH_HEADER_LOWER,
+  timingSafeEqualString,
+} from "../../src/utils/client-auth.js";
+
+describe("client-auth constants", () => {
+  it("should expose the lowercased header name Node's req.headers is keyed by", () => {
+    expect(CLIENT_AUTH_HEADER_LOWER).toBe(CLIENT_AUTH_HEADER.toLowerCase());
+  });
+});
+
+describe("timingSafeEqualString", () => {
+  it("should return true for equal strings", () => {
+    expect(timingSafeEqualString("secret-token", "secret-token")).toBe(true);
+  });
+
+  it("should return false for different strings of equal length", () => {
+    expect(timingSafeEqualString("secret-token", "secret-tokeN")).toBe(false);
+  });
+
+  it("should return false when only the first byte differs", () => {
+    expect(timingSafeEqualString("aaaaaaaa", "baaaaaaa")).toBe(false);
+  });
+
+  it("should return false when only the last byte differs", () => {
+    expect(timingSafeEqualString("aaaaaaaa", "aaaaaaab")).toBe(false);
+  });
+
+  it("should return false for strings of different lengths", () => {
+    expect(timingSafeEqualString("secret", "secret-token")).toBe(false);
+    expect(timingSafeEqualString("secret-token", "secret")).toBe(false);
+  });
+
+  it("should treat a prefix as a mismatch, not a match", () => {
+    expect(timingSafeEqualString("secret-token", "secret-token-extra")).toBe(false);
+  });
+
+  it("should return true for two empty strings", () => {
+    expect(timingSafeEqualString("", "")).toBe(true);
+  });
+
+  it("should return false when only one side is empty", () => {
+    expect(timingSafeEqualString("", "secret")).toBe(false);
+    expect(timingSafeEqualString("secret", "")).toBe(false);
+  });
+
+  // Comparison is over UTF-8 bytes, so multi-byte input must round-trip and
+  // must not be truncated or compared by code-unit count.
+  it("should compare multi-byte UTF-8 correctly", () => {
+    expect(timingSafeEqualString("tökén-🔐", "tökén-🔐")).toBe(true);
+    expect(timingSafeEqualString("tökén-🔐", "tökén-🔓")).toBe(false);
+  });
+
+  it("should distinguish strings of equal code-unit length but different byte length", () => {
+    // "é" is two UTF-8 bytes, "e" is one: same string length, different byte length.
+    expect("é".length).toBe("e".length);
+    expect(timingSafeEqualString("é", "e")).toBe(false);
+  });
+});

--- a/tests/utils/security.test.ts
+++ b/tests/utils/security.test.ts
@@ -8,6 +8,7 @@ import {
   getBindAddress,
   SecurityOptions,
 } from "../../src/utils/security.js";
+import { CLIENT_AUTH_HEADER_LOWER } from "../../src/utils/client-auth.js";
 
 // Helper to create mock request
 function createMockRequest(
@@ -203,6 +204,123 @@ describe("Security Utilities", () => {
         
         expect(result.allowed).toBe(true);
       });
+
+      // The dedicated header. Everything above is the legacy Authorization
+      // fallback and must keep passing unchanged — that is the compatibility
+      // proof for existing deployments.
+      it("should allow requests with the correct X-MCP-Auth-Token header", async () => {
+        const req = createMockRequest("GET", {
+          origin: "http://localhost:3000",
+          [CLIENT_AUTH_HEADER_LOWER]: "secret-token",
+        });
+        const options: SecurityOptions = { authToken: "secret-token" };
+        const result = await validateRequestSecurity(req, options, 3000);
+
+        expect(result.allowed).toBe(true);
+      });
+
+      it("should reject a wrong token on the X-MCP-Auth-Token header", async () => {
+        const req = createMockRequest("GET", {
+          origin: "http://localhost:3000",
+          [CLIENT_AUTH_HEADER_LOWER]: "wrong-token",
+        });
+        const options: SecurityOptions = { authToken: "secret-token" };
+        const result = await validateRequestSecurity(req, options, 3000);
+
+        expect(result.allowed).toBe(false);
+        expect(result.statusCode).toBe(401);
+        expect(result.error).toBe("Invalid client authentication token");
+      });
+
+      // The point of the dedicated header: client auth and the per-user Fizzy
+      // token can now both be present without fighting over Authorization.
+      it("should allow the client token alongside a different Fizzy token on Authorization", async () => {
+        const req = createMockRequest("GET", {
+          origin: "http://localhost:3000",
+          [CLIENT_AUTH_HEADER_LOWER]: "secret-token",
+          authorization: "Bearer user-fizzy-pat",
+        });
+        const options: SecurityOptions = { authToken: "secret-token" };
+        const result = await validateRequestSecurity(req, options, 3000);
+
+        expect(result.allowed).toBe(true);
+      });
+
+      it("should reject a wrong X-MCP-Auth-Token even when Authorization carries the token", async () => {
+        const req = createMockRequest("GET", {
+          origin: "http://localhost:3000",
+          [CLIENT_AUTH_HEADER_LOWER]: "wrong-token",
+          authorization: "Bearer secret-token",
+        });
+        const options: SecurityOptions = { authToken: "secret-token" };
+        const result = await validateRequestSecurity(req, options, 3000);
+
+        expect(result.allowed).toBe(false);
+        expect(result.statusCode).toBe(401);
+        expect(result.error).toBe("Invalid client authentication token");
+      });
+
+      // An empty header is not a presented token; it falls through to the
+      // Authorization path, which here has nothing either.
+      it("should fall back to Authorization when X-MCP-Auth-Token is empty", async () => {
+        const req = createMockRequest("GET", {
+          origin: "http://localhost:3000",
+          [CLIENT_AUTH_HEADER_LOWER]: "",
+          authorization: "Bearer secret-token",
+        });
+        const options: SecurityOptions = { authToken: "secret-token" };
+        const result = await validateRequestSecurity(req, options, 3000);
+
+        expect(result.allowed).toBe(true);
+      });
+
+      // A duplicated header arrives as an array; that is ambiguous, so it must
+      // never be read as a pass.
+      it("should not accept a duplicated X-MCP-Auth-Token header as a pass", async () => {
+        const req = createMockRequest("GET", { origin: "http://localhost:3000" });
+        (req.headers as Record<string, unknown>)[CLIENT_AUTH_HEADER_LOWER] = [
+          "secret-token",
+          "secret-token",
+        ];
+        const options: SecurityOptions = { authToken: "secret-token" };
+        const result = await validateRequestSecurity(req, options, 3000);
+
+        expect(result.allowed).toBe(false);
+        expect(result.statusCode).toBe(401);
+        expect(result.error).toBe("Client authentication required");
+      });
+
+      // A browser sends no custom headers and no Authorization on a preflight,
+      // so requiring the token here would fail every browser client before it
+      // could send the real, authenticated request.
+      it("should exempt OPTIONS preflight from client authentication", async () => {
+        const req = createMockRequest("OPTIONS", { origin: "http://localhost:3000" });
+        const options: SecurityOptions = { authToken: "secret-token" };
+        const result = await validateRequestSecurity(req, options, 3000);
+
+        expect(result.allowed).toBe(true);
+      });
+
+      it("should still reject a disallowed origin on an OPTIONS preflight", async () => {
+        const req = createMockRequest("OPTIONS", { origin: "https://evil.com" });
+        const options: SecurityOptions = {
+          authToken: "secret-token",
+          allowedOrigins: ["http://localhost:3000"],
+        };
+        const result = await validateRequestSecurity(req, options, 3000);
+
+        expect(result.allowed).toBe(false);
+        expect(result.statusCode).toBe(403);
+      });
+
+      it("should still require the token on the real request after a preflight", async () => {
+        const req = createMockRequest("POST", { origin: "http://localhost:3000" });
+        const options: SecurityOptions = { authToken: "secret-token" };
+        const result = await validateRequestSecurity(req, options, 3000);
+
+        expect(result.allowed).toBe(false);
+        expect(result.statusCode).toBe(401);
+      });
     });
 
     describe("Custom Authorization", () => {
@@ -273,7 +391,7 @@ describe("Security Utilities", () => {
       
       expect(res.setHeader).toHaveBeenCalledWith("Access-Control-Allow-Origin", "https://myapp.com");
       expect(res.setHeader).toHaveBeenCalledWith("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-      expect(res.setHeader).toHaveBeenCalledWith("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-session-id");
+      expect(res.setHeader).toHaveBeenCalledWith("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-session-id, X-MCP-Auth-Token");
       expect(res.setHeader).toHaveBeenCalledWith("Access-Control-Expose-Headers", "mcp-session-id");
       expect(res.setHeader).toHaveBeenCalledWith("Access-Control-Allow-Credentials", "true");
     });

--- a/tsconfig.cloudflare.json
+++ b/tsconfig.cloudflare.json
@@ -26,6 +26,7 @@
     "src/utils/logger.ts",
     "src/utils/attachments.ts",
     "src/utils/base64.ts",
+    "src/utils/client-auth.ts",
     "src/utils/file-source.ts",
     "src/utils/md5.ts",
     "src/utils/origin.ts",


### PR DESCRIPTION
The Worker documented `MCP_AUTH_TOKEN` as a supported security control but never read it. An operator who set it got no client authentication and no warning — on the one deployment that is reachable from anywhere.

Fixes #64

## Why not just mirror the Node transports

Issue #64 suggested mirroring `validateRequestSecurity()`, which reads the client token from `Authorization: Bearer`. That is not implementable here: `extractFizzyToken` (`src/cloudflare/index.ts:41`) already reads `Authorization` as the caller's per-user Fizzy Personal Access Token, with no env fallback. Enforcing client auth on the same header would make the two layers mutually exclusive rather than independent — every client sending its own PAT would be rejected as a missing client token.

So client auth gets a dedicated header:

```
Authorization: Bearer <fizzy-personal-access-token>   # who you are
X-MCP-Auth-Token: <mcp-auth-token>                    # may you connect at all
```

This is what makes the two layers genuinely independent, which `docs/CLOUDFLARE.md` already claimed they were.

## Changes

- **`src/utils/client-auth.ts`** (new) — the header name, shared error strings, and `timingSafeEqualString`, a `TextEncoder` + XOR-accumulator comparison that works in both Node and Workers. Shared by both deployments the same way `utils/origin.ts` is.
- **Worker** — `Env.MCP_AUTH_TOKEN`, enforced in `validateSecurity`. The CORS origin is computed before the auth check so a 401 carries it too; without that a browser sees an opaque network failure instead of the error. It is never more permissive than the success path.
- **Node transports** — accept the same header, falling back to today's `Authorization` behaviour when it is absent. Non-breaking: every existing client-auth test passes unchanged.
- **CORS preflight exempted from client auth.** Browsers send no custom headers on an `OPTIONS` preflight, so requiring the token there rejected every browser client before it could send the real request. This was pre-existing on the Node transports and made client auth unusable from a browser there. Origin validation still applies to preflights, and the request they clear is still fully authenticated.
- **`src/cloudflare/headers.ts`** (new) — the CORS and security header helpers move out of `index.ts` so tests exercise them directly, following the pattern `security.ts` established.

## Compatibility

No client needs a token unless an operator sets `MCP_AUTH_TOKEN`; when it is unset the whole check is skipped and behaviour is identical to today. `wrangler.jsonc` does not set it in any of the three environments.

Confirmed against the deployment: `wrangler secret list` returns `[]` for both `fizzy-mcp-production` and `fizzy-mcp-staging`, so `MCP_AUTH_TOKEN` is not set as a secret either. Enforcement stays dormant until an operator deliberately sets it, and no existing client is affected by this merge.

## Test coverage

Issue #64 noted that eight tests asserted enforcement the Worker did not have, against a local reimplementation of `validateSecurity`. That shim is deleted and those suites now call the real function, including the case that matters most: a client token sent on `Authorization` is rejected, and a correct client token alongside a *different* Fizzy PAT is allowed.

The Worker's CORS suite had the same problem — it asserted against its own copy of `setCorsHeaders`, so dropping the header from production would not have failed it. Extracting the helper fixed that; mutation-tested by removing `X-MCP-Auth-Token` from the allowlist, which now fails 2 tests and previously failed none.

762 unit tests, 124 Cloudflare tests, `typecheck`, `typecheck:cf` and `build` all clean. `npm run lint` cannot run in this environment (`eslint: command not found`), unchanged from `main`.

## Follow-up

#66 — test files are type-checked by neither tsconfig, so nothing verified that `MockEnv` still matches the real `Env`. Filed rather than fixed here; it needs a CI change and will surface pre-existing errors.
