### PR TITLE
chore(deps): batch the two dev-only transitive Dependabot bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,9 +1880,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3231,9 +3231,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -3251,7 +3251,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Combines Dependabot #70 and #71. Both are lockfile-only; `package.json` is untouched because both new versions already satisfy their parents' declared ranges.

| Package | From | To | Source | Reached via |
| --- | --- | --- | --- | --- |
| `postcss` | 8.5.6 | 8.5.28 | #71 | `vitest` → `vite` |
| `brace-expansion` | 2.0.2 | 2.1.4 | #70 | `@vitest/coverage-v8` → `test-exclude` → `minimatch` |

Neither is a direct dependency and neither reaches production: both sit under the vitest toolchain, which is `devDependencies`-only and excluded from the published package by the `files` allowlist.

Batched for the same reason as #68 — each Dependabot branch rewrites `package-lock.json` from the same base, so merging one forces the other to rebase.

## Not a security fix

Worth stating explicitly, since `brace-expansion` has a ReDoS advisory ([GHSA-v6h2-p8h4-qcjw](https://github.com/advisories/GHSA-v6h2-p8h4-qcjw)) in this version neighbourhood: that advisory covers `<= 2.0.2`, and the tree was already on the patched 2.0.2. This bump is routine.

## Verification

`typecheck`, `typecheck:cf`, `build`, `test:cloudflare` (124 passed) all green locally. Unit tests show the 5 known port-3100/3001 flakes on this machine (4 in `sse-multi-user.test.ts`, 1 in `security-warnings.test.ts`); CI on a clean runner is authoritative.

## Note

Both packages live under vitest 2.x, so #61 would supersede this part of the tree if that upgrade lands. Taking them now regardless, since #61 is a major that may not survive review.