### PR TITLE
feat(attachments): add a read path so a model can see what is already on a card

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ npx fizzy-mcp --transport http --port 3000
 
 ---
 
-## Available Tools (53 total)
+## Available Tools (54 total)
 
 ### Identity & Accounts (2)
 | Tool | Description |
@@ -544,7 +544,7 @@ npx fizzy-mcp --transport http --port 3000
 |------|-------------|
 | `fizzy_get_cards` | List cards with optional filters (board, indexed_by, column, assignees, tags, search); `search_mode="all"` requires every usable search word instead of any; `fields="summary"` returns a much smaller payload for browsing |
 | `fizzy_get_pins` | List the current user's pinned cards (not paginated, max 100); prefer `fields="summary"` |
-| `fizzy_get_card` | Get card details including description, assignees, tags |
+| `fizzy_get_card` | Get card details including description, assignees, tags; `include_attachments=true` adds structured attachment metadata |
 | `fizzy_create_card` | Create a new card with title, description, status, column, assignees, tags, due date |
 | `fizzy_update_card` | Update any card property |
 | `fizzy_delete_card` | Delete a card |
@@ -569,7 +569,7 @@ npx fizzy-mcp --transport http --port 3000
 ### Comments (5)
 | Tool | Description |
 |------|-------------|
-| `fizzy_get_card_comments` | List comments on a card (complete thread; every upstream page is fetched server-side); `fields="summary"` drops the duplicated HTML body and repeated card/creator detail |
+| `fizzy_get_card_comments` | List comments on a card (complete thread; every upstream page is fetched server-side); `fields="summary"` drops the duplicated HTML body and repeated card/creator detail; `include_attachments=true` adds structured attachment metadata |
 | `fizzy_get_comment` | Get a specific comment |
 | `fizzy_create_comment` | Add a comment to a card (supports HTML) |
 | `fizzy_update_comment` | Update a comment |
@@ -620,10 +620,11 @@ npx fizzy-mcp --transport http --port 3000
 | `fizzy_mark_notification_unread` | Mark notification as unread |
 | `fizzy_mark_all_notifications_read` | Mark all notifications as read |
 
-### Attachments (1)
+### Attachments (2)
 | Tool | Description |
 |------|-------------|
 | `fizzy_upload_file` | Upload a file and get back HTML that embeds it in rich text |
+| `fizzy_get_attachment` | Fetch a file already attached to a card or comment; images come back as an image |
 
 #### Attaching a file to a card or comment
 
@@ -672,6 +673,62 @@ HTTP and SSE transports serve remote callers — honouring a path there would le
 client read the *server's* disk — and Workers have no filesystem. Uploads are
 capped at 10 MB on both paths.
 
+#### Reading an attachment that is already on a card
+
+The API never reports attachments as data. They exist only as
+`<action-text-attachment>` markup inside the rich-text HTML — `description_html`
+on a card, `body.html` on a comment — and the plain-text rendering flattens each
+one to a bare `[filename.png]` with no URL. Reading one back is therefore two
+steps.
+
+`include_attachments` is opt-in and changes nothing when omitted: without it,
+both tools return exactly the response they always did.
+
+```jsonc
+// 1. Ask for the structured metadata alongside the card.
+{ "name": "fizzy_get_card",
+  "arguments": { "account_slug": "1234567", "card_id": "42", "include_attachments": true } }
+
+// Adds an "attachments" array to the usual card payload:
+// [{
+//   "filename": "screenshot.png",
+//   "content_type": "image/png",
+//   "byte_size": 204800,
+//   "width": 1600,
+//   "height": 900,
+//   "signed_id": "eyJfcmFpbHMi...--1111...",
+//   "url": "https://app.fizzy.do/1234567/rails/active_storage/blobs/redirect/...",
+//   "preview_url": "https://app.fizzy.do/1234567/rails/active_storage/representations/redirect/...",
+//   "preview_variation": "eyJfcmFpbHMi...--3333..."
+// }]
+
+// 2. Fetch it. Pass preview_variation as `variation` to get the resized
+//    preview, which is what a model can usefully look at.
+{ "name": "fizzy_get_attachment",
+  "arguments": {
+    "account_slug": "1234567",
+    "signed_id": "eyJfcmFpbHMi...--1111...",
+    "filename": "screenshot.png",
+    "variation": "eyJfcmFpbHMi...--3333..."
+  } }
+```
+
+PNG, JPEG, GIF and WebP come back as an MCP image block the model can see.
+Anything else — PDFs, archives, SVG, video — comes back as metadata with a note
+that it is not renderable, and its bytes are never downloaded.
+
+**`fizzy_get_attachment` takes no URL, by design.** Fetching a caller-supplied
+URL with the account's access token attached would be a server-side request
+forgery carrying a credential, so the tool takes the blob's `signed_id` and
+rebuilds the address itself. Inlined images are capped at 3 MB — Base64 inflates
+by ~4/3 into the response — and an original over that is refused in favour of its
+preview rather than truncated.
+
+The token is never sent to the storage host. ActiveStorage answers with a
+redirect to a signed storage URL, and that redirect is followed by hand: the
+`Authorization` header is attached only while the URL is still on the configured
+Fizzy origin, rather than trusting a runtime to strip credentials across origins.
+
 ---
 
 ## Example Prompts
@@ -685,6 +742,7 @@ Once configured, you can ask your AI assistant things like:
 - "Move the 'Design review' card to the 'Done' column"
 - "Add a comment to the authentication card saying 'Ready for review'"
 - "Attach this screenshot to card 42 as evidence"
+- "Show me the screenshot attached to card 42"
 - "Show me my unread notifications"
 - "List all users in my account"
 - "Create a new column called 'In Review' with blue color on the Engineering board"

--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -1598,6 +1598,14 @@ export class FizzyClient {
   private static readonly MAX_ATTACHMENT_REDIRECTS = 4;
 
   /**
+   * How much of a failed attachment response is read to build its error message.
+   *
+   * Enough for a Rails error page's useful opening; small enough that an
+   * unbounded body on the least trustworthy hop in the chain costs nothing.
+   */
+  private static readonly MAX_ATTACHMENT_ERROR_BYTES = 8 * 1024;
+
+  /**
    * Build the ActiveStorage path for a blob, or for one of its representations.
    *
    * Every component is interpolated, never concatenated from caller-supplied
@@ -1677,6 +1685,56 @@ export class FizzyClient {
    * is the fallback for partial mocks that define no `body`, matching the
    * capability checks the JSON path already makes.
    */
+  /**
+   * Read at most `limit` bytes of a body as text, discarding the remainder.
+   *
+   * Exists because the *error* path would otherwise be the one place the
+   * attachment size cap does not apply. `readBoundedBody` guards a successful
+   * response, but a storage host answering 500 with a chunked body — no
+   * `Content-Length` needed — would have been buffered whole by `.text()` just
+   * to build an error message, defeating the cap on precisely the response
+   * least worth trusting.
+   *
+   * Never throws: a failure reading an error body must not replace the HTTP
+   * error being reported with a less informative one.
+   */
+  private async readTruncatedText(response: Response, limit: number): Promise<string> {
+    const body = response.body;
+    if (!body || typeof body.getReader !== "function") {
+      // No stream to bound — mocked and older-runtime responses only.
+      const text = await response.text().catch(() => "");
+      return text.length > limit ? `${text.slice(0, limit)}…` : text;
+    }
+
+    const reader = body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      while (total < limit) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        const remaining = limit - total;
+        const slice = value.byteLength > remaining ? value.subarray(0, remaining) : value;
+        chunks.push(slice);
+        total += slice.byteLength;
+      }
+    } catch {
+      // Fall through with whatever was read.
+    } finally {
+      // Discards the untruncated tail and releases the connection.
+      await reader.cancel().catch(() => {});
+    }
+
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(bytes);
+  }
+
   private async readBoundedBody(
     response: Response,
     maxBytes: number,
@@ -1795,14 +1853,28 @@ export class FizzyClient {
           signal: controller.signal,
         });
 
-        const next = this.resolveAttachmentRedirect(response, url);
+        let next: string | null;
+        try {
+          next = this.resolveAttachmentRedirect(response, url);
+        } catch (error) {
+          // A rejected redirect still arrived with a body nobody will read.
+          await response.body?.cancel?.().catch(() => {});
+          throw error;
+        }
         if (next !== null) {
+          // Nothing reads a redirect's body, so release the connection rather
+          // than leaving it to the GC — and a 302 carrying a large body then
+          // costs one header round trip instead of its full length.
+          await response.body?.cancel?.().catch(() => {});
           url = next;
           continue;
         }
 
         if (!response.ok) {
-          const errorText = await response.text().catch(() => "");
+          const errorText = await this.readTruncatedText(
+            response,
+            FizzyClient.MAX_ATTACHMENT_ERROR_BYTES
+          );
           throw createAPIError(response.status, response.statusText, errorText);
         }
 

--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -32,9 +32,14 @@ import type {
   DirectUploadBlobRequest,
   FizzyDirectUpload,
   FileUpload,
+  AttachmentRef,
+  FetchAttachmentOptions,
+  FetchedAttachment,
 } from "./types.js";
 import {
   createAPIError,
+  FizzyAttachmentTooLargeError,
+  FizzyAuthError,
   FizzyNetworkError,
   FizzyTimeoutError,
   FizzyParseError,
@@ -112,6 +117,18 @@ export class FizzyClient {
           maxEntryBytes: config.cacheMaxEntryBytes,
         })
       : null;
