### PR TITLE
chore(deps): bump ajv from 8.17.1 to 8.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
Dependabot #78. Lockfile-only — 8.20.0 already satisfies the range the MCP SDK declares, so `package.json` is untouched and **exactly one package moves**.

## Why this one matters more than the rest of the sweep

Unlike everything else in this dependency pass, `ajv` is a **production** dependency (`dev: false` in the lock), reached through `@modelcontextprotocol/sdk@1.30.0` both directly and via `ajv-formats`:

```
fizzy-mcp@1.1.0
└─┬ @modelcontextprotocol/sdk@1.30.0
  ├─┬ ajv-formats@3.0.1
  │ └── ajv@8.17.1 deduped
  └── ajv@8.17.1
```

It carries [GHSA-2g4f-4pwh-qvx6](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6) — a moderate ReDoS in the `$data` option affecting `>=7.0.0-alpha.0 <8.18.0`. 8.20.0 clears it.

This was the **last outstanding `npm audit` finding** and the only one that reached shipped code. The tree went from 17 findings to 1 over this sweep; this is the 1.

## Verification

`typecheck`, `typecheck:cf`, `build`, `test:cloudflare` (124 passed), `npm test` (757 passed) all green. The 5 remaining unit-test failures are the known port-3100/3001 conflict on this machine, equally present on `main`.

`npm audit --omit=dev` reports **0 vulnerabilities** after the bump. The full-tree audit could not be re-confirmed at PR time — npm's advisory endpoint was returning 503 — so the `dependency-review` check on this PR is the independent confirmation.