### PR TITLE
chore: standardize the placeholder account slug across docs and tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,15 @@ Instructions for AI coding agents working in this repository.
 ## Pull requests
 
 - Do not mention Claude, Claude Code, or AI assistance anywhere in pull requests — no "Generated with Claude Code" footers, badges, or AI attribution in PR titles, bodies, or review comments.
+
+## Test data and examples
+
+Use synthetic values wherever examples appear: tests, fixtures, code comments, README and doc
+examples, tool descriptions, and commit messages. This is a public repository, and tool
+descriptions in particular compile into `dist/`, ship in the published package, and are
+returned to every client in `tools/list`.
+
+- The established placeholder account slug is `123456`. Reuse it rather than introducing new ones.
+- Where behaviour is verified against a real account, keep the findings and drop the identifiers before committing. Account slugs, card numbers and titles, board and user IDs, `sgid` and Active Storage `signed_id` tokens, attachment filenames, and user names or email addresses all count.
+- Fixtures should keep the *shape* of real payloads (attribute names and ordering, nested element structure, token charset and length) and fabricate the *values*. Structure is what the code must handle; values are what leak.
+- Don't hardcode upstream hostnames. Base URLs are configurable, so assert on behaviour instead.

--- a/MCP_REFACTORING_COMPLETE.md
+++ b/MCP_REFACTORING_COMPLETE.md
@@ -51,7 +51,7 @@ account_slug: z.string().describe("The account slug identifier")
 
 // After  
 account_slug: z.string().describe(
-  "The account slug identifier (e.g., '6117483' or '/6117483'). " +
+  "The account slug identifier (e.g., '123456' or '/123456'). " +
   "This identifies which Fizzy account to operate on. " +
   "Get available account slugs from fizzy_get_identity or fizzy_get_accounts."
 )
@@ -310,7 +310,7 @@ outputSchema: z.object({
 // In definitions.ts
 examples: [
   {
-    input: { account_slug: "6117483" },
+    input: { account_slug: "123456" },
     output: { /* expected response */ }
   }
 ]

--- a/REFACTORING_SUCCESS.md
+++ b/REFACTORING_SUCCESS.md
@@ -49,7 +49,7 @@ account_slug: z.string().describe("The account slug identifier")
 
 // After
 account_slug: z.string().describe(
-  "The account slug identifier (e.g., '6117483' or '/6117483'). " +
+  "The account slug identifier (e.g., '123456' or '/123456'). " +
   "This identifies which Fizzy account to operate on. " +
   "Get available account slugs from fizzy_get_identity or fizzy_get_accounts."
 )

--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -169,7 +169,7 @@ export class FizzyClient {
 
   /**
    * Normalize account slug by removing leading slash if present.
-   * The Fizzy API returns slugs like "/6117483" but API paths need "6117483"
+   * The Fizzy API returns slugs like "/123456" but API paths need "123456"
    */
   private normalizeSlug(slug: string): string {
     if (!slug) {

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 
 // Common ID schemas with detailed descriptions
 export const accountSlugSchema = z.string().describe(
-  "The account slug identifier (e.g., '6117483' or '/6117483'). " +
+  "The account slug identifier (e.g., '123456' or '/123456'). " +
   "This identifies which Fizzy account to operate on. " +
   "Get available account slugs from fizzy_get_identity or fizzy_get_accounts."
 );

--- a/tests/client/fizzy-client.test.ts
+++ b/tests/client/fizzy-client.test.ts
@@ -185,10 +185,10 @@ describe("FizzyClient", () => {
         json: async () => [],
       });
 
-      await client.getBoards("/6117483");
+      await client.getBoards("/123456");
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://app.fizzy.do/6117483/boards",
+        "https://app.fizzy.do/123456/boards",
         expect.any(Object)
       );
     });
@@ -200,10 +200,10 @@ describe("FizzyClient", () => {
         json: async () => [],
       });
 
-      await client.getBoards("6117483");
+      await client.getBoards("123456");
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://app.fizzy.do/6117483/boards",
+        "https://app.fizzy.do/123456/boards",
         expect.any(Object)
       );
     });
@@ -1651,10 +1651,10 @@ describe("FizzyClient", () => {
     it("should strip the leading slash from the account slug for pins", async () => {
       mockFetch.mockResolvedValueOnce(createMockResponse([]));
 
-      await client.getPins("/6117483");
+      await client.getPins("/123456");
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://app.fizzy.do/6117483/my/pins",
+        "https://app.fizzy.do/123456/my/pins",
         expect.any(Object)
       );
     });

--- a/tests/tools/json-schema.test.ts
+++ b/tests/tools/json-schema.test.ts
@@ -165,10 +165,10 @@ describe("Tool JSON Schema — fizzy_get_cards pagination", () => {
     )!.schema;
 
     expect(
-      schema.safeParse({ account_slug: "6117483", page: 0 }).success
+      schema.safeParse({ account_slug: "123456", page: 0 }).success
     ).toBe(false);
     expect(
-      schema.safeParse({ account_slug: "6117483", page: 1 }).success
+      schema.safeParse({ account_slug: "123456", page: 1 }).success
     ).toBe(true);
   });
 });


### PR DESCRIPTION
Examples and fixtures used two different placeholder account slugs depending on which file you looked at. The README, `card-assignments.test.ts` and `upload-file.test.ts` already used `123456`; six other files used a different value. This settles on `123456` everywhere, so there is one obvious placeholder rather than two competing ones.

Worth doing rather than leaving alone because one of those examples is not just documentation. The `account_slug` schema description in `src/tools/schemas.ts` compiles into `dist/`, which is in `package.json`'s `files` array — so it ships in the published package and is returned to every client in every `tools/list` response. An example on that surface is also what every model using this server sees, so it should be unmistakably a placeholder.

## Changed

| File | Occurrences |
| --- | --- |
| `tests/client/fizzy-client.test.ts` | 6 |
| `MCP_REFACTORING_COMPLETE.md` | 2 |
| `tests/tools/json-schema.test.ts` | 2 |
| `src/tools/schemas.ts` | 1 |
| `src/client/fizzy-client.ts` | 1 |
| `REFACTORING_SUCCESS.md` | 1 |

`CLAUDE.md` gains a "Test data and examples" section recording the convention, so the next example added reuses the placeholder rather than introducing a third.

## Verification

`typecheck`, `typecheck:cf`, `test:cloudflare` (124 tests) and `build` all pass.

The unit suite passes apart from 5 pre-existing `EADDRINUSE` failures in the transport tests, caused by a foreign process holding port 3100 on the test machine. Unrelated to this change: the diff touches no transport code, and neither failing test file references the slug.