+  }
+
+  /**
+   * The API origin this client is configured against.
+   *
+   * Exposed because the rich-text fields the tools return carry
+   * account-scoped *paths*, and turning those into usable URLs must resolve
+   * against the configured host rather than a hardcoded one — a self-hosted or
+   * staging Fizzy has to resolve against itself.
+   */
+  getBaseUrl(): string {
+    return this.baseUrl;
   }
 
   /**
@@ -1566,5 +1583,274 @@ export class FizzyClient {
     );
 
     return upload;
+  }
+
+  // ============ Attachments (reading a blob back) ============
+
+  /**
+   * Hard stop on the redirect chain out of ActiveStorage.
+   *
+   * One hop is what the service actually does today (API → storage). The extra
+   * headroom covers a storage backend that redirects once more of its own
+   * accord, while still turning a redirect loop into an error rather than an
+   * unbounded request loop — the same reasoning as MAX_AGGREGATED_PAGES.
+   */
+  private static readonly MAX_ATTACHMENT_REDIRECTS = 4;
+
+  /**
+   * Build the ActiveStorage path for a blob, or for one of its representations.
+   *
+   * Every component is interpolated, never concatenated from caller-supplied
+   * text: `parseAttachmentRequest` has already pinned each of them to a single
+   * path segment, and the filename is percent-encoded on top of that because
+   * ActiveStorage treats it as decoration and a legal name can still contain
+   * characters that mean something in a URL.
+   */
+  private attachmentPath(slug: string, ref: AttachmentRef): string {
+    const filename = encodeURIComponent(ref.filename);
+    return ref.variation
+      ? `/${slug}/rails/active_storage/representations/redirect/${ref.signedId}/${ref.variation}/${filename}`
+      : `/${slug}/rails/active_storage/blobs/redirect/${ref.signedId}/${filename}`;
+  }
+
+  /**
+   * Where a 3xx points, resolved and vetted, or null when this is not a redirect.
+   *
+   * The `Location` of a response is not trusted input just because the response
+   * came from Fizzy: it decides the URL this client fetches next, so it is
+   * pinned to http/https here. A `file:`, `data:` or `blob:` target would
+   * otherwise be handed straight to `fetch`.
+   */
+  private resolveAttachmentRedirect(response: Response, from: string): string | null {
+    const status = response.status;
+    if (status !== 301 && status !== 302 && status !== 303 && status !== 307 && status !== 308) {
+      return null;
+    }
+
+    const location = response.headers?.get?.("Location");
+    if (!location) {
+      throw new FizzyParseError(
+        `Attachment request returned ${status} with no Location header`
+      );
+    }
+
+    let next: URL;
+    try {
+      next = new URL(location, from);
+    } catch {
+      throw new FizzyParseError("Attachment redirect Location is not a valid URL");
+    }
+    if (next.protocol !== "http:" && next.protocol !== "https:") {
+      throw new FizzyParseError(
+        `Refusing to follow an attachment redirect to ${next.protocol} — only http and https are followed`
+      );
+    }
+
+    // Unauthenticated reads of a blob redirect land on the sign-in page rather
+    // than a 401, so without this the caller gets an HTML login form typed as
+    // their attachment. Reported as the auth failure it actually is.
+    if (next.origin === this.originOfBaseUrl() && /^\/session(\/|$)/.test(next.pathname)) {
+      throw new FizzyAuthError(
+        "Authentication failed: the attachment request was redirected to sign-in. " +
+          "Check the access token and that it can read this account."
+      );
+    }
+
+    return next.toString();
+  }
+
+  /** The configured base URL's origin, or "" when it is not parseable. */
+  private originOfBaseUrl(): string {
+    try {
+      return new URL(this.baseUrl).origin;
+    } catch {
+      return "";
+    }
+  }
+
+  /**
+   * Read a response body, refusing rather than truncating past `maxBytes`.
+   *
+   * `Content-Length` is checked first so an oversized attachment costs nothing
+   * to reject, then the stream is read incrementally so a response that
+   * declares no length — or lies about it — is still bounded. `arrayBuffer()`
+   * is the fallback for partial mocks that define no `body`, matching the
+   * capability checks the JSON path already makes.
+   */
+  private async readBoundedBody(
+    response: Response,
+    maxBytes: number,
+    describe: string
+  ): Promise<Uint8Array> {
+    const declared = Number(response.headers?.get?.("Content-Length") ?? Number.NaN);
+    if (Number.isSafeInteger(declared) && declared > maxBytes) {
+      throw new FizzyAttachmentTooLargeError(
+        `${describe} is ${declared} bytes, over the ${maxBytes}-byte limit for an inlined attachment`,
+        maxBytes,
+        declared
+      );
+    }
+
+    const body = response.body;
+    if (!body || typeof body.getReader !== "function") {
+      const buffer = await response.arrayBuffer();
+      if (buffer.byteLength > maxBytes) {
+        throw new FizzyAttachmentTooLargeError(
+          `${describe} is ${buffer.byteLength} bytes, over the ${maxBytes}-byte limit for an inlined attachment`,
+          maxBytes,
+          buffer.byteLength
+        );
+      }
+      return new Uint8Array(buffer);
+    }
+
+    const reader = body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        total += value.byteLength;
+        if (total > maxBytes) {
+          throw new FizzyAttachmentTooLargeError(
+            `${describe} is over the ${maxBytes}-byte limit for an inlined attachment`,
+            maxBytes
+          );
+        }
+        chunks.push(value);
+      }
+    } finally {
+      // Releases the connection on the throw path; a no-op once the stream ended.
+      await reader.cancel().catch(() => {});
+    }
+
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return bytes;
+  }
+
+  /**
+   * Read an attachment back, following ActiveStorage's redirect to storage by
+   * hand.
+   *
+   * **The Fizzy bearer token must never reach the storage host.** The redirect
+   * is therefore followed manually — `redirect: "manual"` on every hop — and
+   * the `Authorization` header is attached only while the URL is still on the
+   * configured Fizzy origin. Auto-following is not an option: whether a runtime
+   * strips credentials on a cross-origin redirect is runtime-dependent, and
+   * this code ships on both Node (undici) and Cloudflare Workers. The same
+   * invariant governs the upload direction — see `putBlobToStorage`, which
+   * sends only the headers storage signed.
+   *
+   * Deciding per hop rather than assuming exactly two also keeps the
+   * representation endpoint working: a variant that is not yet processed can
+   * redirect within the Fizzy origin first, and that hop *does* need the token.
+   *
+   * No retry, for the same reason `putBlobToStorage` has none: replaying
+   * against a signed storage URL that may since have expired turns one clear
+   * error into a slower, less obvious one.
+   *
+   * The storage URL itself is deliberately not returned. It is a signed,
+   * time-limited grant to download the blob without any credential at all —
+   * handing it back to the model would put a bearer-equivalent secret into a
+   * transcript and let anything downstream fetch outside these checks.
+   */
+  async fetchAttachment(
+    accountSlug: string,
+    ref: AttachmentRef,
+    options: FetchAttachmentOptions
+  ): Promise<FetchedAttachment> {
+    const slug = this.normalizeSlug(accountSlug);
+    const baseOrigin = this.originOfBaseUrl();
+    let url = `${this.baseUrl}${this.attachmentPath(slug, ref)}`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      for (let hop = 0; hop <= FizzyClient.MAX_ATTACHMENT_REDIRECTS; hop++) {
+        // The whole point of the manual walk: credentials are attached by
+        // origin, so they stop at the boundary between Fizzy and storage.
+        const onFizzyOrigin = baseOrigin !== "" && this.isSameOrigin(url, baseOrigin);
+        const headers: Record<string, string> = { Accept: "*/*" };
+        if (onFizzyOrigin) {
+          headers.Authorization = `Bearer ${this.accessToken}`;
+        }
+
+        this.log.debug("Fetching attachment", {
+          hop,
+          authenticated: onFizzyOrigin,
+        });
+
+        const response = await fetch(url, {
+          method: "GET",
+          headers,
+          redirect: "manual",
+          signal: controller.signal,
+        });
+
+        const next = this.resolveAttachmentRedirect(response, url);
+        if (next !== null) {
+          url = next;
+          continue;
+        }
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "");
+          throw createAPIError(response.status, response.statusText, errorText);
+        }
+
+        const contentType = (response.headers?.get?.("Content-Type") ?? "")
+          .split(";")[0]
+          .trim()
+          .toLowerCase();
+        const declared = Number(response.headers?.get?.("Content-Length") ?? Number.NaN);
+        const byteSize = Number.isSafeInteger(declared) && declared >= 0 ? declared : undefined;
+
+        if (options.shouldReadBody && !options.shouldReadBody(contentType)) {
+          // Nothing here wants the bytes, so don't pay for them.
+          await response.body?.cancel?.().catch(() => {});
+          return { contentType, byteSize };
+        }
+
+        const bytes = await this.readBoundedBody(response, options.maxBytes, ref.filename);
+        return { contentType, bytes, byteSize: bytes.length };
+      }
+
+      throw new FizzyNetworkError(
+        `Attachment request redirected more than ${FizzyClient.MAX_ATTACHMENT_REDIRECTS} times`
+      );
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new FizzyTimeoutError(
+          `Attachment fetch timed out after ${this.timeout}ms`,
+          this.timeout
+        );
+      }
+      if (error instanceof TypeError && error.message.includes("fetch")) {
+        throw new FizzyNetworkError(
+          `Network error while fetching attachment: ${error.message}`,
+          error
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /** Whether `url` is on `origin`; an unparseable URL is never same-origin. */
+  private isSameOrigin(url: string, origin: string): boolean {
+    try {
+      return new URL(url).origin === origin;
+    } catch {
+      return false;
+    }
   }
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -317,3 +317,48 @@ export interface FileUpload {
   filename: string;
   contentType: string;
 }
+
+/**
+ * Which blob to read back, named by signed id rather than by URL.
+ *
+ * Never a URL. The address is rebuilt from these parts inside the client, so a
+ * caller cannot steer the request that carries the Fizzy bearer token — see
+ * `parseAttachmentRequest` in utils/attachments.ts, which validates every part
+ * before one of these is constructed.
+ */
+export interface AttachmentRef {
+  /** ActiveStorage signed id of the blob, purpose "blob_id". */
+  signedId: string;
+  /** Single path segment; ActiveStorage uses it only for Content-Disposition. */
+  filename: string;
+  /**
+   * Signed ActiveStorage variation key. Present to fetch the resized
+   * representation (the preview) rather than the full-resolution original.
+   */
+  variation?: string;
+}
+
+/** How much of an attachment to read, and how much of it to tolerate. */
+export interface FetchAttachmentOptions {
+  /** Hard cap on the bytes read. Exceeding it throws rather than truncating. */
+  maxBytes: number;
+  /**
+   * Whether the body is worth downloading, given the type the server reports.
+   * Returning false leaves `bytes` unset and cancels the body — the difference
+   * between reporting that a 40 MB archive is attached and downloading it.
+   */
+  shouldReadBody?: (contentType: string) => boolean;
+}
+
+/** An attachment as read back from storage. */
+export interface FetchedAttachment {
+  /** The final response's media type, parameters stripped, lowercased. */
+  contentType: string;
+  /** Unset when `shouldReadBody` declined this type. */
+  bytes?: Uint8Array;
+  /**
+   * Size in bytes: the length actually read, or the declared Content-Length
+   * when the body was skipped. Unset when neither is known.
+   */
+  byteSize?: number;
+}

--- a/src/cloudflare/mcp-session.ts
+++ b/src/cloudflare/mcp-session.ts
@@ -39,7 +39,7 @@ import {
   buildMcpToolDefinitions,
   type McpToolDefinition,
 } from "../tools/json-schema.js";
-import { executeToolHandler } from "../tools/handlers.js";
+import { executeToolHandler, toMcpContent } from "../tools/handlers.js";
 import { CLIENT_AUTH_HEADER } from "../utils/client-auth.js";
 
 /**
@@ -360,12 +360,10 @@ export class McpSessionDO extends DurableObject<Env> {
         jsonrpc: "2.0",
         id,
         result: {
-          content: [
-            {
-              type: "text",
-              text: typeof result === "string" ? result : JSON.stringify(result, null, 2),
-            },
-          ],
+          // Shared with server.ts rather than reimplemented, so both transports
+          // format a tool result identically — including fizzy_get_attachment,
+          // whose `image` block JSON in a text block cannot stand in for.
+          content: toMcpContent(result),
         },
       };
     } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,20 +10,23 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { FizzyClient } from "./client/fizzy-client.js";
 import { ALL_TOOLS } from "./tools/definitions.js";
-import { executeToolHandler } from "./tools/handlers.js";
+import {
+  executeToolHandler,
+  toMcpContent,
+  type McpContentBlock,
+} from "./tools/handlers.js";
 
 /**
  * Format handler result as MCP tool response
+ *
+ * The rule itself lives in `toMcpContent`, shared with the Cloudflare
+ * transport so both answer identically — including for the one handler that
+ * returns an `image` block rather than serialized JSON.
  */
 function formatMcpResponse(result: unknown): {
-  content: Array<{ type: "text"; text: string }>;
+  content: McpContentBlock[];
 } {
-  const text = typeof result === "string"
-    ? result
-    : JSON.stringify(result, null, 2);
-  return {
-    content: [{ type: "text" as const, text }],
-  };
+  return { content: toMcpContent(result) };
 }
 
 /**

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -177,7 +177,14 @@ export const TOOL_DEFINITIONS = {
       description:
         "Get detailed information about a specific card including full description (HTML), " +
         "assignees, tags, due dates, steps (to-dos), and metadata. " +
-        "Use this to see complete card content before making updates.",
+        "Use this to see complete card content before making updates. " +
+        "Attachments — screenshots, images, PDFs, logs — appear in the description only as " +
+        "raw <action-text-attachment> markup, and the plain-text description flattens them " +
+        "to a bare filename with no way to fetch them. Pass include_attachments=true to also " +
+        "get an 'attachments' array with each file's filename, content_type, byte_size, " +
+        "dimensions and signed_id; pass that signed_id and filename to fizzy_get_attachment " +
+        "to actually see an image. Do that whenever a card mentions a screenshot or the " +
+        "answer depends on what a picture shows.",
       schema: schemas.getCardSchema,
       annotations: {
         readOnlyHint: true,
@@ -399,7 +406,12 @@ export const TOOL_DEFINITIONS = {
         "The result is the complete thread: every upstream page is fetched server-side, so there is no page " +
         "parameter and nothing further to request. " +
         "Use fields='summary' to drop the duplicated HTML body and the repeated per-comment card/creator " +
-        "detail — comment text itself is never truncated in either mode.",
+        "detail — comment text itself is never truncated in either mode. " +
+        "Attachments posted in a comment appear only as raw <action-text-attachment> markup inside the " +
+        "HTML body, which fields='summary' drops entirely. Pass include_attachments=true to add a " +
+        "per-comment 'attachments' array with each file's filename, content_type, byte_size, dimensions " +
+        "and signed_id — it works in both modes — then pass that signed_id and filename to " +
+        "fizzy_get_attachment to actually see an image.",
       schema: schemas.getCardCommentsSchema,
       annotations: {
         readOnlyHint: true,
@@ -758,6 +770,28 @@ export const TOOL_DEFINITIONS = {
       schema: schemas.uploadFileSchema,
       annotations: {
         readOnlyHint: false,
+        destructiveHint: false,
+      },
+    },
+    {
+      name: "fizzy_get_attachment",
+      title: "Get Attachment",
+      description:
+        "Fetch a file already attached to a card or comment and return it so it can actually be " +
+        "looked at. Images (PNG, JPEG, GIF, WebP) come back as an image the model can see; any " +
+        "other type comes back as metadata with a note that it cannot be rendered, and its bytes " +
+        "are not downloaded. " +
+        "Get the 'signed_id' and 'filename' to pass here from fizzy_get_card or " +
+        "fizzy_get_card_comments called with include_attachments=true — this tool takes no URL, " +
+        "and building the arguments from a URL by hand will not work. " +
+        "Prefer the preview: when the attachment reports a 'preview_variation', pass it as " +
+        "'variation' to get the resized version, which is a fraction of the bytes and is what a " +
+        "full-resolution screenshot is refused in favour of. " +
+        "Use this whenever a card or comment references a screenshot, mockup, diagram, or error " +
+        "image and the answer depends on what it shows.",
+      schema: schemas.getAttachmentSchema,
+      annotations: {
+        readOnlyHint: true,
         destructiveHint: false,
       },
     },

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -17,7 +17,16 @@ import {
 } from "../client/types.js";
 import { resolveCardNumber } from "../utils/card-resolver.js";
 import { splitSearchTerms, type SearchTerms } from "../utils/search-terms.js";
-import { attachmentHtml, resolveAttachment } from "../utils/attachments.js";
+import { parseActionTextAttachments } from "../utils/action-text.js";
+import {
+  attachmentHtml,
+  isInlineableImage,
+  parseAttachmentRequest,
+  resolveAttachment,
+  MAX_INLINE_IMAGE_BYTES,
+} from "../utils/attachments.js";
+import { bytesToBase64 } from "../utils/base64.js";
+import { FizzyAttachmentTooLargeError } from "../utils/errors.js";
 import {
   parseFieldsMode,
   summarizeCard,
@@ -29,6 +38,76 @@ import {
  * Tool handler result - either data to serialize or a success message
  */
 export type HandlerResult = unknown;
+
+/**
+ * A block of an MCP tool response, for the handlers that need to return
+ * something other than serialized JSON.
+ */
+export type McpContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
+/**
+ * A handler result that is already MCP content rather than data to serialize.
+ *
+ * Both transports format a handler's return value the same way — a string
+ * verbatim, anything else as pretty-printed JSON in a single `text` block — and
+ * that is right for every tool but one. `fizzy_get_attachment` has to emit an
+ * `image` block, which no amount of JSON in a text block substitutes for: the
+ * point of the tool is that the model can *see* the screenshot. Rather than
+ * teaching each transport about that tool, handlers can return this marker and
+ * both formatters pass its blocks straight through.
+ */
+export interface McpContentResult {
+  mcp_content: McpContentBlock[];
+}
+
+/** Wrap MCP content blocks so the transports forward them unchanged. */
+export function mcpContent(blocks: McpContentBlock[]): McpContentResult {
+  return { mcp_content: blocks };
+}
+
+function isMcpContentBlock(value: unknown): value is McpContentBlock {
+  if (typeof value !== "object" || value === null) return false;
+  const block = value as Record<string, unknown>;
+  if (block.type === "text") return typeof block.text === "string";
+  if (block.type === "image") {
+    return typeof block.data === "string" && typeof block.mimeType === "string";
+  }
+  return false;
+}
+
+/**
+ * Whether a handler result is pre-formatted MCP content.
+ *
+ * Every block is shape-checked, not just the marker key. An API response that
+ * happened to carry an `mcp_content` array would otherwise be reinterpreted as
+ * content blocks and silently lose its data; requiring each element to be a
+ * well-formed block makes that collision effectively impossible.
+ */
+export function isMcpContentResult(result: unknown): result is McpContentResult {
+  if (typeof result !== "object" || result === null) return false;
+  const blocks = (result as Record<string, unknown>).mcp_content;
+  return Array.isArray(blocks) && blocks.length > 0 && blocks.every(isMcpContentBlock);
+}
+
+/**
+ * Render a handler result as the `content` array of an MCP tool response.
+ *
+ * One function rather than one per transport: the standard server and the
+ * Cloudflare Durable Object previously each carried their own copy of this
+ * two-line rule, and a tool whose response formatting differed between them
+ * would be a bug nobody could see from either side.
+ */
+export function toMcpContent(result: unknown): McpContentBlock[] {
+  if (isMcpContentResult(result)) return result.mcp_content;
+  return [
+    {
+      type: "text",
+      text: typeof result === "string" ? result : JSON.stringify(result, null, 2),
+    },
+  ];
+}
 
 /**
  * Tool handler function signature
@@ -63,6 +142,43 @@ function parseSearchMode(value: unknown): "any" | "all" {
   throw new Error(
     `Invalid search_mode: ${JSON.stringify(value)}. Expected "any" or "all".`
   );
+}
+
+/**
+ * Validate the optional `include_attachments` flag of fizzy_get_card and
+ * fizzy_get_card_comments.
+ *
+ * Here rather than only in the Zod schema for the usual reason — the Cloudflare
+ * transport dispatches raw args — and with the usual leniency about `"true"`,
+ * which LLM clients send routinely for a boolean.
+ *
+ * Anything else throws rather than defaulting to `false`. Silently ignoring a
+ * malformed value would hand back a response with no `attachments` field and no
+ * indication why, which reads as "this card has no attachments".
+ */
+function parseIncludeAttachments(value: unknown): boolean {
+  if (value === undefined) return false;
+  if (typeof value === "boolean") return value;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(
+    `include_attachments must be a boolean, got: ${JSON.stringify(value)}`
+  );
+}
+
+/**
+ * The HTML side of a rich-text field, whether it arrives as `{html, plain_text}`
+ * (a comment body) or as a bare string (a card's `description_html`).
+ *
+ * Structural and defensive, like the projections: `description_html` is one of
+ * the fields the live API returns and `client/types.ts` does not model.
+ */
+function richTextHtml(value: unknown): unknown {
+  if (typeof value === "string") return value;
+  if (typeof value === "object" && value !== null) {
+    return (value as Record<string, unknown>).html;
+  }
+  return undefined;
 }
 
 function parsePage(value: unknown): number | undefined {
@@ -309,7 +425,32 @@ export const toolHandlers: Record<string, ToolHandler> = {
   },
 
   fizzy_get_card: async (client, args) => {
-    return client.getCard(args.account_slug as string, args.card_id as string);
+    // Parsed before the request so a malformed flag fails without spending an
+    // API round-trip, the same ordering fizzy_get_pins uses for `fields`.
+    const includeAttachments = parseIncludeAttachments(args.include_attachments);
+    const card = await client.getCard(
+      args.account_slug as string,
+      args.card_id as string
+    );
+    // Without the flag this returns the client's value untouched — the response
+    // is byte-for-byte what it was before include_attachments existed.
+    if (!includeAttachments) return card;
+
+    // Defensive: the declared return type says this is always an object, but a
+    // 204 or an empty body reaches here as undefined, and spreading that throws.
+    if (typeof card !== "object" || card === null) return card;
+
+    const record = card as unknown as Record<string, unknown>;
+    return {
+      ...record,
+      // `description_html` is one of the fields the live API returns and
+      // client/types.ts does not model; parseActionTextAttachments takes
+      // `unknown` precisely so this needs no cast to reach it.
+      attachments: parseActionTextAttachments(
+        richTextHtml(record.description_html),
+        client.getBaseUrl()
+      ),
+    };
   },
 
   // Assignments are applied *after* the card exists rather than in the create
@@ -563,6 +704,7 @@ export const toolHandlers: Record<string, ToolHandler> = {
     // unvalidated Cloudflare path a bad `fields` value would otherwise spend a request
     // first, and a failure there would mask the real invalid-argument error.
     const fieldsMode = parseFieldsMode(args.fields);
+    const includeAttachments = parseIncludeAttachments(args.include_attachments);
     const cardNumber = await resolveCardNumber(
       client,
       args.account_slug as string,
@@ -570,10 +712,27 @@ export const toolHandlers: Record<string, ToolHandler> = {
       args.card_number as string | undefined
     );
     const comments = await client.getCardComments(args.account_slug as string, cardNumber);
-    if (fieldsMode === "full") return comments;
-    return comments.map((comment) =>
-      summarizeComment(comment as unknown as Record<string, unknown>)
-    );
+
+    // Both modes' existing output is produced first and returned untouched when
+    // the flag is absent, so neither response shape moves for existing callers.
+    if (!includeAttachments) {
+      if (fieldsMode === "full") return comments;
+      return comments.map((comment) =>
+        summarizeComment(comment as unknown as Record<string, unknown>)
+      );
+    }
+
+    // Attachments are added in summary mode too, and are most useful there:
+    // summarizeComment drops `body.html`, which is the only place they appear.
+    const baseUrl = client.getBaseUrl();
+    return comments.map((comment) => {
+      const record = comment as unknown as Record<string, unknown>;
+      const projected = fieldsMode === "full" ? record : summarizeComment(record);
+      return {
+        ...projected,
+        attachments: parseActionTextAttachments(richTextHtml(record.body), baseUrl),
+      };
+    });
   },
 
   fizzy_get_comment: async (client, args) => {
@@ -803,6 +962,61 @@ export const toolHandlers: Record<string, ToolHandler> = {
         "example as the 'body' of fizzy_create_comment, or the 'description' of " +
         "fizzy_update_card. Do not rebuild the tag by hand.",
     };
+  },
+
+  // Reads an attachment back so the model can look at it. The security
+  // properties this depends on live one layer down, deliberately:
+  // parseAttachmentRequest refuses a caller-supplied URL and pins every token to
+  // a single path segment, and FizzyClient.fetchAttachment walks the redirect to
+  // storage by hand so the Fizzy token never leaves the Fizzy origin.
+  fizzy_get_attachment: async (client, args) => {
+    const { accountSlug, ...ref } = parseAttachmentRequest(args);
+
+    let fetched;
+    try {
+      fetched = await client.fetchAttachment(accountSlug, ref, {
+        maxBytes: MAX_INLINE_IMAGE_BYTES,
+        // A zip or a video has nothing a model can look at, so its bytes are
+        // never downloaded — the caller gets the metadata and an explanation
+        // instead of megabytes of base64.
+        shouldReadBody: isInlineableImage,
+      });
+    } catch (error) {
+      if (error instanceof FizzyAttachmentTooLargeError && ref.variation === undefined) {
+        throw new Error(
+          `${error.message}. Re-request it with the attachment's 'preview_variation' ` +
+            `as 'variation' to fetch the resized preview instead.`
+        );
+      }
+      throw error;
+    }
+
+    const contentType = fetched.contentType || "application/octet-stream";
+    const summary = {
+      filename: ref.filename,
+      content_type: contentType,
+      byte_size: fetched.byteSize,
+      variant: ref.variation ? "preview" : "original",
+    };
+
+    if (fetched.bytes === undefined) {
+      return {
+        ...summary,
+        renderable: false,
+        note:
+          `This attachment is ${contentType}, which cannot be shown as an image, so its ` +
+          `bytes were not downloaded. Open the attachment's 'url' in a browser to view it.`,
+      };
+    }
+
+    return mcpContent([
+      { type: "text", text: JSON.stringify(summary, null, 2) },
+      {
+        type: "image",
+        data: bytesToBase64(fetched.bytes),
+        mimeType: contentType,
+      },
+    ]);
   },
 };
 

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -201,9 +201,31 @@ export const getCardsSchema = z.object({
 });
 
 
+// Shared opt-in flag for the structured attachment metadata that
+// fizzy_get_card and fizzy_get_card_comments can add to their responses.
+//
+// Opt-in rather than default-on, deliberately: this server runs in production
+// and is published to npm, and every existing caller's parsing of these two
+// responses has to keep working byte for byte. Omitting the flag produces
+// exactly the response the tool returned before it existed. The steering that
+// gets a model to pass it lives in the tool descriptions instead.
+export const includeAttachmentsSchema = z
+  .boolean()
+  .optional()
+  .describe(
+    "Set true to add an 'attachments' array parsed out of the rich-text HTML: each " +
+    "file's filename, content_type, byte_size, width, height, signed_id, url and " +
+    "preview_url. Attachments are otherwise visible only as raw " +
+    "<action-text-attachment> markup inside the HTML, and not at all in the plain-text " +
+    "rendering. Pass the returned signed_id and filename to fizzy_get_attachment to " +
+    "actually see an image. Omitting this parameter (the default) leaves the response " +
+    "exactly as it was before this option existed."
+  );
+
 export const getCardSchema = z.object({
   account_slug: accountSlugSchema,
   card_id: cardNumberSchema,
+  include_attachments: includeAttachmentsSchema,
 });
 
 export const createCardSchema = z.object({
@@ -317,6 +339,7 @@ const commentCardSelectorBase = z.object({
 
 export const getCardCommentsSchema = commentCardSelectorBase.extend({
   fields: fieldsSchema,
+  include_attachments: includeAttachmentsSchema,
 });
 
 export const createCommentSchema = commentCardSelectorBase.extend({
@@ -638,3 +661,33 @@ export const uploadFileSchema = z
         "falling back to application/octet-stream."
       ),
   });
+
+// Reading an attachment back.
+//
+// There is deliberately no `url` parameter, and never will be: fetching a
+// caller-supplied URL with the user's Fizzy token attached would be a
+// server-side request forgery carrying a credential. The tool takes the blob's
+// signed id and rebuilds the address itself. `parseAttachmentRequest` in
+// utils/attachments.ts rejects a URL-shaped argument outright and validates
+// each token before it reaches a path — that layer, not this one, is the
+// enforcement point, because the Cloudflare transport dispatches raw arguments
+// without running Zod at all.
+export const getAttachmentSchema = z.object({
+  account_slug: accountSlugSchema,
+  signed_id: z.string().describe(
+    "The attachment's ActiveStorage signed id, exactly as reported in the 'signed_id' " +
+    "field of fizzy_get_card or fizzy_get_card_comments with include_attachments=true. " +
+    "Not a URL and not a file path."
+  ),
+  filename: z.string().describe(
+    "The attachment's filename, from the same 'filename' field, e.g. 'screenshot.png'. " +
+    "A single file name — anything containing a path separator is rejected."
+  ),
+  variation: z.string().optional().describe(
+    "The attachment's 'preview_variation' token, to fetch the resized preview instead " +
+    "of the full-resolution original. Strongly preferred for screenshots and photos: " +
+    "the preview is a fraction of the bytes at the resolution a model can actually " +
+    "read, and a large original is refused outright. Omit only when the attachment " +
+    "reported no preview_variation, or when full resolution is genuinely needed."
+  ),
+});

--- a/src/utils/action-text.ts
+++ b/src/utils/action-text.ts
@@ -1,0 +1,329 @@
+/**
+ * Structured metadata for the `<action-text-attachment>` elements embedded in a
+ * rich-text HTML field.
+ *
+ * The API never reports a card's or comment's attachments as data. They exist
+ * only as ActionText markup inside `description_html` / `body.html`, and the
+ * matching plain-text rendering flattens each one to a bare `[filename.png]`
+ * with no size, no dimensions and — crucially — no way to fetch the bytes. This
+ * module turns that markup back into the fields `fizzy_get_attachment` needs.
+ *
+ * **No DOM parser.** Workers ships `HTMLRewriter` and Node does not; Node ships
+ * neither `DOMParser` nor `HTMLRewriter`, and this module is reached from the
+ * shared tool handlers, so it must run identically on both. What is left is
+ * careful string scanning: quote-aware tag slicing rather than a single
+ * `<action-text-attachment[^>]*>` regex, because an attribute value may legally
+ * contain `>`.
+ *
+ * Nothing here throws. Rich text is user-authored content that has already made
+ * a round trip through a database; a malformed attribute must cost the caller
+ * that one field, never the whole `fizzy_get_card` response.
+ */
+
+/**
+ * One `<action-text-attachment>` element, as much of it as the markup actually
+ * carried. Every field is optional because every attribute is: ActionText omits
+ * `width`/`height` for non-images, and a remote or half-migrated attachment can
+ * be missing any of the rest.
+ */
+export interface ActionTextAttachment {
+  filename?: string;
+  content_type?: string;
+  byte_size?: number;
+  width?: number;
+  height?: number;
+  /**
+   * The blob's ActiveStorage signed id, lifted out of the `url` attribute's
+   * path. This is what `fizzy_get_attachment` takes — the tool rebuilds the
+   * whole path from it server-side and never fetches `url` itself.
+   */
+  signed_id?: string;
+  /** Absolute URL of the full-resolution blob. Reported for humans, never fetched. */
+  url?: string;
+  /** Absolute URL of the resized preview variant, when the markup carried one. */
+  preview_url?: string;
+  /**
+   * The signed variation token out of `preview_url`'s path. Pass it to
+   * `fizzy_get_attachment` as `variation` to fetch the preview instead of the
+   * full-resolution original — typically a fraction of the bytes for a
+   * screenshot, at the resolution a model actually needs.
+   */
+  preview_variation?: string;
+}
+
+/**
+ * Cap on elements parsed out of a single field.
+ *
+ * A rich-text field is already bounded by the API response that carried it, so
+ * this is not the primary defence — it is a stop on the scan doing unbounded
+ * work if a field ever arrives with pathological markup. Well past any real
+ * card: cards observed in practice carry single-digit attachment counts.
+ */
+const MAX_ATTACHMENTS_PER_FIELD = 200;
+
+/**
+ * Opening tag, matched case-insensitively and only where the element name
+ * actually ends — the lookahead is what stops this from also matching a
+ * hypothetical `<action-text-attachment-group>`.
+ *
+ * A regex does the *search* rather than `indexOf` over a lowercased copy,
+ * because `toLowerCase()` is not length-preserving for every Unicode input, so
+ * indices taken from a lowercased copy cannot be used to slice the original.
+ */
+const OPEN_TAG_PATTERN = /<action-text-attachment(?=[\s/>])/gi;
+
+/** Closing tag, used only to bound the element's inner markup. */
+const CLOSE_TAG_PATTERN = /<\/action-text-attachment\s*>/gi;
+
+/** `name="value"`, `name='value'`, or an unquoted value. */
+const ATTRIBUTE_PATTERN =
+  /([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
+
+/** Any `src=` / `href=` inside the element's inner markup (the `<figure>` body). */
+const INNER_URL_PATTERN = /\b(?:src|href)\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+
+/** `…/rails/active_storage/blobs/{redirect|proxy}/<signed_id>/<filename>` */
+const BLOB_PATH_PATTERN =
+  /\/rails\/active_storage\/blobs\/(?:redirect|proxy)\/([^/?#]+)\//;
+
+/** `…/rails/active_storage/representations/{redirect|proxy}/<signed_id>/<variation>/<filename>` */
+const REPRESENTATION_PATH_PATTERN =
+  /\/rails\/active_storage\/representations\/(?:redirect|proxy)\/([^/?#]+)\/([^/?#]+)\//;
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+/**
+ * Decode the entity references an HTML attribute value can carry.
+ *
+ * One pass, so `&amp;lt;` decodes to the literal text `&lt;` rather than being
+ * decoded twice into `<`. Unrecognised references are left verbatim, which is
+ * what a browser does with them too.
+ */
+function decodeEntities(value: string): string {
+  if (!value.includes("&")) return value;
+  return value.replace(
+    /&(#[0-9]+|#[xX][0-9A-Fa-f]+|[A-Za-z][A-Za-z0-9]*);/g,
+    (whole, reference: string) => {
+      if (reference[0] === "#") {
+        const isHex = reference[1] === "x" || reference[1] === "X";
+        const code = Number.parseInt(
+          isHex ? reference.slice(2) : reference.slice(1),
+          isHex ? 16 : 10
+        );
+        // Lone surrogates and out-of-range code points throw in fromCodePoint.
+        if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return whole;
+        if (code >= 0xd800 && code <= 0xdfff) return whole;
+        return String.fromCodePoint(code);
+      }
+      return NAMED_ENTITIES[reference.toLowerCase()] ?? whole;
+    }
+  );
+}
+
+/**
+ * Index of the `>` that closes the tag opened at `start`, or -1 when the markup
+ * is truncated.
+ *
+ * Quote-aware on purpose: `<action-text-attachment caption="a > b" …>` is legal
+ * markup, and `[^>]*` would cut the tag in half at the caption.
+ */
+function findTagEnd(html: string, start: number): number {
+  let quote: string | null = null;
+  for (let i = start; i < html.length; i++) {
+    const char = html[i];
+    if (quote !== null) {
+      if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ">") {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/** Parse a tag's attribute text into a lowercase-keyed, entity-decoded map. */
+function parseAttributes(attributeText: string): Map<string, string> {
+  const attributes = new Map<string, string>();
+  ATTRIBUTE_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ATTRIBUTE_PATTERN.exec(attributeText)) !== null) {
+    const name = match[1].toLowerCase();
+    // First spelling wins, matching how browsers treat a duplicated attribute.
+    if (attributes.has(name)) continue;
+    attributes.set(name, decodeEntities(match[2] ?? match[3] ?? match[4] ?? ""));
+  }
+  return attributes;
+}
+
+/** The first non-empty value among `names`, trimmed, or undefined. */
+function attribute(
+  attributes: Map<string, string>,
+  ...names: string[]
+): string | undefined {
+  for (const name of names) {
+    const value = attributes.get(name);
+    if (value !== undefined && value.trim() !== "") return value.trim();
+  }
+  return undefined;
+}
+
+/**
+ * A non-negative integer attribute, or undefined when it is absent or is not
+ * one. ActionText writes these as plain decimal strings; anything else is
+ * treated as missing rather than coerced, so a caller never sees `NaN`.
+ */
+function integerAttribute(
+  attributes: Map<string, string>,
+  name: string
+): number | undefined {
+  const raw = attribute(attributes, name);
+  if (raw === undefined || !/^[0-9]+$/.test(raw)) return undefined;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+/**
+ * Resolve a possibly-relative URL against the client's configured base URL.
+ *
+ * ActionText writes the `url` attribute as an account-scoped *path*, so this is
+ * what makes the result usable at all. The base URL comes from the client's
+ * config and is never hardcoded, so a self-hosted or staging Fizzy resolves
+ * against itself.
+ *
+ * Restricted to http/https: an attribute is authored content, and a
+ * `javascript:` or `data:` value resolves perfectly well through `new URL`
+ * while being something no caller should be handed as "the attachment's URL".
+ */
+function absoluteUrl(raw: string | undefined, baseUrl: string): string | undefined {
+  if (raw === undefined) return undefined;
+  try {
+    const resolved = new URL(raw, baseUrl);
+    if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+      return undefined;
+    }
+    return resolved.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The element's inner markup: everything between this tag and whichever comes
+ * first, its closing tag or the next attachment's opening tag. Taking the
+ * earlier of the two keeps an unclosed element from swallowing its successors'
+ * previews.
+ */
+function innerMarkup(html: string, contentStart: number, nextOpenIndex: number): string {
+  CLOSE_TAG_PATTERN.lastIndex = contentStart;
+  const close = CLOSE_TAG_PATTERN.exec(html);
+  const closeIndex = close === null ? html.length : close.index;
+  const boundary = nextOpenIndex === -1 ? closeIndex : Math.min(closeIndex, nextOpenIndex);
+  return html.slice(contentStart, boundary);
+}
+
+/** The first `src`/`href` in the element's body that points at a variant. */
+function findRepresentationUrl(inner: string): string | undefined {
+  INNER_URL_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = INNER_URL_PATTERN.exec(inner)) !== null) {
+    const value = decodeEntities(match[1] ?? match[2] ?? "");
+    if (REPRESENTATION_PATH_PATTERN.test(value)) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Extract `{filename, content_type, byte_size, width, height, signed_id, url,
+ * preview_url, preview_variation}` for every attachment in a rich-text HTML
+ * field.
+ *
+ * @param html The `description_html` / `body.html` value. Anything that is not
+ * a non-empty string yields `[]`, so callers can pass a field the `Fizzy*`
+ * interfaces do not model without checking its type first.
+ * @param baseUrl The client's configured base URL, used to absolutize the
+ * account-scoped paths ActionText writes.
+ */
+export function parseActionTextAttachments(
+  html: unknown,
+  baseUrl: string
+): ActionTextAttachment[] {
+  if (typeof html !== "string" || html === "") return [];
+
+  const results: ActionTextAttachment[] = [];
+  OPEN_TAG_PATTERN.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = OPEN_TAG_PATTERN.exec(html)) !== null) {
+    if (results.length >= MAX_ATTACHMENTS_PER_FIELD) break;
+
+    const attributesStart = match.index + match[0].length;
+    const tagEnd = findTagEnd(html, attributesStart);
+    if (tagEnd === -1) break; // Truncated markup: nothing further is parseable.
+
+    // Resume the outer scan past this tag, then look ahead for the next opening
+    // tag so the inner markup can be bounded without a second full pass.
+    OPEN_TAG_PATTERN.lastIndex = tagEnd + 1;
+    const lookahead = new RegExp(OPEN_TAG_PATTERN.source, "gi");
+    lookahead.lastIndex = tagEnd + 1;
+    const next = lookahead.exec(html);
+
+    const attributes = parseAttributes(html.slice(attributesStart, tagEnd));
+    const inner = innerMarkup(html, tagEnd + 1, next === null ? -1 : next.index);
+
+    const rawUrl = attribute(attributes, "url", "href");
+    const rawPreviewUrl = findRepresentationUrl(inner);
+
+    const attachment: ActionTextAttachment = {};
+
+    const filename = attribute(attributes, "filename");
+    if (filename !== undefined) attachment.filename = filename;
+
+    const contentType = attribute(attributes, "content-type", "content_type");
+    if (contentType !== undefined) attachment.content_type = contentType;
+
+    const byteSize = integerAttribute(attributes, "filesize");
+    if (byteSize !== undefined) attachment.byte_size = byteSize;
+
+    const width = integerAttribute(attributes, "width");
+    if (width !== undefined) attachment.width = width;
+
+    const height = integerAttribute(attributes, "height");
+    if (height !== undefined) attachment.height = height;
+
+    // The signed id is read out of the blob path first and the representation
+    // path second: both carry the same blob token, but only some attachments
+    // have a preview, and a remote image has neither.
+    const signedId =
+      (rawUrl !== undefined ? BLOB_PATH_PATTERN.exec(rawUrl)?.[1] : undefined) ??
+      (rawPreviewUrl !== undefined
+        ? REPRESENTATION_PATH_PATTERN.exec(rawPreviewUrl)?.[1]
+        : undefined);
+    if (signedId !== undefined) attachment.signed_id = signedId;
+
+    const url = absoluteUrl(rawUrl, baseUrl);
+    if (url !== undefined) attachment.url = url;
+
+    if (rawPreviewUrl !== undefined) {
+      const previewUrl = absoluteUrl(rawPreviewUrl, baseUrl);
+      if (previewUrl !== undefined) {
+        attachment.preview_url = previewUrl;
+        const variation = REPRESENTATION_PATH_PATTERN.exec(rawPreviewUrl)?.[2];
+        if (variation !== undefined) attachment.preview_variation = variation;
+      }
+    }
+
+    // An element that yielded nothing at all is markup this parser does not
+    // understand; reporting `{}` would be worse than reporting nothing.
+    if (Object.keys(attachment).length > 0) results.push(attachment);
+  }
+
+  return results;
+}

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,6 +1,7 @@
 /**
  * Turning a tool call's arguments into the bytes Fizzy's direct-upload flow
- * needs, plus the ActionText markup that references the result.
+ * needs and the ActionText markup that references the result, plus the reverse
+ * direction: validating the arguments that name an attachment to read back.
  *
  * Validation lives here rather than in the Zod schema, for two reasons: the
  * Cloudflare transport executes raw arguments without Zod at all — the same
@@ -8,8 +9,14 @@
  * either/or rules cannot be expressed as Zod refinements without turning the
  * schema into a ZodEffects, which `McpServer.registerTool` publishes to stdio
  * clients as an empty property list. So this is the only place they live.
+ *
+ * For the read direction that reasoning is not a convenience, it is the
+ * security boundary: the tokens validated below are interpolated into a URL
+ * path that is then fetched with the caller's Fizzy credential attached, and
+ * the Workers path would otherwise reach that fetch with no validation at all.
  */
 
+import type { AttachmentRef } from "../client/types.js";
 import { base64ToBytes, maxEncodedLength } from "./base64.js";
 import { getLocalFileReader } from "./file-source.js";
 
@@ -171,4 +178,201 @@ export async function resolveAttachment(
     filename,
     contentType: explicitContentType ?? contentTypeForFilename(filename),
   };
+}
+
+// ============ Reading an attachment back ============
+
+/**
+ * Upper bound on an image inlined into a tool response as an MCP `image`
+ * content block.
+ *
+ * Deliberately well below {@link MAX_ATTACHMENT_BYTES}. The upload direction
+ * spends its budget once, on a frame the client already holds in memory; an
+ * inlined image is base64 in the response *and* then decoded, re-encoded and
+ * charged as vision tokens by whatever model receives it. 3 MB of image is a
+ * ~4 MB base64 payload, which stays inside the 5 MB per-image ceiling the
+ * Anthropic Messages API applies — the practical limit long before any
+ * transport's.
+ *
+ * A full-resolution screenshot over this is not truncated: the caller is told
+ * to re-request it with the `variation` token from the attachment's
+ * `preview_variation`, which is what they wanted anyway.
+ */
+export const MAX_INLINE_IMAGE_BYTES = 3 * 1024 * 1024;
+
+/**
+ * The image media types worth returning as an MCP `image` content block.
+ *
+ * Narrower than `image/*` on purpose. The set is what vision models actually
+ * decode; handing back an `image/svg+xml` or `image/tiff` block produces a
+ * client-side error rather than a picture, and a caller is better served by
+ * being told the type is not renderable than by a failed response. Anything
+ * outside this set is reported as metadata instead.
+ */
+const INLINEABLE_IMAGE_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+/** Whether an attachment of this media type can be returned as an image block. */
+export function isInlineableImage(contentType: string): boolean {
+  return INLINEABLE_IMAGE_TYPES.has(contentType.toLowerCase());
+}
+
+/**
+ * Characters a Rails signed id or an ActiveStorage variation token can contain.
+ *
+ * Both are URL-safe base64 payloads joined to a hex digest by `--`, so the
+ * alphabet is deliberately narrow. What matters is not what it admits but what
+ * it excludes: `/` and `\` cannot appear, so a token can never introduce a path
+ * segment of its own, and `%` cannot appear, so it cannot smuggle an encoded
+ * one either. `.` is admitted because it is legal in the alphabet, and the
+ * traversal it would otherwise enable is closed by rejecting a token that is
+ * exactly `.` or `..` — without a separator, no other spelling traverses.
+ */
+const SIGNED_TOKEN_PATTERN = /^[A-Za-z0-9_.~=+-]+$/;
+
+/**
+ * Generous next to a real signed id (a few hundred characters) and still short
+ * enough that a rejected token never becomes a multi-kilobyte error message.
+ */
+const MAX_SIGNED_TOKEN_LENGTH = 4096;
+
+/** Arguments that would name a URL rather than a blob. See {@link parseAttachmentRequest}. */
+const URL_SHAPED_ARGUMENTS = ["url", "preview_url", "blob_url", "attachment_url", "src"];
+
+/**
+ * An attachment to read back, with every component already validated: the
+ * client's {@link AttachmentRef} plus the account it belongs to.
+ */
+export interface AttachmentRequest extends AttachmentRef {
+  accountSlug: string;
+}
+
+function requiredString(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${key} is required and must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+/**
+ * Validate one opaque signed token destined for a URL path segment.
+ *
+ * @throws Error naming the argument — these surface verbatim to the model.
+ */
+function validateSignedToken(value: string, key: string): string {
+  if (value.length > MAX_SIGNED_TOKEN_LENGTH) {
+    throw new Error(`${key} is too long to be a signed id`);
+  }
+  if (value === "." || value === "..") {
+    throw new Error(`${key} must be a signed id, not a path`);
+  }
+  if (!SIGNED_TOKEN_PATTERN.test(value)) {
+    throw new Error(
+      `${key} contains characters that are not part of a signed id. ` +
+        `Pass the 'signed_id' (or 'preview_variation') exactly as fizzy_get_card ` +
+        `reported it — never a URL or a file path.`
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate the download filename.
+ *
+ * Only ever used as the last path segment, where ActiveStorage treats it as
+ * decoration for the Content-Disposition header rather than as part of the
+ * lookup — but it is still caller-controlled text spliced into a path, so it
+ * has to be a single segment. `/`, `\` and a `..` segment are rejected outright
+ * rather than escaped away, so a traversal attempt fails loudly instead of
+ * silently fetching something else.
+ */
+function validateAttachmentFilename(value: string): string {
+  if (value.length > 255) {
+    throw new Error("filename is too long");
+  }
+  if (value.includes("/") || value.includes("\\")) {
+    throw new Error(
+      "filename must be a single file name, not a path — it cannot contain / or \\"
+    );
+  }
+  if (value === "." || value === "..") {
+    throw new Error("filename must be a file name, not a path segment");
+  }
+  // Escaped, not written literally: a raw NUL in source is invisible in review.
+  if (/[\x00-\x1f\x7f]/.test(value)) {
+    throw new Error("filename contains control characters");
+  }
+  return value;
+}
+
+/**
+ * Validate the account slug this attachment is scoped to.
+ *
+ * Narrower than the slug handling elsewhere in the client, which only strips a
+ * leading `/`. This path builds a URL that is fetched with the bearer token
+ * attached and whose response is streamed back to the model, so the slug is
+ * pinned to a single path segment here rather than trusted.
+ */
+function validateAccountSlug(value: string): string {
+  const slug = value.startsWith("/") ? value.slice(1) : value;
+  if (slug === "" || slug === "." || slug === "..") {
+    throw new Error("account_slug is required and must be an account slug");
+  }
+  if (!/^[A-Za-z0-9._-]+$/.test(slug)) {
+    throw new Error(
+      "account_slug must be an account slug such as '1234567', not a path or URL"
+    );
+  }
+  return slug;
+}
+
+/**
+ * Resolve the arguments of `fizzy_get_attachment` into a validated request.
+ *
+ * **The tool never accepts a URL.** A caller-supplied URL fetched with the
+ * user's Fizzy token attached is a server-side request forgery with a
+ * credential on it, so the address is rebuilt server-side from a signed blob id
+ * instead. A URL-shaped argument is rejected explicitly rather than ignored:
+ * the Zod path would silently strip it and the Workers path would silently
+ * carry it, and in both cases a model that thinks it asked for one URL and
+ * quietly got another is worse off than one that gets an error saying so.
+ *
+ * @throws Error with a message naming the argument at fault — these surface
+ * verbatim to the model, so they have to say what to send instead.
+ */
+export function parseAttachmentRequest(
+  args: Record<string, unknown>
+): AttachmentRequest {
+  const supplied = URL_SHAPED_ARGUMENTS.filter((key) => args[key] !== undefined);
+  if (supplied.length > 0) {
+    throw new Error(
+      `fizzy_get_attachment does not take a URL (${supplied.join(", ")}). ` +
+        `Pass the attachment's 'signed_id' and 'filename' — from fizzy_get_card or ` +
+        `fizzy_get_card_comments with include_attachments=true — and the address is ` +
+        `rebuilt server-side.`
+    );
+  }
+
+  const accountSlug = validateAccountSlug(requiredString(args, "account_slug"));
+  const signedId = validateSignedToken(requiredString(args, "signed_id"), "signed_id");
+  const filename = validateAttachmentFilename(requiredString(args, "filename"));
+
+  const rawVariation = args.variation;
+  let variation: string | undefined;
+  if (rawVariation !== undefined && rawVariation !== null) {
+    if (typeof rawVariation !== "string") {
+      throw new Error("variation must be a string");
+    }
+    const trimmed = rawVariation.trim();
+    if (trimmed !== "") {
+      variation = validateSignedToken(trimmed, "variation");
+    }
+  }
+
+  return { accountSlug, signedId, filename, variation };
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -158,6 +158,26 @@ export class FizzyParseError extends FizzyError {
 }
 
 /**
+ * An attachment is larger than the caller asked to read.
+ *
+ * A distinct type rather than a plain Error because the tool layer answers it
+ * with advice the client has no business knowing — that the same attachment can
+ * usually be re-requested as its much smaller preview variant — and matching on
+ * a message string to decide that would be fragile.
+ */
+export class FizzyAttachmentTooLargeError extends FizzyError {
+  constructor(
+    message: string,
+    public readonly maxBytes: number,
+    /** Undefined when the server declared no size and the read hit the cap. */
+    public readonly byteSize?: number
+  ) {
+    super(message, "ATTACHMENT_TOO_LARGE");
+    this.name = "FizzyAttachmentTooLargeError";
+  }
+}
+
+/**
  * Create appropriate error from HTTP status code
  */
 export function createAPIError(

--- a/tests/client/attachment-fetch.test.ts
+++ b/tests/client/attachment-fetch.test.ts
@@ -327,3 +327,84 @@ describe("fetchAttachment: size and body handling", () => {
     expect(result.contentType).toBe("image/png");
   });
 });
+
+/**
+ * Bodies that nobody wants must not be paid for.
+ *
+ * The success path is bounded by `maxBytes`, but a redirect body and a
+ * non-2xx error body are read on different paths — and those are the hops most
+ * likely to come from a host other than Fizzy. Both are asserted on behaviour:
+ * the stream is cancelled, and only a bounded prefix is ever pulled.
+ */
+describe("fetchAttachment body bounding on non-success paths", () => {
+  /** A stream that reports how much of it was actually consumed. */
+  function countingStream(chunk: Uint8Array, repeats: number) {
+    const state = { pulled: 0, cancelled: false };
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (state.pulled >= repeats) {
+          controller.close();
+          return;
+        }
+        state.pulled += 1;
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        state.cancelled = true;
+      },
+    });
+    return { stream, state };
+  }
+
+  it("cancels a redirect's body instead of leaving it dangling", async () => {
+    const { stream, state } = countingStream(new Uint8Array(1024), 512);
+    stubFetch((_call, index) => {
+      if (index === 0) {
+        return new Response(stream, {
+          status: 302,
+          headers: { Location: STORAGE_URL },
+        });
+      }
+      return binaryResponse(PNG_BYTES);
+    });
+
+    const result = await client().fetchAttachment(ACCOUNT, REF, { maxBytes: 4096 });
+
+    expect(result.bytes).toEqual(PNG_BYTES);
+    expect(state.cancelled).toBe(true);
+  });
+
+  it("cancels the body of a redirect it refuses to follow", async () => {
+    // A sign-in redirect is rejected inside the resolver rather than followed,
+    // so its body is released on the throw path rather than the continue path.
+    const { stream, state } = countingStream(new Uint8Array(1024), 512);
+    stubFetch(
+      () =>
+        new Response(stream, {
+          status: 302,
+          headers: { Location: `${BASE_URL}/session/new` },
+        })
+    );
+
+    await expect(
+      client().fetchAttachment(ACCOUNT, REF, { maxBytes: 4096 })
+    ).rejects.toBeInstanceOf(FizzyAuthError);
+
+    expect(state.cancelled).toBe(true);
+  });
+
+  it("reads only a bounded prefix of an unbounded error body", async () => {
+    // 8 MB available, no Content-Length: `.text()` would have buffered all of
+    // it just to build the error message, past the 4 KB cap on the success path.
+    const { stream, state } = countingStream(new Uint8Array(64 * 1024), 128);
+    stubFetch(() => new Response(stream, { status: 500, statusText: "Server Error" }));
+
+    await expect(
+      client().fetchAttachment(ACCOUNT, REF, { maxBytes: 4096 })
+    ).rejects.toThrow();
+
+    expect(state.cancelled).toBe(true);
+    // A handful of 64 KB chunks at most — not the whole 8 MB.
+    expect(state.pulled).toBeLessThan(8);
+  });
+});

--- a/tests/client/attachment-fetch.test.ts
+++ b/tests/client/attachment-fetch.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Reading an attachment back, exercised against a stubbed `fetch`.
+ *
+ * The assertion this file exists for is the one no API error would ever
+ * reveal: the Fizzy bearer token must reach the API host and must NOT reach
+ * whatever host the API's redirect names. Everything is asserted on behaviour —
+ * hop 2 goes wherever hop 1's `Location` pointed, carrying no `Authorization` —
+ * rather than on any particular storage hostname, which is configurable and
+ * deployment-specific.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { FizzyClient } from "../../src/client/fizzy-client.js";
+import {
+  FizzyAttachmentTooLargeError,
+  FizzyAuthError,
+  FizzyNotFoundError,
+} from "../../src/utils/errors.js";
+
+const BASE_URL = "https://fizzy.example.com";
+const ACCOUNT = "/1234567";
+const STORAGE_URL = "https://blobs.storage.example/download/abc?signature=xyz";
+
+const SIGNED_ID =
+  "eyJfcmFpbHMiOnsiZGF0YSI6ImV4YW1wbGVibG9iaWQiLCJwdXIiOiJibG9iX2lkIn19--1111111111111111111111111111111111111111";
+const VARIATION =
+  "eyJfcmFpbHMiOnsiZGF0YSI6InJlc2l6ZV90b19saW1pdCIsInB1ciI6InZhcmlhdGlvbiJ9fQ==--3333333333333333333333333333333333333333";
+
+const REF = { signedId: SIGNED_ID, filename: "screenshot.png" };
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  redirect: string | undefined;
+}
+
+let calls: RecordedCall[];
+const originalFetch = globalThis.fetch;
+
+function stubFetch(handler: (call: RecordedCall, index: number) => Response) {
+  globalThis.fetch = vi.fn(async (url: unknown, init: Record<string, unknown> = {}) => {
+    const call: RecordedCall = {
+      url: String(url),
+      method: (init.method as string) ?? "GET",
+      headers: (init.headers as Record<string, string>) ?? {},
+      redirect: init.redirect as string | undefined,
+    };
+    calls.push(call);
+    return handler(call, calls.length - 1);
+  }) as unknown as typeof fetch;
+}
+
+function redirectTo(location: string, status = 302): Response {
+  return new Response(null, { status, headers: { Location: location } });
+}
+
+function binaryResponse(
+  bytes: Uint8Array,
+  contentType: string,
+  extraHeaders: Record<string, string> = {}
+): Response {
+  return new Response(bytes, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Content-Length": String(bytes.length),
+      ...extraHeaders,
+    },
+  });
+}
+
+function client(overrides: Record<string, unknown> = {}): FizzyClient {
+  // Retries off and a short timeout: a retrying client would blur which
+  // request actually carried which headers.
+  return new FizzyClient({
+    accessToken: "test-token",
+    baseUrl: BASE_URL,
+    maxRetries: 0,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("fetchAttachment: the two hops and their credentials", () => {
+  it("authenticates hop 1 and sends nothing to the host hop 1 redirects to", async () => {
+    stubFetch((_call, index) =>
+      index === 0 ? redirectTo(STORAGE_URL) : binaryResponse(PNG_BYTES, "image/png")
+    );
+
+    const result = await client().fetchAttachment(ACCOUNT, REF, {
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(calls).toHaveLength(2);
+
+    const [apiCall, storageCall] = calls;
+    expect(apiCall.url).toBe(
+      `${BASE_URL}/1234567/rails/active_storage/blobs/redirect/${SIGNED_ID}/screenshot.png`
+    );
+    expect(apiCall.headers.Authorization).toBe("Bearer test-token");
+
+    // Hop 2 goes wherever hop 1 pointed, and goes there bare.
+    expect(storageCall.url).toBe(STORAGE_URL);
+    expect(storageCall.headers.Authorization).toBeUndefined();
+    expect(
+      Object.keys(storageCall.headers).map((name) => name.toLowerCase())
+    ).not.toContain("authorization");
+    expect(
+      JSON.stringify(storageCall.headers).includes("test-token")
+    ).toBe(false);
+
+    expect(result.contentType).toBe("image/png");
+    expect(result.bytes).toEqual(PNG_BYTES);
+    expect(result.byteSize).toBe(PNG_BYTES.length);
+  });
+
+  it("never lets the runtime follow the redirect on its own", async () => {
+    // Auto-follow would decide for itself whether to keep the Authorization
+    // header across origins, and that decision differs between undici and
+    // Workers. Both hops must be issued with redirect: "manual".
+    stubFetch((_call, index) =>
+      index === 0 ? redirectTo(STORAGE_URL) : binaryResponse(PNG_BYTES, "image/png")
+    );
+
+    await client().fetchAttachment(ACCOUNT, REF, { maxBytes: 1024 * 1024 });
+
+    expect(calls.map((call) => call.redirect)).toEqual(["manual", "manual"]);
+  });
+
+  it("keeps the token on a redirect that stays on the Fizzy origin", async () => {
+    // A variant that is not yet processed can redirect within the API host
+    // first; that hop still needs the credential, which is why the decision is
+    // per-origin rather than per-hop-number.
+    const sameOrigin = `${BASE_URL}/1234567/rails/active_storage/representations/proxy/${SIGNED_ID}/${VARIATION}/screenshot.png`;
+    stubFetch((_call, index) => {
+      if (index === 0) return redirectTo(sameOrigin);
+      if (index === 1) return redirectTo(STORAGE_URL);
+      return binaryResponse(PNG_BYTES, "image/png");
+    });
+
+    await client().fetchAttachment(ACCOUNT, REF, { maxBytes: 1024 * 1024 });
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].headers.Authorization).toBe("Bearer test-token");
+    expect(calls[1].headers.Authorization).toBe("Bearer test-token");
+    expect(calls[2].headers.Authorization).toBeUndefined();
+  });
+
+  it("resolves a relative Location against the URL that returned it", async () => {
+    stubFetch((_call, index) =>
+      index === 0
+        ? redirectTo("/1234567/elsewhere/screenshot.png")
+        : binaryResponse(PNG_BYTES, "image/png")
+    );
+
+    await client().fetchAttachment(ACCOUNT, REF, { maxBytes: 1024 * 1024 });
+
+    expect(calls[1].url).toBe(`${BASE_URL}/1234567/elsewhere/screenshot.png`);
+    expect(calls[1].headers.Authorization).toBe("Bearer test-token");
+  });
+
+  it("serves the blob directly when there is no redirect at all", async () => {
+    stubFetch(() => binaryResponse(PNG_BYTES, "image/png"));
+
+    const result = await client().fetchAttachment(ACCOUNT, REF, {
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(result.bytes).toEqual(PNG_BYTES);
+  });
+});
+
+describe("fetchAttachment: what it refuses to follow", () => {
+  it("refuses a redirect to a non-http scheme", async () => {
+    stubFetch(() => redirectTo("file:///etc/passwd"));
+
+    await expect(
+      client().fetchAttachment(ACCOUNT, REF, { maxBytes: 1024 })
+    ).rejects.toThrow(/only http and https/i);
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("reports a redirect to sign-in as the authentication failure it is", async () => {
+    stubFetch(() => redirectTo(`${BASE_URL}/session/new`));
+
+    await expect(
+      client().fetchAttachment(ACCOUNT, REF, { maxBytes: 1024 })
+    ).rejects.toBeInstanceOf(FizzyAuthError);
+
+    // The sign-in page is never fetched, so an HTML login form can never come
+    // back typed as the caller's attachment.
+    expect(calls).toHaveLength(1);
+  });
+
+  it("stops a redirect loop rather than looping forever", async () => {
+    stubFetch((call) => redirectTo(`${call.url}x`));
+
+    await expect(
+      client().fetchAttachment(ACCOUNT, REF, { maxBytes: 1024 })
+    ).rejects.toThrow(/redirected more than/i);
+
+    expect(calls.length).toBeLessThanOrEqual(6);
+  });
+
+  it("surfaces a 3xx with no Location rather than hanging on it", async () => {
+    stubFetch(() => new Response(null, { status: 302 }));
+
+    await expect(
+      client().fetchAttachment(ACCOUNT, REF, { maxBytes: 1024 })
+    ).rejects.toThrow(/no Location header/i);
+  });
+
+  it("maps an API error status onto the usual error classes", async () => {
+    stubFetch(() => new Response("no such blob", { status: 404 }));
+
+    await expect(
+      client().fetchAttachment(ACCOUNT, REF, { maxBytes: 1024 })
+    ).rejects.toBeInstanceOf(FizzyNotFoundError);
+  });
+});
+
+describe("fetchAttachment: paths it builds", () => {
+  it("builds the representation path when a variation is given", async () => {
+    stubFetch(() => binaryResponse(PNG_BYTES, "image/png"));
+
+    await client().fetchAttachment(
+      ACCOUNT,
+      { ...REF, variation: VARIATION },
+      { maxBytes: 1024 * 1024 }
+    );
+
+    expect(calls[0].url).toBe(
+      `${BASE_URL}/1234567/rails/active_storage/representations/redirect/` +
+        `${SIGNED_ID}/${VARIATION}/screenshot.png`
+    );
+  });
+
+  it("percent-encodes the filename segment", async () => {
+    stubFetch(() => binaryResponse(PNG_BYTES, "image/png"));
+
+    await client().fetchAttachment(
+      ACCOUNT,
+      { signedId: SIGNED_ID, filename: "a b&c.png" },
+      { maxBytes: 1024 * 1024 }
+    );
+
+    expect(calls[0].url).toContain("/a%20b%26c.png");
+  });
+
+  it("accepts an account slug with or without its leading slash", async () => {
+    stubFetch(() => binaryResponse(PNG_BYTES, "image/png"));
+
+    await client().fetchAttachment("1234567", REF, { maxBytes: 1024 * 1024 });
+
+    expect(calls[0].url).toContain(`${BASE_URL}/1234567/rails/`);
+  });
+});
+
+describe("fetchAttachment: size and body handling", () => {
+  it("skips the body entirely when the caller does not want this type", async () => {
+    const zip = new Uint8Array(64);
+    stubFetch((_call, index) =>
+      index === 0
+        ? redirectTo(STORAGE_URL)
+        : new Response(zip, {
+            status: 200,
+            headers: {
+              "Content-Type": "application/zip",
+              "Content-Length": "40000000",
+            },
+          })
+    );
+
+    const result = await client().fetchAttachment(ACCOUNT, REF, {
+      maxBytes: 1024,
+      shouldReadBody: (contentType) => contentType.startsWith("image/"),
+    });
+
+    // 40 MB declared, well over maxBytes, and still no error: the cap applies
+    // to bytes read, and nothing wanted these.
+    expect(result.contentType).toBe("application/zip");
+    expect(result.bytes).toBeUndefined();
+    expect(result.byteSize).toBe(40000000);
+  });
+
+  it("refuses an oversized attachment on its declared length, before reading", async () => {
+    stubFetch(() =>
+      new Response(PNG_BYTES, {
+        status: 200,
+        headers: { "Content-Type": "image/png", "Content-Length": "9999999" },
+      })
+    );
+
+    await expect(
+      client().fetchAttachment(ACCOUNT, REF, { maxBytes: 1024 })
+    ).rejects.toBeInstanceOf(FizzyAttachmentTooLargeError);
+  });
+
+  it("still refuses when the response declares no length", async () => {
+    const big = new Uint8Array(4096);
+    stubFetch(
+      () => new Response(big, { status: 200, headers: { "Content-Type": "image/png" } })
+    );
+
+    await expect(
+      client().fetchAttachment(ACCOUNT, REF, { maxBytes: 1024 })
+    ).rejects.toBeInstanceOf(FizzyAttachmentTooLargeError);
+  });
+
+  it("strips parameters from the content type", async () => {
+    stubFetch(() => binaryResponse(PNG_BYTES, "IMAGE/PNG; charset=binary"));
+
+    const result = await client().fetchAttachment(ACCOUNT, REF, { maxBytes: 4096 });
+
+    expect(result.contentType).toBe("image/png");
+  });
+});

--- a/tests/tools/attachment-metadata.test.ts
+++ b/tests/tools/attachment-metadata.test.ts
@@ -1,0 +1,262 @@
+/**
+ * The `include_attachments` opt-in on fizzy_get_card and
+ * fizzy_get_card_comments.
+ *
+ * The load-bearing assertions are the negative ones: omitting the flag must
+ * produce the response these tools produced before it existed, down to the key
+ * set. This server runs in production and is published to npm, so a default
+ * that quietly grew a field would break callers parsing these responses.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FizzyClient } from "../../src/client/fizzy-client.js";
+import { toolHandlers } from "../../src/tools/handlers.js";
+
+const BASE_URL = "https://fizzy.example.com";
+const ACCOUNT = "1234567";
+
+const BLOB_SIGNED_ID =
+  "eyJfcmFpbHMiOnsiZGF0YSI6ImV4YW1wbGVibG9iaWQiLCJwdXIiOiJibG9iX2lkIn19--1111111111111111111111111111111111111111";
+const VARIATION =
+  "eyJfcmFpbHMiOnsiZGF0YSI6InJlc2l6ZV90b19saW1pdCIsInB1ciI6InZhcmlhdGlvbiJ9fQ==--3333333333333333333333333333333333333333";
+
+const BLOB_PATH = `/${ACCOUNT}/rails/active_storage/blobs/redirect/${BLOB_SIGNED_ID}/screenshot.png`;
+const PREVIEW_PATH = `/${ACCOUNT}/rails/active_storage/representations/redirect/${BLOB_SIGNED_ID}/${VARIATION}/screenshot.png`;
+
+const ATTACHMENT_MARKUP =
+  `<action-text-attachment content-type="image/png" url="${BLOB_PATH}" ` +
+  `filename="screenshot.png" filesize="204800" width="1600" height="900" previewable="true">` +
+  `<figure><a href="${BLOB_PATH}"><img src="${PREVIEW_PATH}" /></a></figure>` +
+  `</action-text-attachment>`;
+
+/** As the API returns it: attachments live only in the HTML. */
+const CARD = {
+  id: "card-1",
+  number: 42,
+  title: "Login button misaligned",
+  status: "published",
+  description: "Here is the failure: [screenshot.png]",
+  description_html: `<div class="trix-content"><p>Here is the failure:</p>${ATTACHMENT_MARKUP}</div>`,
+  has_attachments: true,
+  url: `${BASE_URL}/${ACCOUNT}/cards/42`,
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+const COMMENTS = [
+  {
+    id: "comment-1",
+    body: {
+      plain_text: "Same here: [screenshot.png]",
+      html: `<div>Same here:${ATTACHMENT_MARKUP}</div>`,
+    },
+    creator: { id: "user-1", name: "Test User" },
+    created_at: "2024-01-02T00:00:00Z",
+    url: `${BASE_URL}/${ACCOUNT}/cards/42/comments/comment-1`,
+  },
+  {
+    id: "comment-2",
+    body: { plain_text: "No files on this one", html: "<div>No files on this one</div>" },
+    creator: { id: "user-2", name: "Other User" },
+    created_at: "2024-01-03T00:00:00Z",
+    url: `${BASE_URL}/${ACCOUNT}/cards/42/comments/comment-2`,
+  },
+];
+
+function mockClient(): FizzyClient {
+  return {
+    getBaseUrl: () => BASE_URL,
+    getCard: vi.fn(async () => structuredClone(CARD)),
+    getCardComments: vi.fn(async () => structuredClone(COMMENTS)),
+  } as unknown as FizzyClient;
+}
+
+const EXPECTED_ATTACHMENT = {
+  filename: "screenshot.png",
+  content_type: "image/png",
+  byte_size: 204800,
+  width: 1600,
+  height: 900,
+  signed_id: BLOB_SIGNED_ID,
+  url: `${BASE_URL}${BLOB_PATH}`,
+  preview_url: `${BASE_URL}${PREVIEW_PATH}`,
+  preview_variation: VARIATION,
+};
+
+let client: FizzyClient;
+
+beforeEach(() => {
+  client = mockClient();
+});
+
+describe("fizzy_get_card: default response is unchanged", () => {
+  it("returns the card untouched when the flag is omitted", async () => {
+    const result = await toolHandlers.fizzy_get_card(client, {
+      account_slug: ACCOUNT,
+      card_id: "42",
+    });
+
+    expect(result).toEqual(CARD);
+    expect(result).not.toHaveProperty("attachments");
+  });
+
+  it("returns the card untouched when the flag is explicitly false", async () => {
+    const result = await toolHandlers.fizzy_get_card(client, {
+      account_slug: ACCOUNT,
+      card_id: "42",
+      include_attachments: false,
+    });
+
+    expect(result).toEqual(CARD);
+  });
+});
+
+describe("fizzy_get_card: include_attachments", () => {
+  it("adds the structured attachments alongside every existing field", async () => {
+    const result = (await toolHandlers.fizzy_get_card(client, {
+      account_slug: ACCOUNT,
+      card_id: "42",
+      include_attachments: true,
+    })) as Record<string, unknown>;
+
+    // Additive only: nothing that was there before is dropped or rewritten.
+    expect(result).toMatchObject(CARD);
+    expect(result.attachments).toEqual([EXPECTED_ATTACHMENT]);
+  });
+
+  it("accepts the string form LLM clients send for booleans", async () => {
+    const result = (await toolHandlers.fizzy_get_card(client, {
+      account_slug: ACCOUNT,
+      card_id: "42",
+      include_attachments: "true",
+    })) as Record<string, unknown>;
+
+    expect(result.attachments).toHaveLength(1);
+  });
+
+  it("reports an empty list for a card with no attachments", async () => {
+    const plain = {
+      ...structuredClone(CARD),
+      description_html: "<div><p>Nothing attached.</p></div>",
+      has_attachments: false,
+    };
+    const plainClient = {
+      getBaseUrl: () => BASE_URL,
+      getCard: vi.fn(async () => plain),
+    } as unknown as FizzyClient;
+
+    const result = (await toolHandlers.fizzy_get_card(plainClient, {
+      account_slug: ACCOUNT,
+      card_id: "42",
+      include_attachments: true,
+    })) as Record<string, unknown>;
+
+    expect(result.attachments).toEqual([]);
+  });
+
+  it("does not throw when the card carries no description_html at all", async () => {
+    const bare = { id: "card-2", title: "No HTML", status: "published" };
+    const bareClient = {
+      getBaseUrl: () => BASE_URL,
+      getCard: vi.fn(async () => bare),
+    } as unknown as FizzyClient;
+
+    const result = (await toolHandlers.fizzy_get_card(bareClient, {
+      account_slug: ACCOUNT,
+      card_id: "42",
+      include_attachments: true,
+    })) as Record<string, unknown>;
+
+    expect(result.attachments).toEqual([]);
+  });
+
+  it("rejects a malformed flag rather than silently omitting attachments", async () => {
+    await expect(
+      toolHandlers.fizzy_get_card(client, {
+        account_slug: ACCOUNT,
+        card_id: "42",
+        include_attachments: "yes",
+      })
+    ).rejects.toThrow(/include_attachments/);
+  });
+
+  it("validates the flag before spending an API round-trip", async () => {
+    await expect(
+      toolHandlers.fizzy_get_card(client, {
+        account_slug: ACCOUNT,
+        card_id: "42",
+        include_attachments: 1,
+      })
+    ).rejects.toThrow();
+
+    expect(client.getCard).not.toHaveBeenCalled();
+  });
+});
+
+describe("fizzy_get_card_comments: default responses are unchanged", () => {
+  it("returns the full comments untouched when the flag is omitted", async () => {
+    const result = await toolHandlers.fizzy_get_card_comments(client, {
+      account_slug: ACCOUNT,
+      card_number: "42",
+    });
+
+    expect(result).toEqual(COMMENTS);
+  });
+
+  it("returns the summary projection untouched when the flag is omitted", async () => {
+    const result = (await toolHandlers.fizzy_get_card_comments(client, {
+      account_slug: ACCOUNT,
+      card_number: "42",
+      fields: "summary",
+    })) as Array<Record<string, unknown>>;
+
+    expect(result[0]).toEqual({
+      id: "comment-1",
+      created_at: "2024-01-02T00:00:00Z",
+      url: COMMENTS[0].url,
+      creator: { id: "user-1", name: "Test User" },
+      body: { plain_text: "Same here: [screenshot.png]" },
+    });
+    expect(result[0]).not.toHaveProperty("attachments");
+  });
+});
+
+describe("fizzy_get_card_comments: include_attachments", () => {
+  it("adds a per-comment attachments array in full mode", async () => {
+    const result = (await toolHandlers.fizzy_get_card_comments(client, {
+      account_slug: ACCOUNT,
+      card_number: "42",
+      include_attachments: true,
+    })) as Array<Record<string, unknown>>;
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject(COMMENTS[0]);
+    expect(result[0].attachments).toEqual([EXPECTED_ATTACHMENT]);
+    // A comment with no attachment gets an empty list, not a missing key —
+    // "none" and "not asked" must not look the same.
+    expect(result[1].attachments).toEqual([]);
+  });
+
+  it("adds them in summary mode too, where the HTML is dropped entirely", async () => {
+    const result = (await toolHandlers.fizzy_get_card_comments(client, {
+      account_slug: ACCOUNT,
+      card_number: "42",
+      fields: "summary",
+      include_attachments: true,
+    })) as Array<Record<string, unknown>>;
+
+    expect(result[0].body).toEqual({ plain_text: "Same here: [screenshot.png]" });
+    expect(result[0]).not.toHaveProperty("html");
+    expect(result[0].attachments).toEqual([EXPECTED_ATTACHMENT]);
+  });
+
+  it("still rejects an invalid fields value alongside the new flag", async () => {
+    await expect(
+      toolHandlers.fizzy_get_card_comments(client, {
+        account_slug: ACCOUNT,
+        card_number: "42",
+        fields: "tiny",
+        include_attachments: true,
+      })
+    ).rejects.toThrow(/fields/);
+  });
+});

--- a/tests/tools/get-attachment.test.ts
+++ b/tests/tools/get-attachment.test.ts
@@ -1,0 +1,355 @@
+/**
+ * fizzy_get_attachment: the argument validation that is the tool's security
+ * boundary, and the content blocks it returns.
+ *
+ * The validation tests matter disproportionately because the Cloudflare
+ * transport dispatches raw arguments with no Zod validation at all — the
+ * handler is the only enforcement point on that path, so every case here is
+ * driven through the handler rather than through a schema.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { FizzyClient } from "../../src/client/fizzy-client.js";
+import { createFizzyServer } from "../../src/server.js";
+import { FizzyClient as RealFizzyClient } from "../../src/client/fizzy-client.js";
+import { toolHandlers, toMcpContent } from "../../src/tools/handlers.js";
+import { MAX_INLINE_IMAGE_BYTES } from "../../src/utils/attachments.js";
+import { FizzyAttachmentTooLargeError } from "../../src/utils/errors.js";
+import { bytesToBase64 } from "../../src/utils/base64.js";
+
+const SIGNED_ID =
+  "eyJfcmFpbHMiOnsiZGF0YSI6ImV4YW1wbGVibG9iaWQiLCJwdXIiOiJibG9iX2lkIn19--1111111111111111111111111111111111111111";
+const VARIATION =
+  "eyJfcmFpbHMiOnsiZGF0YSI6InJlc2l6ZV90b19saW1pdCIsInB1ciI6InZhcmlhdGlvbiJ9fQ==--3333333333333333333333333333333333333333";
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]);
+
+const VALID_ARGS = {
+  account_slug: "1234567",
+  signed_id: SIGNED_ID,
+  filename: "screenshot.png",
+};
+
+interface FetchCall {
+  accountSlug: string;
+  ref: { signedId: string; filename: string; variation?: string };
+  options: {
+    maxBytes: number;
+    shouldReadBody?: (contentType: string) => boolean;
+  };
+}
+
+let fetchCalls: FetchCall[];
+
+function mockClient(
+  result: unknown = { contentType: "image/png", bytes: PNG_BYTES, byteSize: PNG_BYTES.length }
+): FizzyClient {
+  return {
+    getBaseUrl: () => "https://fizzy.example.com",
+    fetchAttachment: vi.fn(async (accountSlug, ref, options) => {
+      fetchCalls.push({ accountSlug, ref, options } as FetchCall);
+      if (result instanceof Error) throw result;
+      return result;
+    }),
+  } as unknown as FizzyClient;
+}
+
+const getAttachment = (client: FizzyClient, args: Record<string, unknown>) =>
+  toolHandlers.fizzy_get_attachment(client, args);
+
+beforeEach(() => {
+  fetchCalls = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fizzy_get_attachment: never takes a URL", () => {
+  it.each(["url", "preview_url", "blob_url", "attachment_url", "src"])(
+    "rejects a caller-supplied %s outright",
+    async (key) => {
+      await expect(
+        getAttachment(mockClient(), {
+          ...VALID_ARGS,
+          [key]: "https://attacker.example/collect",
+        })
+      ).rejects.toThrow(/does not take a URL/i);
+
+      // Rejected before any request: a URL argument must never reach a fetch
+      // that carries the Fizzy token.
+      expect(fetchCalls).toHaveLength(0);
+    }
+  );
+
+  it("rejects a URL passed in place of the signed id", async () => {
+    await expect(
+      getAttachment(mockClient(), {
+        ...VALID_ARGS,
+        signed_id: "https://attacker.example/steal",
+      })
+    ).rejects.toThrow(/signed_id/i);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe("fizzy_get_attachment: path components", () => {
+  it.each([
+    ["a directory separator", "../../etc/passwd"],
+    ["a nested path", "images/screenshot.png"],
+    ["a Windows separator", "..\\..\\secrets.txt"],
+    ["a bare parent segment", ".."],
+    ["a bare current segment", "."],
+  ])("rejects a filename that is %s", async (_label, filename) => {
+    await expect(
+      getAttachment(mockClient(), { ...VALID_ARGS, filename })
+    ).rejects.toThrow();
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it.each([
+    ["a slash", `${SIGNED_ID}/../../admin`],
+    ["a backslash", `${SIGNED_ID}\\x`],
+    ["a percent escape", `${SIGNED_ID}%2F..%2Fadmin`],
+    ["a parent segment", ".."],
+    ["a space", `${SIGNED_ID} extra`],
+  ])("rejects a signed_id containing %s", async (_label, signedId) => {
+    await expect(
+      getAttachment(mockClient(), { ...VALID_ARGS, signed_id: signedId })
+    ).rejects.toThrow(/signed_id/i);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("rejects a variation token containing a separator", async () => {
+    await expect(
+      getAttachment(mockClient(), { ...VALID_ARGS, variation: "../other" })
+    ).rejects.toThrow(/variation/i);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it.each([
+    ["a path", "1234567/../9999999"],
+    ["a URL", "https://attacker.example"],
+    ["a parent segment", ".."],
+  ])("rejects an account_slug that is %s", async (_label, slug) => {
+    await expect(
+      getAttachment(mockClient(), { ...VALID_ARGS, account_slug: slug })
+    ).rejects.toThrow(/account_slug/i);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("accepts an account slug written with its leading slash", async () => {
+    await getAttachment(mockClient(), { ...VALID_ARGS, account_slug: "/1234567" });
+    expect(fetchCalls[0].accountSlug).toBe("1234567");
+  });
+
+  it.each(["account_slug", "signed_id", "filename"])(
+    "requires %s",
+    async (key) => {
+      const args = { ...VALID_ARGS } as Record<string, unknown>;
+      delete args[key];
+      await expect(getAttachment(mockClient(), args)).rejects.toThrow(
+        new RegExp(key, "i")
+      );
+    }
+  );
+
+  it("passes the validated parts through unchanged", async () => {
+    await getAttachment(mockClient(), { ...VALID_ARGS, variation: VARIATION });
+
+    expect(fetchCalls[0].ref).toEqual({
+      signedId: SIGNED_ID,
+      filename: "screenshot.png",
+      variation: VARIATION,
+    });
+  });
+});
+
+describe("fizzy_get_attachment: what it returns", () => {
+  it("returns an image content block a model can actually see", async () => {
+    const result = await getAttachment(mockClient(), VALID_ARGS);
+
+    const content = toMcpContent(result);
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({
+      type: "text",
+      text: JSON.stringify(
+        {
+          filename: "screenshot.png",
+          content_type: "image/png",
+          byte_size: PNG_BYTES.length,
+          variant: "original",
+        },
+        null,
+        2
+      ),
+    });
+    expect(content[1]).toEqual({
+      type: "image",
+      data: bytesToBase64(PNG_BYTES),
+      mimeType: "image/png",
+    });
+  });
+
+  it("labels a variation fetch as the preview", async () => {
+    const result = await getAttachment(mockClient(), {
+      ...VALID_ARGS,
+      variation: VARIATION,
+    });
+
+    const [summary] = toMcpContent(result);
+    expect(summary.type).toBe("text");
+    expect(JSON.parse((summary as { text: string }).text).variant).toBe("preview");
+  });
+
+  it("caps what it will inline well below the upload limit", async () => {
+    await getAttachment(mockClient(), VALID_ARGS);
+    expect(fetchCalls[0].options.maxBytes).toBe(MAX_INLINE_IMAGE_BYTES);
+    expect(MAX_INLINE_IMAGE_BYTES).toBeLessThan(10 * 1024 * 1024);
+  });
+
+  it("only asks for the bytes of types a model can decode", async () => {
+    await getAttachment(mockClient(), VALID_ARGS);
+    const shouldReadBody = fetchCalls[0].options.shouldReadBody!;
+
+    expect(shouldReadBody("image/png")).toBe(true);
+    expect(shouldReadBody("image/jpeg")).toBe(true);
+    expect(shouldReadBody("image/gif")).toBe(true);
+    expect(shouldReadBody("image/webp")).toBe(true);
+    // Not renderable by a vision model, so not worth downloading either.
+    expect(shouldReadBody("image/svg+xml")).toBe(false);
+    expect(shouldReadBody("application/zip")).toBe(false);
+    expect(shouldReadBody("application/pdf")).toBe(false);
+    expect(shouldReadBody("")).toBe(false);
+  });
+
+  it("reports a non-renderable type as metadata instead of base64", async () => {
+    const client = mockClient({
+      contentType: "application/zip",
+      byteSize: 40_000_000,
+    });
+
+    const result = await getAttachment(client, { ...VALID_ARGS, filename: "logs.zip" });
+
+    expect(result).toEqual({
+      filename: "logs.zip",
+      content_type: "application/zip",
+      byte_size: 40_000_000,
+      variant: "original",
+      renderable: false,
+      note: expect.stringContaining("cannot be shown as an image"),
+    });
+    // Formatted as ordinary JSON text — no image block, no megabytes of base64.
+    const content = toMcpContent(result);
+    expect(content).toHaveLength(1);
+    expect(content[0].type).toBe("text");
+  });
+
+  it("falls back to a generic type when the server names none", async () => {
+    const client = mockClient({ contentType: "", byteSize: 12 });
+    const result = (await getAttachment(client, VALID_ARGS)) as Record<string, unknown>;
+
+    expect(result.content_type).toBe("application/octet-stream");
+    expect(result.renderable).toBe(false);
+  });
+});
+
+describe("fizzy_get_attachment: oversized attachments", () => {
+  it("points an oversized original at its preview variation", async () => {
+    const client = mockClient(
+      new FizzyAttachmentTooLargeError(
+        "screenshot.png is 9000000 bytes, over the 3145728-byte limit for an inlined attachment",
+        3145728,
+        9000000
+      )
+    );
+
+    await expect(getAttachment(client, VALID_ARGS)).rejects.toThrow(
+      /preview_variation/
+    );
+  });
+
+  it("does not suggest the preview when the preview is what was already asked for", async () => {
+    const client = mockClient(
+      new FizzyAttachmentTooLargeError("too big", 3145728, 9000000)
+    );
+
+    await expect(
+      getAttachment(client, { ...VALID_ARGS, variation: VARIATION })
+    ).rejects.toThrow(/^too big$/);
+  });
+});
+
+describe("fizzy_get_attachment over a real MCP connection", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("delivers the image block through the standard server's formatter", async () => {
+    // The transports used to hardcode a single text block; this proves the
+    // image survives the whole path, not just the handler.
+    globalThis.fetch = vi.fn(async () =>
+      new Response(PNG_BYTES, {
+        status: 200,
+        headers: {
+          "Content-Type": "image/png",
+          "Content-Length": String(PNG_BYTES.length),
+        },
+      })
+    ) as unknown as typeof fetch;
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createFizzyServer(
+      new RealFizzyClient({
+        accessToken: "test-token",
+        baseUrl: "https://fizzy.example.com",
+        maxRetries: 0,
+      })
+    );
+    await server.connect(serverTransport);
+    const client = new Client({ name: "attachment-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+
+    const result = (await client.callTool({
+      name: "fizzy_get_attachment",
+      arguments: VALID_ARGS,
+    })) as { content: Array<Record<string, unknown>> };
+    await client.close();
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[1]).toEqual({
+      type: "image",
+      data: bytesToBase64(PNG_BYTES),
+      mimeType: "image/png",
+    });
+  });
+});
+
+describe("toMcpContent", () => {
+  it("serializes ordinary results exactly as before", () => {
+    expect(toMcpContent("Card 42 pinned")).toEqual([
+      { type: "text", text: "Card 42 pinned" },
+    ]);
+    expect(toMcpContent({ id: "1" })).toEqual([
+      { type: "text", text: JSON.stringify({ id: "1" }, null, 2) },
+    ]);
+  });
+
+  it("does not mistake API data that happens to carry an mcp_content key", () => {
+    // The marker is shape-checked, not just present-checked, so a payload that
+    // borrows the name is still serialized as data.
+    const payload = { mcp_content: ["not", "blocks"] };
+    expect(toMcpContent(payload)).toEqual([
+      { type: "text", text: JSON.stringify(payload, null, 2) },
+    ]);
+
+    const emptyish = { mcp_content: [] };
+    expect(toMcpContent(emptyish)).toEqual([
+      { type: "text", text: JSON.stringify(emptyish, null, 2) },
+    ]);
+  });
+});

--- a/tests/tools/published-schemas.test.ts
+++ b/tests/tools/published-schemas.test.ts
@@ -76,6 +76,7 @@ describe("published tool schemas", () => {
       "card_id",
       "card_number",
       "fields",
+      "include_attachments",
     ]);
   });
 

--- a/tests/tools/tools-list-over-protocol.test.ts
+++ b/tests/tools/tools-list-over-protocol.test.ts
@@ -58,6 +58,7 @@ describe("tools/list over a real MCP connection", () => {
       "card_id",
       "card_number",
       "fields",
+      "include_attachments",
     ]);
   });
 

--- a/tests/utils/action-text.test.ts
+++ b/tests/utils/action-text.test.ts
@@ -1,0 +1,265 @@
+/**
+ * The ActionText attachment parser.
+ *
+ * The fixture below mirrors the shape the live API returns — attribute names
+ * and ordering, the nested `<figure>`/`<a>`/`<img>`, and the
+ * `representations/redirect/<signed_id>/<variation>/<filename>` preview path —
+ * with entirely synthetic ids, filenames and sizes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseActionTextAttachments } from "../../src/utils/action-text.js";
+
+const BASE_URL = "https://fizzy.example.com";
+const ACCOUNT = "1234567";
+
+const BLOB_SIGNED_ID =
+  "eyJfcmFpbHMiOnsiZGF0YSI6ImV4YW1wbGVibG9iaWQiLCJwdXIiOiJibG9iX2lkIn19--1111111111111111111111111111111111111111";
+const ATTACHABLE_SGID =
+  "eyJfcmFpbHMiOnsiZGF0YSI6ImV4YW1wbGVzZ2lkIiwicHVyIjoiYXR0YWNoYWJsZSJ9fQ==--2222222222222222222222222222222222222222";
+const VARIATION =
+  "eyJfcmFpbHMiOnsiZGF0YSI6InJlc2l6ZV90b19saW1pdCIsInB1ciI6InZhcmlhdGlvbiJ9fQ==--3333333333333333333333333333333333333333";
+
+const BLOB_PATH = `/${ACCOUNT}/rails/active_storage/blobs/redirect/${BLOB_SIGNED_ID}/screenshot.png`;
+const PREVIEW_PATH = `/${ACCOUNT}/rails/active_storage/representations/redirect/${BLOB_SIGNED_ID}/${VARIATION}/screenshot.png`;
+
+/** One image attachment, shaped as the API actually renders it. */
+const IMAGE_ATTACHMENT_HTML =
+  `<div class="trix-content">` +
+  `<p>Here is the failure:</p>` +
+  `<action-text-attachment sgid="${ATTACHABLE_SGID}" content-type="image/png" ` +
+  `url="${BLOB_PATH}" filename="screenshot.png" filesize="204800" width="1600" height="900" ` +
+  `previewable="true" presentation="gallery">` +
+  `<figure class="attachment attachment--preview attachment--png">` +
+  `<a href="${BLOB_PATH}">` +
+  `<img src="${PREVIEW_PATH}" width="1600" height="900" />` +
+  `</a>` +
+  `<figcaption class="attachment__caption">screenshot.png</figcaption>` +
+  `</figure>` +
+  `</action-text-attachment>` +
+  `</div>`;
+
+describe("parseActionTextAttachments", () => {
+  it("extracts every field from real-shaped markup", () => {
+    const [attachment, ...rest] = parseActionTextAttachments(
+      IMAGE_ATTACHMENT_HTML,
+      BASE_URL
+    );
+
+    expect(rest).toHaveLength(0);
+    expect(attachment).toEqual({
+      filename: "screenshot.png",
+      content_type: "image/png",
+      byte_size: 204800,
+      width: 1600,
+      height: 900,
+      signed_id: BLOB_SIGNED_ID,
+      url: `${BASE_URL}${BLOB_PATH}`,
+      preview_url: `${BASE_URL}${PREVIEW_PATH}`,
+      preview_variation: VARIATION,
+    });
+  });
+
+  it("makes the relative paths absolute against the configured base URL", () => {
+    // Never app.fizzy.do: a self-hosted or staging deployment has to resolve
+    // against itself, which is why the client's baseUrl is threaded through.
+    const [attachment] = parseActionTextAttachments(
+      IMAGE_ATTACHMENT_HTML,
+      "https://fizzy.internal.example:8443"
+    );
+
+    expect(attachment.url).toBe(`https://fizzy.internal.example:8443${BLOB_PATH}`);
+    expect(attachment.preview_url).toBe(
+      `https://fizzy.internal.example:8443${PREVIEW_PATH}`
+    );
+  });
+
+  it("lifts the signed id out of the url path so it can be fetched directly", () => {
+    const [attachment] = parseActionTextAttachments(IMAGE_ATTACHMENT_HTML, BASE_URL);
+    expect(attachment.signed_id).toBe(BLOB_SIGNED_ID);
+  });
+
+  it("returns nothing for HTML with no attachments", () => {
+    expect(
+      parseActionTextAttachments(
+        "<div><p>Just a description with <b>markup</b> and a <a href='/x'>link</a>.</p></div>",
+        BASE_URL
+      )
+    ).toEqual([]);
+  });
+
+  it("returns nothing for absent, empty, or non-string fields", () => {
+    expect(parseActionTextAttachments(undefined, BASE_URL)).toEqual([]);
+    expect(parseActionTextAttachments(null, BASE_URL)).toEqual([]);
+    expect(parseActionTextAttachments("", BASE_URL)).toEqual([]);
+    expect(parseActionTextAttachments(42, BASE_URL)).toEqual([]);
+    expect(parseActionTextAttachments({ html: IMAGE_ATTACHMENT_HTML }, BASE_URL)).toEqual(
+      []
+    );
+  });
+
+  it("parses several attachments without letting one bleed into the next", () => {
+    const second = BLOB_PATH.replace("screenshot.png", "diagram.png");
+    const html =
+      IMAGE_ATTACHMENT_HTML +
+      `<action-text-attachment content-type="image/png" url="${second}" ` +
+      `filename="diagram.png" filesize="1024">` +
+      `<figure><img src="${second}" /></figure>` +
+      `</action-text-attachment>`;
+
+    const parsed = parseActionTextAttachments(html, BASE_URL);
+
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].filename).toBe("screenshot.png");
+    expect(parsed[0].preview_url).toBe(`${BASE_URL}${PREVIEW_PATH}`);
+    // The second has no representation of its own and must not inherit the
+    // first's — that is what bounding the inner markup buys.
+    expect(parsed[1].filename).toBe("diagram.png");
+    expect(parsed[1].preview_url).toBeUndefined();
+    expect(parsed[1].preview_variation).toBeUndefined();
+  });
+
+  describe("malformed markup", () => {
+    it("reports the attributes that are present and omits the rest", () => {
+      const [attachment] = parseActionTextAttachments(
+        `<action-text-attachment filename="notes.txt"></action-text-attachment>`,
+        BASE_URL
+      );
+
+      expect(attachment).toEqual({ filename: "notes.txt" });
+    });
+
+    it("treats a non-numeric size or dimension as missing rather than NaN", () => {
+      const [attachment] = parseActionTextAttachments(
+        `<action-text-attachment filename="a.png" filesize="unknown" width="" height="-5">` +
+          `</action-text-attachment>`,
+        BASE_URL
+      );
+
+      expect(attachment.byte_size).toBeUndefined();
+      expect(attachment.width).toBeUndefined();
+      expect(attachment.height).toBeUndefined();
+    });
+
+    it("does not throw on an unterminated tag", () => {
+      expect(() =>
+        parseActionTextAttachments(
+          `<p>x</p><action-text-attachment filename="a.png" url="${BLOB_PATH}"`,
+          BASE_URL
+        )
+      ).not.toThrow();
+      expect(
+        parseActionTextAttachments(
+          `<p>x</p><action-text-attachment filename="a.png" url="${BLOB_PATH}"`,
+          BASE_URL
+        )
+      ).toEqual([]);
+    });
+
+    it("does not cut the tag short at a > inside a quoted attribute", () => {
+      const [attachment] = parseActionTextAttachments(
+        `<action-text-attachment caption="before &gt; after > still caption" ` +
+          `filename="a.png" content-type="image/png"></action-text-attachment>`,
+        BASE_URL
+      );
+
+      expect(attachment.filename).toBe("a.png");
+      expect(attachment.content_type).toBe("image/png");
+    });
+
+    it("decodes entity references in attribute values", () => {
+      const [attachment] = parseActionTextAttachments(
+        `<action-text-attachment filename="a &amp; b.png" ` +
+          `url="/1234567/rails/active_storage/blobs/redirect/${BLOB_SIGNED_ID}/a%20b.png?x=1&amp;y=2">` +
+          `</action-text-attachment>`,
+        BASE_URL
+      );
+
+      expect(attachment.filename).toBe("a & b.png");
+      expect(attachment.url).toContain("?x=1&y=2");
+    });
+
+    it("drops a url whose scheme is not http or https", () => {
+      const [attachment] = parseActionTextAttachments(
+        `<action-text-attachment filename="a.png" url="javascript:alert(1)">` +
+          `</action-text-attachment>`,
+        BASE_URL
+      );
+
+      expect(attachment.url).toBeUndefined();
+      expect(attachment.filename).toBe("a.png");
+    });
+
+    it("survives a base URL it cannot parse", () => {
+      const parsed = parseActionTextAttachments(IMAGE_ATTACHMENT_HTML, "not a url");
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].url).toBeUndefined();
+      // The signed id comes out of the path, so it survives a broken base URL —
+      // which is the field fizzy_get_attachment actually needs.
+      expect(parsed[0].signed_id).toBe(BLOB_SIGNED_ID);
+    });
+
+    it("keeps a remote image that has no signed id at all", () => {
+      const [attachment] = parseActionTextAttachments(
+        `<action-text-attachment content-type="image/jpeg" ` +
+          `url="https://images.example.com/remote.jpg" filename="remote.jpg">` +
+          `</action-text-attachment>`,
+        BASE_URL
+      );
+
+      expect(attachment.url).toBe("https://images.example.com/remote.jpg");
+      expect(attachment.signed_id).toBeUndefined();
+    });
+
+    it("ignores an element that carries nothing usable", () => {
+      expect(
+        parseActionTextAttachments(
+          `<action-text-attachment></action-text-attachment>`,
+          BASE_URL
+        )
+      ).toEqual([]);
+    });
+
+    it("does not match a differently named element that shares the prefix", () => {
+      expect(
+        parseActionTextAttachments(
+          `<action-text-attachment-group filename="a.png"></action-text-attachment-group>`,
+          BASE_URL
+        )
+      ).toEqual([]);
+    });
+  });
+
+  it("reads the blob path out of an href when there is no url attribute", () => {
+    const [attachment] = parseActionTextAttachments(
+      `<action-text-attachment content-type="application/zip" href="${BLOB_PATH.replace(
+        "screenshot.png",
+        "logs.zip"
+      )}" filename="logs.zip" filesize="90210"></action-text-attachment>`,
+      BASE_URL
+    );
+
+    expect(attachment.signed_id).toBe(BLOB_SIGNED_ID);
+    expect(attachment.byte_size).toBe(90210);
+    expect(attachment.content_type).toBe("application/zip");
+  });
+
+  it("matches the element name case-insensitively", () => {
+    const [attachment] = parseActionTextAttachments(
+      `<ACTION-TEXT-ATTACHMENT FILENAME="a.png" CONTENT-TYPE="image/png">` +
+        `</ACTION-TEXT-ATTACHMENT>`,
+      BASE_URL
+    );
+
+    expect(attachment).toEqual({ filename: "a.png", content_type: "image/png" });
+  });
+
+  it("stops scanning long before an implausible number of elements", () => {
+    const one = `<action-text-attachment filename="a.png"></action-text-attachment>`;
+    const parsed = parseActionTextAttachments(one.repeat(500), BASE_URL);
+
+    expect(parsed.length).toBeLessThanOrEqual(200);
+    expect(parsed.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/utils/attachments.test.ts
+++ b/tests/utils/attachments.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   MAX_ATTACHMENT_BYTES,
+  MAX_INLINE_IMAGE_BYTES,
   attachmentHtml,
   contentTypeForFilename,
+  isInlineableImage,
+  parseAttachmentRequest,
   resolveAttachment,
 } from "../../src/utils/attachments.js";
 import { maxEncodedLength } from "../../src/utils/base64.js";
@@ -215,5 +218,116 @@ describe("resolveAttachment", () => {
       setLocalFileReader(async () => new Uint8Array(MAX_ATTACHMENT_BYTES));
       await expect(resolveAttachment({ file_path: "big.png" })).resolves.toBeDefined();
     });
+  });
+});
+
+describe("isInlineableImage", () => {
+  it.each(["image/png", "image/jpeg", "image/gif", "image/webp", "IMAGE/PNG"])(
+    "accepts %s",
+    (contentType) => {
+      expect(isInlineableImage(contentType)).toBe(true);
+    }
+  );
+
+  it.each([
+    // Vector and exotic raster formats: a vision model cannot decode these, so
+    // returning an image block for them produces a client error, not a picture.
+    "image/svg+xml",
+    "image/tiff",
+    "image/heic",
+    "image/bmp",
+    "application/pdf",
+    "application/zip",
+    "text/plain",
+    "",
+  ])("declines %s", (contentType) => {
+    expect(isInlineableImage(contentType)).toBe(false);
+  });
+});
+
+describe("MAX_INLINE_IMAGE_BYTES", () => {
+  it("is well under the upload cap, because base64 inflates into the response", () => {
+    expect(MAX_INLINE_IMAGE_BYTES).toBeLessThan(MAX_ATTACHMENT_BYTES);
+    // 4/3 inflation has to stay inside the 5 MB per-image API ceiling.
+    expect(Math.ceil((MAX_INLINE_IMAGE_BYTES * 4) / 3)).toBeLessThan(5 * 1024 * 1024);
+  });
+});
+
+describe("parseAttachmentRequest", () => {
+  const SIGNED_ID =
+    "eyJfcmFpbHMiOnsiZGF0YSI6ImV4YW1wbGVibG9iaWQiLCJwdXIiOiJibG9iX2lkIn19--1111111111111111111111111111111111111111";
+
+  it("returns the validated parts, with the account slug normalized", () => {
+    expect(
+      parseAttachmentRequest({
+        account_slug: "/1234567",
+        signed_id: SIGNED_ID,
+        filename: "screenshot.png",
+      })
+    ).toEqual({
+      accountSlug: "1234567",
+      signedId: SIGNED_ID,
+      filename: "screenshot.png",
+    });
+  });
+
+  it("carries a variation token through when one is given", () => {
+    const variation = "eyJfcmFpbHMiOnt9fQ==--4444444444444444444444444444444444444444";
+    expect(
+      parseAttachmentRequest({
+        account_slug: "1234567",
+        signed_id: SIGNED_ID,
+        filename: "a.png",
+        variation,
+      }).variation
+    ).toBe(variation);
+  });
+
+  it("treats an empty or null variation as absent rather than as a token", () => {
+    const base = { account_slug: "1234567", signed_id: SIGNED_ID, filename: "a.png" };
+    expect(parseAttachmentRequest({ ...base, variation: "" }).variation).toBeUndefined();
+    expect(parseAttachmentRequest({ ...base, variation: null }).variation).toBeUndefined();
+  });
+
+  it("rejects a non-string variation", () => {
+    expect(() =>
+      parseAttachmentRequest({
+        account_slug: "1234567",
+        signed_id: SIGNED_ID,
+        filename: "a.png",
+        variation: 7,
+      })
+    ).toThrow(/variation must be a string/);
+  });
+
+  it("rejects a signed id long enough to be a payload rather than a token", () => {
+    expect(() =>
+      parseAttachmentRequest({
+        account_slug: "1234567",
+        signed_id: "a".repeat(5000),
+        filename: "a.png",
+      })
+    ).toThrow(/too long/);
+  });
+
+  it("rejects a filename longer than a filesystem would accept", () => {
+    expect(() =>
+      parseAttachmentRequest({
+        account_slug: "1234567",
+        signed_id: SIGNED_ID,
+        filename: `${"a".repeat(300)}.png`,
+      })
+    ).toThrow(/filename is too long/);
+  });
+
+  it("rejects a filename carrying a control character", () => {
+    // A NUL truncates a path in anything that hands it to a C API downstream.
+    expect(() =>
+      parseAttachmentRequest({
+        account_slug: "1234567",
+        signed_id: SIGNED_ID,
+        filename: "a\u0000.png",
+      })
+    ).toThrow(/control characters/);
   });
 });

--- a/tests/verify-refactoring.test.ts
+++ b/tests/verify-refactoring.test.ts
@@ -17,10 +17,11 @@ describe("Refactored Server Verification", () => {
     expect(() => createFizzyServer(client)).not.toThrow();
   });
 
-  it("should have all 53 tools defined in definitions.ts", () => {
-    expect(ALL_TOOLS).toHaveLength(53);
+  it("should have all 54 tools defined in definitions.ts", () => {
+    expect(ALL_TOOLS).toHaveLength(54);
     const names = ALL_TOOLS.map((tool) => tool.name);
     expect(names).toContain("fizzy_upload_file");
+    expect(names).toContain("fizzy_get_attachment");
     expect(names).toEqual(
       expect.arrayContaining(["fizzy_pin_card", "fizzy_unpin_card", "fizzy_get_pins"])
     );

--- a/tsconfig.cloudflare.json
+++ b/tsconfig.cloudflare.json
@@ -24,6 +24,7 @@
     "src/utils/errors.ts",
     "src/utils/etag-cache.ts",
     "src/utils/logger.ts",
+    "src/utils/action-text.ts",
     "src/utils/attachments.ts",
     "src/utils/base64.ts",
     "src/utils/client-auth.ts",


### PR DESCRIPTION
The server could upload attachments but never read one back, so a screenshot already on a card was invisible to a model. The bytes were reachable the whole time — just not through anything the server exposed.

Three things stood in the way. Attachments appear only as raw `<action-text-attachment>` markup inside `description_html`, with a **relative** `url`; the plain-text `description` flattens each one to a bare `[filename.png]` with no URL at all; and `fields: "summary"` drops `description_html` entirely, leaving only `has_attachments: true`. Even with the URL in hand it is authenticated, so a client without the token gets the sign-in page.

## What this adds

**`fizzy_get_attachment`** — fetches a blob through the authenticated client and returns it as an MCP image content block, so the image is actually visible rather than merely referenced.

**`include_attachments`** — opt-in on `fizzy_get_card` and `fizzy_get_card_comments`, parsing the markup into `{filename, content_type, byte_size, width, height, signed_id, url, preview_url, preview_variation}`. Omitting it leaves today's responses byte-for-byte unchanged.

## The credential boundary

Fetching a blob is a redirect chain that crosses hosts: the first hop is authenticated against the Fizzy origin and redirects to third-party storage. The bearer token must not follow.

`fetchAttachment` walks the chain with `redirect: "manual"` and decides authentication **per hop, by origin comparison** against the configured base URL — not by hop number. That is deliberately stronger than "authenticate hop 1, leave hop 2 bare": the representations endpoint may redirect same-origin before reaching storage, and a hop-number rule would send an unauthenticated request to Fizzy and get an HTML sign-in form back, typed as the caller's screenshot. A redirect to `/session/*` on the Fizzy origin is now raised as an auth error rather than fetched. An unparseable base URL yields an empty origin and withholds the token, so the failure mode is closed rather than open.

The tool never accepts a caller-supplied URL — that would be an SSRF sink with the user's token attached. It takes a `signed_id` and rebuilds the path, with every interpolated component pinned to a single path segment. That validation lives in the shared handler layer rather than the zod schema, because the Cloudflare transport executes tool arguments without zod, making the schema decorative on that path.

Bodies are bounded on every path, not just the successful one: redirect bodies are cancelled before the next hop, and error bodies read through an 8 KB truncating reader. Otherwise the least trustworthy response in the chain would be the only one read without limit.

## Notable choices

- **Inline cap is 3 MB**, not the 10 MB used for uploads. Base64 inflates ~4/3 to ~4 MB, staying under the 5 MB per-image ceiling that binds long before any transport limit. An oversized original points the caller at its `preview_variation` rather than truncating.
- **Only PNG/JPEG/GIF/WebP are inlined.** SVG and TIFF render as a client-side error rather than a picture, so they take the metadata path. Non-inlineable types have their body cancelled rather than downloaded, so a large zip costs one round trip.
- **Not wired into the list tools** — those payloads are already the ones under size pressure.
- `toMcpContent()` is now shared between the stdio and Workers formatters, which previously each carried their own copy of the same rule.

## Verification

`typecheck`, `typecheck:cf`, `test:cloudflare` (124) and `build` all pass. Unit suite: 867 passing, with 5 pre-existing `EADDRINUSE` failures in transport tests caused by a foreign process holding port 3100 on the test machine — unrelated to this diff, which touches no transport code.

New tests: 90 across four files, covering the parser, the fetch chain, the tool, and the metadata wiring. The credential assertions are written against behaviour — that a hop carries no `Authorization` once it leaves the configured origin — rather than against any particular storage hostname, which is deployment-specific.

## Local smoke test

Automated coverage stubs `fetch`, so the live redirect chain is not exercised. One path in particular could not be verified against the real API: **the `representations/redirect/…` preview endpoint**. If it behaves differently from the blob endpoint, only a live call will show it, and the failure would be quiet.

Run the branch's own `dist/` against a real account — the installed server runs deployed `main`, so it will not exercise this code:

1. `npm run build`, then start the built server with a valid access token.
2. `fizzy_get_card` on a card holding a screenshot, with `include_attachments: true`.
   **Expect:** an `attachments` array whose entry carries `filename`, `content_type`, `signed_id` and `preview_variation`.
3. `fizzy_get_attachment` with that `signed_id` and `filename`.
   **Expect:** the screenshot renders. A sign-in page or an HTML blob means the credential boundary is wrong.
4. The same call plus `variation: <preview_variation>`.
   **Expect:** the same image, materially smaller. **This is the unverified path.**
5. `fizzy_get_card` with `include_attachments` omitted.
   **Expect:** identical to before this change.