### PR TITLE
chore(deps-dev)!: bump @cloudflare/workers-types to 5.20260901.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "fizzy-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20241205.0",
+        "@cloudflare/workers-types": "^5.20260901.1",
         "@types/node": "^22.10.0",
         "@vitest/coverage-v8": "^2.1.0",
         "dotenv": "^17.2.3",
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20251210.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251210.0.tgz",
-      "integrity": "sha512-EGf2lWqeVO48LjDYFl1peSbi/AvQFDJ1vj+etwRAGqLjGWgq+R1fwFfLCjXr7tMsX8aHykE17XpCAVuroKpZoQ==",
+      "version": "5.20260901.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260901.1.tgz",
+      "integrity": "sha512-m1rNbR3UYC1pgaEyXkSlwLFLDB11QziYUlY0z/nqjwuYtg5dw9zBrgDudoSfYM6ebbPDKU81ogBQAzLp6h1y4w==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20241205.0",
+    "@cloudflare/workers-types": "^5.20260901.1",
     "@types/node": "^22.10.0",
     "@vitest/coverage-v8": "^2.1.0",
     "dotenv": "^17.2.3",

--- a/src/cloudflare/mcp-session.ts
+++ b/src/cloudflare/mcp-session.ts
@@ -18,7 +18,6 @@ import { DurableObject } from "cloudflare:workers";
 import { FizzyClient } from "../client/fizzy-client.js";
 import type {
   Env,
-  DurableObjectState,
   JsonRpcRequest,
   JsonRpcResponse,
   JsonRpcMessage,
@@ -54,6 +53,19 @@ const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
 const ALARM_INTERVAL_MS = 15 * 60 * 1000;
 
 /**
+ * The `ctx` type the `DurableObject` base class actually declares, derived from the base
+ * class rather than imported separately from `@cloudflare/workers-types`.
+ *
+ * Annotating with the separately-imported `DurableObjectState` compiles and describes the
+ * same runtime value, but under @cloudflare/workers-types v5 it sends the checker into a
+ * combinatorial structural comparison at the `super(ctx, env)` call: `npm run typecheck:cf`
+ * goes from ~1.7s to over twelve minutes without terminating. Deriving the type from the
+ * base class gives the checker an identity match instead of a structural one, which
+ * resolves immediately.
+ */
+type DurableObjectCtx<E> = ConstructorParameters<typeof DurableObject<E>>[0];
+
+/**
  * MCP Session Durable Object
  *
  * Handles Streamable HTTP transport for MCP protocol.
@@ -66,7 +78,7 @@ export class McpSessionDO extends DurableObject<Env> {
   private logger: CloudflareLogger;
   private analytics: CloudflareAnalytics;
 
-  constructor(ctx: DurableObjectState, env: Env) {
+  constructor(ctx: DurableObjectCtx<Env>, env: Env) {
     super(ctx, env);
     
     // Initialize logger with session ID

--- a/src/cloudflare/utils/rate-limiter.ts
+++ b/src/cloudflare/utils/rate-limiter.ts
@@ -12,7 +12,7 @@
  * @see https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/
  */
 
-import type { DurableObjectState, DurableObjectNamespace } from "@cloudflare/workers-types";
+import type { DurableObjectNamespace } from "@cloudflare/workers-types";
 import { DurableObject } from "cloudflare:workers";
 
 /**
@@ -59,10 +59,6 @@ interface RateLimitState {
  */
 export class RateLimiterDO extends DurableObject<object> {
   private state: RateLimitState | null = null;
-
-  constructor(ctx: DurableObjectState, env: object) {
-    super(ctx, env);
-  }
 
   /**
    * Initialize state from storage


### PR DESCRIPTION
Dependabot #63. Type-only and dev-only — no runtime effect, and nothing ships, since `files` publishes only `dist/`, `README.md` and `LICENSE`.

## It is not a drop-in: v5 hangs the Cloudflare typecheck

| | `npm run typecheck:cf` |
| --- | --- |
| v4.20251210.0 | **1.7s** |
| v5.20260901.1, unmodified source | **>12 min, never terminated** |
| v5.20260901.1, this PR | **1.68s** |

Killed at 12:21 while still at 101% CPU and ~2 GB RSS — grinding, not deadlocked. CI allots the whole job ten minutes, so this would have surfaced as a bare timeout with no error to read.

## Root cause

Bisected to the two Durable Object constructors. Both annotated `ctx` with `DurableObjectState` imported from `@cloudflare/workers-types`, while extending `DurableObject` imported from the ambient `cloudflare:workers` module — which declares its *own* `DurableObjectState`. Under v4 the checker reconciles those two cheaply; under v5 the `super(ctx, env)` call sets off a combinatorial structural comparison.

Removing just those two annotations restores the 1.7s time exactly, which is the evidence that the rest of the v5 type surface is fine. Every type this repo uses (`DurableObjectNamespace`, `DurableObjectState`, `AnalyticsEngineDataset`, `KVNamespace`, `R2Bucket`, `ExecutionContext`) is still declared, and `DurableObject`'s own signature is byte-identical between v4 and v5.

Bisection evidence, isolating `src/cloudflare/utils/rate-limiter.ts`:

| Variant | Time |
| --- | --- |
| full file | timeout |
| minus `RATE_LIMIT_CONFIGS` | timeout |
| minus `checkRateLimit()` | timeout |
| minus `class RateLimiter` | timeout |
| **minus `class RateLimiterDO`** | **1s** |
| …and within that class: minus `fetch()` override | timeout |
| …**minus the constructor** | **1s** |

## The two fixes differ, because the two cases differ

- **`RateLimiterDO`** — its constructor was a pure no-op forwarding to `super`, so it is deleted outright. The inherited base constructor has an identical signature and identical behaviour.
- **`McpSessionDO`** — its constructor does real work (logger and analytics setup), so it keeps the constructor and instead derives the parameter type from the base class with `ConstructorParameters`. That hands the checker an identity match rather than a structural one. Since that is an obscure spelling for what is just a plain type, it sits behind a named `DurableObjectCtx<E>` alias with a comment explaining why it cannot simply say `DurableObjectState` — otherwise the next person to read it would "simplify" it straight back into a twelve-minute build.

Both changes are type-level only. No runtime behaviour changes, and the 124 Cloudflare tests — which exercise both Durable Objects — pass unchanged.

## About the major itself

The v4 → v5 break is the removal of the date-versioned entry points (`2021-11-03/` … `2023-07-01/`, `latest/`, `oldest/`); only `index.d.ts` and `experimental/` remain. This repo resolves the default entry through `tsconfig.cloudflare.json`'s `types`, so that removal does not reach it.

## Verification

`typecheck`, `typecheck:cf` (1.68s), `build`, `test:cloudflare` (124 passed) all green. Unit tests show the 5 known port-3100/3001 flakes on this machine (4 in `sse-multi-user.test.ts`, 1 in `security-warnings.test.ts`); CI on a clean runner is authoritative.