### PR TITLE
fix(client): validate every path-segment id, not just account_slug

### DIFF
--- a/src/client/fizzy-client.ts
+++ b/src/client/fizzy-client.ts
@@ -48,6 +48,7 @@ import {
 } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { normalizeAccountSlug } from "../utils/account-slug.js";
+import { assertPathSegment } from "../utils/path-segment.js";
 import { ETagCache } from "../utils/etag-cache.js";
 import { md5Base64 } from "../utils/md5.js";
 
@@ -696,7 +697,8 @@ export class FizzyClient {
    */
   async getBoard(accountSlug: string, boardId: string): Promise<FizzyBoard> {
     const slug = this.normalizeSlug(accountSlug);
-    return this.request<FizzyBoard>("GET", `/${slug}/boards/${boardId}`);
+    const board = assertPathSegment(boardId, "board_id");
+    return this.request<FizzyBoard>("GET", `/${slug}/boards/${board}`);
   }
 
   /**
@@ -725,7 +727,8 @@ export class FizzyClient {
     data: UpdateBoardRequest
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("PUT", `/${slug}/boards/${boardId}`, {
+    const board = assertPathSegment(boardId, "board_id");
+    await this.request<void>("PUT", `/${slug}/boards/${board}`, {
       board: data,
     });
   }
@@ -737,7 +740,8 @@ export class FizzyClient {
    */
   async deleteBoard(accountSlug: string, boardId: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("DELETE", `/${slug}/boards/${boardId}`);
+    const board = assertPathSegment(boardId, "board_id");
+    await this.request<void>("DELETE", `/${slug}/boards/${board}`);
   }
 
   // ============ Cards ============
@@ -756,7 +760,12 @@ export class FizzyClient {
     options?: CardListOptions
   ): Promise<CardsPage> {
     const slug = this.normalizeSlug(accountSlug);
+    // queryString is built internally by buildQueryString from the filter
+    // options, not spliced together from caller text, and deliberately carries
+    // `?`/`&` — it needs no path-segment guard.
     const queryString = options ? this.buildQueryString(options) : "";
+    // requestedPage is a number (CardListOptions.page), checked below to be a
+    // safe positive integer, so it needs no path-segment guard either.
     const requestedPage = options?.page ?? 1;
 
     // The tool layer validates `page` separately; this defends direct client callers.
@@ -797,7 +806,11 @@ export class FizzyClient {
    */
   async getCard(accountSlug: string, cardId: string): Promise<FizzyCard> {
     const slug = this.normalizeSlug(accountSlug);
-    return this.request<FizzyCard>("GET", `/${slug}/cards/${cardId}`);
+    // Guarded as an opaque path segment, not a pinned shape — the /cards/:id
+    // route actually resolves by number, not by this "card_id" (see the note
+    // in utils/path-segment.ts), so there is no single shape to pin here.
+    const card = assertPathSegment(cardId, "card_id");
+    return this.request<FizzyCard>("GET", `/${slug}/cards/${card}`);
   }
 
   /**
@@ -811,9 +824,10 @@ export class FizzyClient {
     data: CreateCardRequest
   ): Promise<FizzyCard> {
     const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
     return this.request<FizzyCard>(
       "POST",
-      `/${slug}/boards/${boardId}/cards`,
+      `/${slug}/boards/${board}/cards`,
       { card: data }
     );
   }
@@ -829,7 +843,9 @@ export class FizzyClient {
     data: UpdateCardRequest
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("PUT", `/${slug}/cards/${cardId}`, {
+    // See getCard: guarded as an opaque path segment, not a pinned shape.
+    const card = assertPathSegment(cardId, "card_id");
+    await this.request<void>("PUT", `/${slug}/cards/${card}`, {
       card: data,
     });
   }
@@ -841,7 +857,9 @@ export class FizzyClient {
    */
   async deleteCard(accountSlug: string, cardId: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("DELETE", `/${slug}/cards/${cardId}`);
+    // See getCard: guarded as an opaque path segment, not a pinned shape.
+    const card = assertPathSegment(cardId, "card_id");
+    await this.request<void>("DELETE", `/${slug}/cards/${card}`);
   }
 
   // ============ Card Actions ============
@@ -853,7 +871,8 @@ export class FizzyClient {
    */
   async closeCard(accountSlug: string, cardNumber: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("POST", `/${slug}/cards/${cardNumber}/closure`);
+    const card = assertPathSegment(cardNumber, "card_number");
+    await this.request<void>("POST", `/${slug}/cards/${card}/closure`);
   }
 
   /**
@@ -863,7 +882,8 @@ export class FizzyClient {
    */
   async reopenCard(accountSlug: string, cardNumber: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("DELETE", `/${slug}/cards/${cardNumber}/closure`);
+    const card = assertPathSegment(cardNumber, "card_number");
+    await this.request<void>("DELETE", `/${slug}/cards/${card}/closure`);
   }
 
   /**
@@ -873,7 +893,8 @@ export class FizzyClient {
    */
   async moveCardToNotNow(accountSlug: string, cardNumber: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("POST", `/${slug}/cards/${cardNumber}/not_now`);
+    const card = assertPathSegment(cardNumber, "card_number");
+    await this.request<void>("POST", `/${slug}/cards/${card}/not_now`);
   }
 
   /**
@@ -887,9 +908,12 @@ export class FizzyClient {
     columnId: string
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    // columnId is sent in the JSON body, not interpolated into the path, so it
+    // needs no guard here.
     await this.request<void>(
       "POST",
-      `/${slug}/cards/${cardNumber}/triage`,
+      `/${slug}/cards/${card}/triage`,
       { column_id: columnId }
     );
   }
@@ -901,7 +925,8 @@ export class FizzyClient {
    */
   async sendCardToTriage(accountSlug: string, cardNumber: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("DELETE", `/${slug}/cards/${cardNumber}/triage`);
+    const card = assertPathSegment(cardNumber, "card_number");
+    await this.request<void>("DELETE", `/${slug}/cards/${card}/triage`);
   }
 
   /**
@@ -916,9 +941,11 @@ export class FizzyClient {
     tagTitle: string
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    // tagTitle is sent in the JSON body, not interpolated into the path.
     await this.request<void>(
       "POST",
-      `/${slug}/cards/${cardNumber}/taggings`,
+      `/${slug}/cards/${card}/taggings`,
       { tag_title: tagTitle }
     );
   }
@@ -934,9 +961,11 @@ export class FizzyClient {
     assigneeId: string
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    // assigneeId is sent in the JSON body, not interpolated into the path.
     await this.request<void>(
       "POST",
-      `/${slug}/cards/${cardNumber}/assignments`,
+      `/${slug}/cards/${card}/assignments`,
       { assignee_id: assigneeId }
     );
   }
@@ -948,7 +977,8 @@ export class FizzyClient {
    */
   async watchCard(accountSlug: string, cardNumber: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("POST", `/${slug}/cards/${cardNumber}/watch`);
+    const card = assertPathSegment(cardNumber, "card_number");
+    await this.request<void>("POST", `/${slug}/cards/${card}/watch`);
   }
 
   /**
@@ -958,7 +988,8 @@ export class FizzyClient {
    */
   async unwatchCard(accountSlug: string, cardNumber: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("DELETE", `/${slug}/cards/${cardNumber}/watch`);
+    const card = assertPathSegment(cardNumber, "card_number");
+    await this.request<void>("DELETE", `/${slug}/cards/${card}/watch`);
   }
 
   /**
@@ -967,7 +998,8 @@ export class FizzyClient {
    */
   async gildCard(accountSlug: string, cardNumber: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("POST", `/${slug}/cards/${cardNumber}/goldness`);
+    const card = assertPathSegment(cardNumber, "card_number");
+    await this.request<void>("POST", `/${slug}/cards/${card}/goldness`);
   }
 
   /**
@@ -976,7 +1008,8 @@ export class FizzyClient {
    */
   async ungildCard(accountSlug: string, cardNumber: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("DELETE", `/${slug}/cards/${cardNumber}/goldness`);
+    const card = assertPathSegment(cardNumber, "card_number");
+    await this.request<void>("DELETE", `/${slug}/cards/${card}/goldness`);
   }
 
   // ============ Pins ============
@@ -988,7 +1021,8 @@ export class FizzyClient {
    */
   async pinCard(accountSlug: string, cardNumber: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("POST", `/${slug}/cards/${cardNumber}/pin`);
+    const card = assertPathSegment(cardNumber, "card_number");
+    await this.request<void>("POST", `/${slug}/cards/${card}/pin`);
   }
 
   /**
@@ -998,7 +1032,8 @@ export class FizzyClient {
    */
   async unpinCard(accountSlug: string, cardNumber: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("DELETE", `/${slug}/cards/${cardNumber}/pin`);
+    const card = assertPathSegment(cardNumber, "card_number");
+    await this.request<void>("DELETE", `/${slug}/cards/${card}/pin`);
   }
 
   /**
@@ -1035,8 +1070,9 @@ export class FizzyClient {
     cardNumber: string
   ): Promise<FizzyComment[]> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
     return this.requestAllPages<FizzyComment>(
-      `/${slug}/cards/${cardNumber}/comments`
+      `/${slug}/cards/${card}/comments`
     );
   }
 
@@ -1051,9 +1087,10 @@ export class FizzyClient {
     data: CreateCommentRequest
   ): Promise<FizzyComment> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
     return this.request<FizzyComment>(
       "POST",
-      `/${slug}/cards/${cardNumber}/comments`,
+      `/${slug}/cards/${card}/comments`,
       { comment: data }
     );
   }
@@ -1069,9 +1106,11 @@ export class FizzyClient {
     commentId: string
   ): Promise<FizzyComment> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    const comment = assertPathSegment(commentId, "comment_id");
     return this.request<FizzyComment>(
       "GET",
-      `/${slug}/cards/${cardNumber}/comments/${commentId}`
+      `/${slug}/cards/${card}/comments/${comment}`
     );
   }
 
@@ -1087,9 +1126,11 @@ export class FizzyClient {
     data: UpdateCommentRequest
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    const comment = assertPathSegment(commentId, "comment_id");
     await this.request<void>(
       "PUT",
-      `/${slug}/cards/${cardNumber}/comments/${commentId}`,
+      `/${slug}/cards/${card}/comments/${comment}`,
       { comment: data }
     );
   }
@@ -1105,9 +1146,11 @@ export class FizzyClient {
     commentId: string
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    const comment = assertPathSegment(commentId, "comment_id");
     await this.request<void>(
       "DELETE",
-      `/${slug}/cards/${cardNumber}/comments/${commentId}`
+      `/${slug}/cards/${card}/comments/${comment}`
     );
   }
 
@@ -1124,9 +1167,11 @@ export class FizzyClient {
     commentId: string
   ): Promise<FizzyReaction[]> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    const comment = assertPathSegment(commentId, "comment_id");
     return this.request<FizzyReaction[]>(
       "GET",
-      `/${slug}/cards/${cardNumber}/comments/${commentId}/reactions`
+      `/${slug}/cards/${card}/comments/${comment}/reactions`
     );
   }
 
@@ -1142,9 +1187,11 @@ export class FizzyClient {
     content: string
   ): Promise<FizzyReaction> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    const comment = assertPathSegment(commentId, "comment_id");
     return this.request<FizzyReaction>(
       "POST",
-      `/${slug}/cards/${cardNumber}/comments/${commentId}/reactions`,
+      `/${slug}/cards/${card}/comments/${comment}/reactions`,
       { reaction: { content } }
     );
   }
@@ -1161,9 +1208,12 @@ export class FizzyClient {
     reactionId: string
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    const comment = assertPathSegment(commentId, "comment_id");
+    const reaction = assertPathSegment(reactionId, "reaction_id");
     await this.request<void>(
       "DELETE",
-      `/${slug}/cards/${cardNumber}/comments/${commentId}/reactions/${reactionId}`
+      `/${slug}/cards/${card}/comments/${comment}/reactions/${reaction}`
     );
   }
 
@@ -1180,9 +1230,11 @@ export class FizzyClient {
     stepId: string
   ): Promise<FizzyStep> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    const step = assertPathSegment(stepId, "step_id");
     return this.request<FizzyStep>(
       "GET",
-      `/${slug}/cards/${cardNumber}/steps/${stepId}`
+      `/${slug}/cards/${card}/steps/${step}`
     );
   }
 
@@ -1197,9 +1249,10 @@ export class FizzyClient {
     data: CreateStepRequest
   ): Promise<FizzyStep> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
     return this.request<FizzyStep>(
       "POST",
-      `/${slug}/cards/${cardNumber}/steps`,
+      `/${slug}/cards/${card}/steps`,
       { step: data }
     );
   }
@@ -1216,9 +1269,11 @@ export class FizzyClient {
     data: UpdateStepRequest
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    const step = assertPathSegment(stepId, "step_id");
     await this.request<void>(
       "PUT",
-      `/${slug}/cards/${cardNumber}/steps/${stepId}`,
+      `/${slug}/cards/${card}/steps/${step}`,
       { step: data }
     );
   }
@@ -1234,9 +1289,11 @@ export class FizzyClient {
     stepId: string
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const card = assertPathSegment(cardNumber, "card_number");
+    const step = assertPathSegment(stepId, "step_id");
     await this.request<void>(
       "DELETE",
-      `/${slug}/cards/${cardNumber}/steps/${stepId}`
+      `/${slug}/cards/${card}/steps/${step}`
     );
   }
 
@@ -1252,9 +1309,10 @@ export class FizzyClient {
     boardId: string
   ): Promise<FizzyColumn[]> {
     const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
     return this.request<FizzyColumn[]>(
       "GET",
-      `/${slug}/boards/${boardId}/columns`
+      `/${slug}/boards/${board}/columns`
     );
   }
 
@@ -1269,9 +1327,11 @@ export class FizzyClient {
     columnId: string
   ): Promise<FizzyColumn> {
     const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
+    const column = assertPathSegment(columnId, "column_id");
     return this.request<FizzyColumn>(
       "GET",
-      `/${slug}/boards/${boardId}/columns/${columnId}`
+      `/${slug}/boards/${board}/columns/${column}`
     );
   }
 
@@ -1286,9 +1346,10 @@ export class FizzyClient {
     data: CreateColumnRequest
   ): Promise<FizzyColumn> {
     const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
     return this.request<FizzyColumn>(
       "POST",
-      `/${slug}/boards/${boardId}/columns`,
+      `/${slug}/boards/${board}/columns`,
       { column: data }
     );
   }
@@ -1305,9 +1366,11 @@ export class FizzyClient {
     data: UpdateColumnRequest
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
+    const column = assertPathSegment(columnId, "column_id");
     await this.request<void>(
       "PUT",
-      `/${slug}/boards/${boardId}/columns/${columnId}`,
+      `/${slug}/boards/${board}/columns/${column}`,
       { column: data }
     );
   }
@@ -1323,9 +1386,11 @@ export class FizzyClient {
     columnId: string
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
+    const column = assertPathSegment(columnId, "column_id");
     await this.request<void>(
       "DELETE",
-      `/${slug}/boards/${boardId}/columns/${columnId}`
+      `/${slug}/boards/${board}/columns/${column}`
     );
   }
 
@@ -1369,7 +1434,8 @@ export class FizzyClient {
    */
   async getUser(accountSlug: string, userId: string): Promise<FizzyUser> {
     const slug = this.normalizeSlug(accountSlug);
-    return this.request<FizzyUser>("GET", `/${slug}/users/${userId}`);
+    const user = assertPathSegment(userId, "user_id");
+    return this.request<FizzyUser>("GET", `/${slug}/users/${user}`);
   }
 
   /**
@@ -1383,7 +1449,8 @@ export class FizzyClient {
     data: UpdateUserRequest
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("PUT", `/${slug}/users/${userId}`, {
+    const user = assertPathSegment(userId, "user_id");
+    await this.request<void>("PUT", `/${slug}/users/${user}`, {
       user: data,
     });
   }
@@ -1395,7 +1462,8 @@ export class FizzyClient {
    */
   async deactivateUser(accountSlug: string, userId: string): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
-    await this.request<void>("DELETE", `/${slug}/users/${userId}`);
+    const user = assertPathSegment(userId, "user_id");
+    await this.request<void>("DELETE", `/${slug}/users/${user}`);
   }
 
   // ============ Notifications ============
@@ -1432,6 +1500,8 @@ export class FizzyClient {
 
     // Page 1 must stay page-less: `?page=1` is not the same request upstream,
     // it drops every unread notification from the response.
+    // requestedPage is a number (NotificationListOptions.page), checked above
+    // to be a safe positive integer, so it needs no path-segment guard.
     const path =
       requestedPage === 1
         ? `/${slug}/notifications`
@@ -1450,9 +1520,10 @@ export class FizzyClient {
     notificationId: string
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const notification = assertPathSegment(notificationId, "notification_id");
     await this.request<void>(
       "POST",
-      `/${slug}/notifications/${notificationId}/reading`
+      `/${slug}/notifications/${notification}/reading`
     );
   }
 
@@ -1466,9 +1537,10 @@ export class FizzyClient {
     notificationId: string
   ): Promise<void> {
     const slug = this.normalizeSlug(accountSlug);
+    const notification = assertPathSegment(notificationId, "notification_id");
     await this.request<void>(
       "DELETE",
-      `/${slug}/notifications/${notificationId}/reading`
+      `/${slug}/notifications/${notification}/reading`
     );
   }
 
@@ -1617,6 +1689,12 @@ export class FizzyClient {
    * characters that mean something in a URL.
    */
   private attachmentPath(slug: string, ref: AttachmentRef): string {
+    // slug here is already normalized: this is only ever called from
+    // fetchAttachment, right after it computes its own `slug` the same way
+    // every other method does. ref.signedId and ref.variation are pinned to a
+    // single path segment by validateSignedToken (utils/attachments.ts) —
+    // that charset admits `=` and `+`, which utils/path-segment.ts's does not,
+    // so they are exempt from that guard rather than re-validated by it.
     const filename = encodeURIComponent(ref.filename);
     return ref.variation
       ? `/${slug}/rails/active_storage/representations/redirect/${ref.signedId}/${ref.variation}/${filename}`

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -12,7 +12,8 @@ export const accountSlugSchema = z.string().describe(
 );
 
 export const boardIdSchema = z.string().describe(
-  "The unique board identifier (numeric string, e.g., '12345'). " +
+  "The unique board identifier: a 25-character identifier, " +
+  "e.g., '0000000000000000000000abc'. " +
   "Get available board IDs from fizzy_get_boards."
 );
 
@@ -28,37 +29,44 @@ export const cardNumberSchema = z.string().describe(
 );
 
 export const columnIdSchema = z.string().describe(
-  "The unique column identifier (numeric string). Columns represent workflow stages. " +
+  "The unique column identifier: a 25-character identifier, " +
+  "e.g., '0000000000000000000000abc'. Columns represent workflow stages. " +
   "Get available column IDs from fizzy_get_columns."
 );
 
 export const tagIdSchema = z.string().describe(
-  "The unique tag identifier (numeric string). Tags are labels for categorizing cards. " +
+  "The unique tag identifier: a 25-character identifier, " +
+  "e.g., '0000000000000000000000abc'. Tags are labels for categorizing cards. " +
   "Get available tag IDs from fizzy_get_tags."
 );
 
 export const userIdSchema = z.string().describe(
-  "The unique user identifier (numeric string). " +
+  "The unique user identifier: a 25-character identifier, " +
+  "e.g., '0000000000000000000000abc'. " +
   "Get available user IDs from fizzy_get_users."
 );
 
 export const notificationIdSchema = z.string().describe(
-  "The unique notification identifier (numeric string). " +
+  "The unique notification identifier: a 25-character identifier, " +
+  "e.g., '0000000000000000000000abc'. " +
   "Get notification IDs from fizzy_get_notifications."
 );
 
 export const commentIdSchema = z.string().describe(
-  "The unique comment identifier (numeric string). " +
+  "The unique comment identifier: a 25-character identifier, " +
+  "e.g., '0000000000000000000000abc'. " +
   "Get comment IDs from fizzy_get_card_comments."
 );
 
 export const reactionIdSchema = z.string().describe(
-  "The unique reaction identifier (numeric string). " +
+  "The unique reaction identifier: a 25-character identifier, " +
+  "e.g., '0000000000000000000000abc'. " +
   "Get reaction IDs from fizzy_get_reactions."
 );
 
 export const stepIdSchema = z.string().describe(
-  "The unique step/to-do identifier (numeric string). Steps are checklist items on cards. " +
+  "The unique step/to-do identifier: a 25-character identifier, " +
+  "e.g., '0000000000000000000000abc'. Steps are checklist items on cards. " +
   "Step IDs are returned when creating steps or fetching card details."
 );
 

--- a/src/utils/account-slug.ts
+++ b/src/utils/account-slug.ts
@@ -11,11 +11,17 @@
  * client should refuse to build the request at all.
  *
  * The slug is not the only caller-supplied value interpolated into a path —
- * `cardId`, `boardId`, `commentId` and the rest are too, and are still
- * unguarded. That is a wider change than this module: those ids have no single
- * agreed shape, so pinning one risks rejecting real ids and breaking every tool
- * for that resource. This covers the value every account-scoped path starts
- * with, which is all of them but `/my/identity`.
+ * `cardId`, `boardId`, `commentId` and the rest are too. Those are guarded by
+ * `assertPathSegment` in `utils/path-segment.ts`, a sibling module rather than
+ * an extension of this one: an account slug is one thing with one shape across
+ * every account, so this module can afford to pin it, but the resource ids are
+ * not — most are a 25-character base36 id, but a card path resolves by number
+ * instead — so that module applies one conservative containment charset
+ * instead of a shape pin, which would risk rejecting a real id and breaking
+ * every tool for that resource. `cardId` in particular has no single shape to
+ * pin regardless — see that module's own doc comment. This module covers the
+ * value every account-scoped path starts with, which is all of them but
+ * `/my/identity`.
  *
  * This lives in its own module because both callers are load-bearing and
  * neither owns the rule: client/fizzy-client.ts applies it to every endpoint,

--- a/src/utils/path-segment.ts
+++ b/src/utils/path-segment.ts
@@ -1,0 +1,88 @@
+/**
+ * A shared containment guard for the resource ids `FizzyClient` interpolates
+ * into request paths — `board_id`, `card_number`, `comment_id`, `step_id`,
+ * `reaction_id`, `user_id`, `column_id`, `notification_id` and `card_id`.
+ *
+ * Every one of those methods builds its path as `/${slug}/boards/${boardId}`
+ * or similar, so an id that escapes its segment retargets the request exactly
+ * the way an unguarded `account_slug` did before `normalizeAccountSlug` (see
+ * `utils/account-slug.ts`): `..` reaches a different resource and `fetch`
+ * resolves the dot segments away before the request is sent, so nothing
+ * downstream ever sees the traversal; a `/` grafts extra segments on; a `?` or
+ * `#` truncates the rest of the path into a query string or fragment. These
+ * ids arrive as MCP tool arguments — model-supplied, not developer-supplied —
+ * and the Cloudflare transport (`cloudflare/mcp-session.ts`) runs tool
+ * arguments through no Zod validation at all, so this client is the only
+ * enforcement point on that path.
+ *
+ * **This is a containment guard, not a per-id shape pin.** Confirmed against
+ * upstream (`basecamp/fizzy`): every resource id is a base36-encoded UUIDv7,
+ * exactly 25 characters from `[0-9a-z]`
+ * (`lib/rails_ext/active_record_uuid_type.rb`; `boards_controller.rb`,
+ * `cards/comments_controller.rb`, `cards/steps_controller.rb`,
+ * `cards/comments/reactions_controller.rb`, `boards/columns_controller.rb`,
+ * `users_controller.rb` and `notifications/readings_controller.rb` all do a
+ * plain `.find(params[:id])` against that column), while a card is instead
+ * looked up by `number` — a plain integer — because `cards_controller.rb`
+ * calls `find_by!(number: params[:id])` and `Card#to_param` returns
+ * `number.to_s`. Both shapes fit comfortably inside the charset below, so one
+ * conservative pattern covers them without hard-coding either encoding into
+ * this client. Pinning a shape instead would tie this client to whatever
+ * upstream happens to use for ids today, and `card_id` in particular has no
+ * single shape to pin regardless: `getCard`/`updateCard`/`deleteCard` build
+ * `/cards/:id` from whatever the caller labels `card_id`, but the route on
+ * the other end resolves that slot by `number`, not by id (see
+ * `utils/card-resolver.ts`, which bridges exactly that gap for the tools that
+ * accept either). This module takes no position on which shape belongs there;
+ * it only keeps whatever value arrives inside a single, inert path segment.
+ * `config/routes.rb` places no constraint on any id segment, so upstream does
+ * no shape checking of its own to fall back on.
+ */
+
+/** Characters a path segment interpolated into a Fizzy request URL may use. */
+const PATH_SEGMENT_PATTERN = /^[A-Za-z0-9._~-]+$/;
+
+/**
+ * Generous next to either real shape (a 25-character base36 id or a card
+ * number a few digits long) and still short enough that a rejected value
+ * never becomes a large error message.
+ */
+const MAX_PATH_SEGMENT_LENGTH = 256;
+
+/**
+ * Assert that `value` is safe to interpolate as a single path segment, and
+ * return it unchanged.
+ *
+ * `name` is the MCP-facing argument name (`board_id`, `card_number`, …), used
+ * only to name the argument in the thrown message — never the value itself,
+ * which is not echoed back. These messages surface verbatim to the model, so
+ * they say what to pass instead of just refusing.
+ *
+ * @throws Error if `value` is empty, is `.` or `..`, is longer than
+ *   {@link MAX_PATH_SEGMENT_LENGTH}, or contains anything outside
+ *   `[A-Za-z0-9._~-]`. That excludes `/` and `\` (cannot introduce a segment
+ *   of their own), `%` (cannot smuggle an encoded one), `?` and `#` (cannot
+ *   truncate the path into a query string or fragment), and control
+ *   characters — which is what matters, not what the charset admits.
+ */
+export function assertPathSegment(value: string, name: string): string {
+  if (value.length > MAX_PATH_SEGMENT_LENGTH) {
+    throw new Error(`${name} is too long to be a valid Fizzy identifier`);
+  }
+
+  // "" and ".." are caught before the charset test, which would accept both:
+  // "." is legitimate inside an id, just not as the whole of one, and the
+  // same reasoning normalizeAccountSlug applies to account_slug applies here.
+  if (value === "" || value === "." || value === "..") {
+    throw new Error(`${name} is required and must be a Fizzy identifier, not a path segment`);
+  }
+
+  if (!PATH_SEGMENT_PATTERN.test(value)) {
+    throw new Error(
+      `${name} contains characters that are not part of a Fizzy identifier. ` +
+        `Pass the id exactly as the Fizzy API returned it — never a path, URL, or query string.`
+    );
+  }
+
+  return value;
+}

--- a/tests/client/fizzy-client.test.ts
+++ b/tests/client/fizzy-client.test.ts
@@ -229,6 +229,33 @@ describe("FizzyClient", () => {
     });
   });
 
+  describe("path segment validation", () => {
+    // Every other caller-supplied id — board_id, card_id, card_number,
+    // comment_id, step_id, column_id, user_id, notification_id, reaction_id —
+    // is interpolated into a request path the same way account_slug is, so it
+    // needs the same containment guard (see utils/path-segment.ts). Checked
+    // against one method per guarded id name so the guard is shown to be
+    // applied broadly, not just on getBoard; the rule itself has its own
+    // suite in tests/utils/path-segment.test.ts, and the sweep in
+    // tests/client/path-segments.test.ts proves every call site uses it.
+    it.each([
+      ["a traversal", "../cards/42"],
+      ["an embedded separator", "123/456"],
+      ["a parent directory", ".."],
+    ])("rejects %s in every guarded id without issuing a request", async (_label, id) => {
+      await expect(client.getBoard("123456", id)).rejects.toThrow(/board_id/);
+      await expect(client.getCard("123456", id)).rejects.toThrow(/card_id/);
+      await expect(client.closeCard("123456", id)).rejects.toThrow(/card_number/);
+      await expect(client.getComment("123456", "1", id)).rejects.toThrow(/comment_id/);
+      await expect(client.getStep("123456", "1", id)).rejects.toThrow(/step_id/);
+      await expect(client.getColumn("123456", "1", id)).rejects.toThrow(/column_id/);
+      await expect(client.getUser("123456", id)).rejects.toThrow(/user_id/);
+      await expect(client.markNotificationAsRead("123456", id)).rejects.toThrow(/notification_id/);
+      await expect(client.removeReaction("123456", "1", "1", id)).rejects.toThrow(/reaction_id/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
   describe("authentication", () => {
     it("should include Bearer token in Authorization header", async () => {
       mockFetch.mockResolvedValueOnce({

--- a/tests/client/path-segments.test.ts
+++ b/tests/client/path-segments.test.ts
@@ -10,22 +10,26 @@
  * `tests/tools/declared-dependencies.test.ts`: TypeScript 7 is the Go port and
  * ships no JavaScript compiler API, so this reads text rather than an AST.
  *
- * **Two independent, additive checks, because each has a blind spot the other
- * covers.**
+ * **Three independent, additive checks, because each has a blind spot the
+ * other two cover.**
  *
  * 1. **The call-site check** (`findCallViolations`) is the primary one, and it
  *    inverts the sweep's original design: instead of looking for template
  *    literals shaped like a path and hoping every path-issuing call happens to
  *    use one, it starts at every call in this file to `this.request<...>(`,
- *    `this.requestAllPages<...>(` and `this.requestWithMeta<...>(` — the only
- *    three ways this file reaches the network — and demands the argument that
- *    supplies the path be provably one of:
+ *    `this.requestAllPages<...>(` and `this.requestWithMeta<...>(` — this
+ *    file's own request layer, and the route almost every method uses to
+ *    reach the network — and demands the argument that supplies the path be
+ *    provably one of:
  *
  *      (a) a template literal whose every `${...}` interpolation is one of the
  *          exemptions below, or a name bound earlier in the *same* method by
  *          `const NAME = assertPathSegment(...)`, `this.normalizeSlug(...)` or
  *          `normalizeAccountSlug(...)` (or the method's own `slug` parameter —
- *          see "the `slug` parameter" below);
+ *          see "the `slug` parameter" below). "Bound" here means bound
+ *          exactly once, at the method's own top level — see the
+ *          duplicate-binding rule below for why a second binding of that name
+ *          anywhere in the method, guarded or not, disqualifies it entirely;
  *      (b) a plain string literal with no interpolation at all (`"/my/identity"`);
  *      (c) a `const` local, bound in the same method, whose initializer is
  *          itself (a) or (b) — including a ternary whose *both* branches are.
@@ -78,22 +82,56 @@
  *    matched the old, narrower rule still starts with `/${` and so still
  *    contains both markers.
  *
+ * 3. **The raw-fetch check** (`findRawFetchViolations`) exists because checks
+ *    1 and 2 share a blind spot neither one covers: this file does not, in
+ *    fact, only reach the network through `this.request`/`requestAllPages`/
+ *    `requestWithMeta`. Three methods — `executeRequestWithMeta`,
+ *    `putBlobToStorage` and `fetchAttachment` — call the global `fetch`
+ *    directly, and nothing about the call-site or template check would notice
+ *    a fourth one added elsewhere, still less one built like this:
+ *
+ *      const path = `/${slug}/boards/` + boardId;
+ *      return fetch(this.baseUrl + path, options);
+ *
+ *    The only recognised template here interpolates the safely-guarded
+ *    `slug`, so the template check passes it clean; the dangerous
+ *    concatenation sits outside that template entirely, and there is no
+ *    `this.request*` call for the call-site check to even start from. Neither
+ *    check's pinned count would move, because neither one ever looked.
+ *
+ *    So this check does not try to re-derive path safety for a raw `fetch` at
+ *    all — that would mean tracing an arbitrary URL expression back through
+ *    whatever built it, exactly the general-purpose data-flow analysis this
+ *    whole sweep avoids. Instead it enumerates every bare `fetch(` call in the
+ *    file, resolves its enclosing method and the exact source text of its URL
+ *    argument, and requires that pair to match one of the hardcoded
+ *    `RAW_FETCH_ALLOWLIST` entries — each one a human judgment call, made
+ *    once, with a comment saying why that specific call is safe. A call in an
+ *    unlisted method, or one whose URL expression no longer matches what the
+ *    entry names (the same method reusing a different variable, say), is a
+ *    violation with no escape hatch, exactly like the other two checks. The
+ *    allowlist's own *count* is pinned too, at 3: a fourth `fetch` anywhere in
+ *    the file fails the suite even if it happens to reuse an
+ *    already-allowlisted method and expression, which the allowlist match
+ *    alone would not catch.
+ *
  * **Design is default-deny, and picks a direction to be wrong in.** Borrowed
  * directly from declared-dependencies.test.ts: a guard that quietly misses a
  * case stops guarding and nobody finds out; a guard that flags one case too
- * many fails loudly and is fixed in a minute. Both checks here are built to
- * make the second mistake, never the first — an expression shape neither
+ * many fails loudly and is fixed in a minute. All three checks here are built
+ * to make the second mistake, never the first — an expression shape neither
  * recognises is a violation, not a pass.
  *
- * **Two independent counts are pinned**, not just the "no violations" result:
- * the number of path-shaped templates (54) and the number of in-scope
- * request-issuing call sites (52). A silent scanning regression — a shape
- * that stops matching — would otherwise still report zero violations over
- * fewer things checked. Pinning the *count* each scan actually walked is what
- * turns "found nothing wrong" into "found nothing wrong in the right number of
- * places"; a new call site or template changes one of these numbers no matter
- * which construction shape it uses, and the count assertion is what catches
- * that even before the safety assertion would.
+ * **Three independent counts are pinned**, not just the "no violations"
+ * result: the number of path-shaped templates (54), the number of in-scope
+ * request-issuing call sites (52), and the number of raw `fetch` call sites
+ * (3). A silent scanning regression — a shape that stops matching — would
+ * otherwise still report zero violations over fewer things checked. Pinning
+ * the *count* each scan actually walked is what turns "found nothing wrong"
+ * into "found nothing wrong in the right number of places"; a new call site,
+ * template or raw `fetch` changes one of these numbers no matter which
+ * construction shape it uses, and the count assertion is what catches that
+ * even before the safety assertion would.
  *
  * **The `slug` parameter.** `attachmentPath` takes an already-normalized slug
  * as a parameter literally named `slug` (never `accountSlug`) rather than
@@ -118,22 +156,59 @@
  * real gap in this scanner's design, not something to paper over by adding
  * `let` back into the pattern.
  *
- * **What neither check can see.** Both read text, not an AST, so a shape
+ * **A name is trusted only if `const` binds it exactly once, at the method's
+ * own top level.** `isProvenSafe` and `resolveConstInitializer` originally
+ * searched all earlier text in the method for `const NAME = ...` with no
+ * awareness of block scope, which let this pass while interpolating an
+ * unguarded value:
+ *
+ *      const board = boardId;
+ *      if (condition) {
+ *        const board = assertPathSegment(boardId, "board_id");
+ *      }
+ *      return this.request("GET", `/${slug}/boards/${board}`);
+ *
+ * At the interpolation, `board` is lexically the outer, raw binding — but a
+ * flat text search just finds whichever `const board = ...` it runs into,
+ * which here is the inner, guarded one sitting in a block that has already
+ * closed. Real scope tracking would fix this properly, but text has no notion
+ * of "which block am I in" without effectively reimplementing a parser.
+ * Instead, both functions require that a name used in a proven position is
+ * bound by `const` **exactly once** anywhere in the method, and that its one
+ * binding sits at the method body's own top level — brace depth 1, counting
+ * `{`/`}` from the method's own start. That depth is always the body's own
+ * level regardless of how many balanced brace pairs precede it (a return-type
+ * object literal, a destructured parameter default), since those must already
+ * balance for the file to compile. A second binding of that name anywhere in
+ * the method — nested or not, guarded or not — is a violation, whatever the
+ * scopes involved, and so is a lone binding that is itself nested. That is
+ * strictly safer than tracking scopes, far simpler to get right in text, and
+ * costs nothing in practice: the client binds each guarded name once, at the
+ * top of the method.
+ *
+ * **What neither check can see.** All three read text, not an AST, so a shape
  * outside what is enumerated above is a violation rather than a considered
  * "no" — that is deliberate, but it also means a genuinely new *safe* shape
  * (a third kind of guard function, a `switch` instead of a ternary, two levels
- * of `const` chaining) will fail here and need this file extended, not just
- * the production code. Neither check follows a value across methods or files:
- * a guard applied in one method never covers a use in another, and a path
- * built by something other than `fizzy-client.ts` — a caller of this client,
- * or Fizzy's own server-side routing — is out of scope entirely. The
- * interpolation regex (`\$\{([^}]*)\}`) stops at the first `}`, so an
- * interpolation containing its own object literal would be split wrong; no
- * such interpolation exists in this file today. And neither check re-verifies
+ * of `const` chaining, a name that legitimately needs binding more than once)
+ * will fail here and need this file extended, not just the production code.
+ * None of the three follows a value across methods or files: a guard applied
+ * in one method never covers a use in another, and a path built by something
+ * other than `fizzy-client.ts` — a caller of this client, or Fizzy's own
+ * server-side routing — is out of scope entirely. The interpolation regex
+ * (`\$\{([^}]*)\}`) stops at the first `}`, so an interpolation containing its
+ * own object literal would be split wrong; no such interpolation exists in
+ * this file today. Neither the call-site nor the template check re-verifies
  * that `assertPathSegment`, `normalizeSlug` or `normalizeAccountSlug`
  * themselves reject what they claim to — only that they were called; their
  * own correctness is `src/utils/path-segment.ts`'s tests to own, not this
- * file's.
+ * file's. And the raw-fetch check re-verifies nothing about *why* an
+ * allowlisted call is safe — `RAW_FETCH_ALLOWLIST`'s `reason` field is a
+ * human judgment call written once, not a claim this scanner checks. It only
+ * confirms the call site's method and URL expression still match what was
+ * reviewed, so a rewritten (but still textually matching) implementation of
+ * an allowlisted method could in principle drift unsafe without tripping this
+ * check at all.
  */
 
 import { describe, it, expect } from "vitest";
@@ -188,6 +263,14 @@ interface RequestCallSite {
   callee: RequestMethodName;
   method: MethodStart;
   pathArg: Span | undefined;
+}
+
+/** One bare `fetch(` call in fizzy-client.ts, with its URL argument (if found). */
+interface FetchCallSite {
+  index: number;
+  line: number;
+  method: MethodStart;
+  urlArg: Span | undefined;
 }
 
 interface Violation {
@@ -298,6 +381,23 @@ function findEnclosingMethod(methodStarts: MethodStart[], index: number): Method
   return best;
 }
 
+/**
+ * Where `method`'s own extent ends in `masked`: the next method's start, or
+ * the end of the source if `method` is the last one. Used only to bound the
+ * duplicate-binding search below — like `findMethodStarts` itself, this does
+ * not need to be the method's *true* end (see that function's doc comment on
+ * why finding a true end is unreliable from text); the next declaration's
+ * start is a safe upper bound because nothing belonging to `method` can sit
+ * past it.
+ */
+function methodExtentEnd(methodStarts: MethodStart[], method: MethodStart, sourceLength: number): number {
+  let end = sourceLength;
+  for (const start of methodStarts) {
+    if (start.index > method.index && start.index < end) end = start.index;
+  }
+  return end;
+}
+
 /** The index right after `class FizzyClient { ... {`'s opening brace, in `masked`. */
 function classBodyStartOf(masked: string): number {
   const classMatch = /class\s+FizzyClient\b[^{]*\{/.exec(masked);
@@ -340,14 +440,89 @@ function findPathTemplates(masked: string): PathTemplate[] {
 }
 
 /**
+ * Raw `{`/`}` nesting depth at `position`, counting from `from` (normally a
+ * method's own start). A quoted string or backtick template — including a
+ * template's own `${...}` interpolation braces — is skipped wholesale via
+ * `skipQuoted` rather than scanned character by character, so an
+ * interpolation's braces are never mistaken for statement-level nesting.
+ *
+ * Depth 1 is always the level of the method body's own top-level statements,
+ * regardless of what precedes the body's opening `{`: a return-type object
+ * literal (`Promise<{ data: T }>`) or a destructured parameter's default
+ * value contributes its own balanced `{`/`}` pair, and a balanced pair nets
+ * to zero by definition — the file would not compile otherwise. So whatever
+ * brace pairs appear in a signature, raw depth is back to 0 by the time the
+ * body's real opening `{` is reached, and that brace brings it to 1. This is
+ * what lets the duplicate-binding rule below identify "top level of the
+ * method body" without first solving the harder problem (noted in
+ * `findMethodStarts`'s doc comment) of locating that opening brace directly.
+ */
+function braceDepthAt(masked: string, from: number, position: number): number {
+  let depth = 0;
+  let i = from;
+  while (i < position) {
+    const ch = masked[i];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      i = skipQuoted(masked, i);
+      continue;
+    }
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+    i++;
+  }
+  return depth;
+}
+
+/**
+ * Every `const NAME` declaration bound anywhere in `method` (from its start
+ * to `methodEnd`), regardless of nesting — used to enforce the
+ * duplicate-binding rule from the module doc comment: a name is trusted only
+ * when this list has exactly one entry, and that entry sits at brace depth 1
+ * (the method body's own top level, per `braceDepthAt`). Returns null rather
+ * than picking a "best" candidate when zero or more than one binding exists,
+ * so callers never have to guess which of several same-named declarations is
+ * the one actually in scope at a use site — a question a text scanner cannot
+ * answer reliably, which is exactly what made the old "last declaration
+ * wins" behavior unsafe.
+ */
+function findSoleConstBinding(
+  masked: string,
+  method: MethodStart,
+  methodEnd: number,
+  name: string
+): { index: number; depth: number } | null {
+  const pattern = new RegExp(`\\bconst\\s+${name}\\b`, "g");
+  pattern.lastIndex = method.index;
+  const indices: number[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(masked)) && match.index < methodEnd) {
+    indices.push(match.index);
+  }
+  if (indices.length !== 1) return null;
+  const index = indices[0];
+  return { index, depth: braceDepthAt(masked, method.index, index) };
+}
+
+/**
  * Whether `expr`, interpolated inside `method` at `boundary`, is provably
  * safe — rule (a) or (b) from the module doc comment above. `boundary` is the
  * position `expr`'s guard must textually precede — the start of the template
  * or call argument it appears in, not necessarily the position of `${expr}`
  * itself, matching how a `const` guard must precede the whole statement that
  * uses it, not just the one interpolation.
+ *
+ * `methodStarts` is needed only to bound the duplicate-binding search to this
+ * method's own extent (`methodExtentEnd`) — see the "trusted only if bound
+ * exactly once" rule in the module doc comment for why a name bound more than
+ * once anywhere in the method, not just before `boundary`, is disqualified.
  */
-function isProvenSafe(masked: string, method: MethodStart, boundary: number, expr: string): boolean {
+function isProvenSafe(
+  masked: string,
+  method: MethodStart,
+  boundary: number,
+  expr: string,
+  methodStarts: MethodStart[]
+): boolean {
   if (EXEMPT_NAMES.has(expr)) return true;
 
   // Only a bare identifier can be traced to a local binding; a property
@@ -355,12 +530,21 @@ function isProvenSafe(masked: string, method: MethodStart, boundary: number, exp
   // fails outright.
   if (!/^[A-Za-z_$][\w$]*$/.test(expr)) return false;
 
-  const window = masked.slice(method.index, boundary);
-  // `const` only — see "let is never a guard" in the module doc comment.
-  const guardPattern = new RegExp(
-    `\\bconst\\s+${expr}\\s*=\\s*(?:assertPathSegment|this\\.normalizeSlug|normalizeAccountSlug)\\s*\\(`
-  );
-  if (guardPattern.test(window)) return true;
+  const methodEnd = methodExtentEnd(methodStarts, method, masked.length);
+  const binding = findSoleConstBinding(masked, method, methodEnd, expr);
+  // The binding must both be the method's only one and precede `boundary` —
+  // `const` is block-scoped, so a binding after the use point could not
+  // actually be in scope there even if it were the sole one found.
+  if (binding && binding.depth === 1 && binding.index < boundary) {
+    const fromBinding = masked.slice(binding.index, boundary);
+    // `const` only — see "let is never a guard" in the module doc comment.
+    // Anchored to the binding's own start (rather than searched for anywhere
+    // in a window) now that there is exactly one candidate to check.
+    const guardPattern = new RegExp(
+      `^const\\s+${expr}\\s*=\\s*(?:assertPathSegment|this\\.normalizeSlug|normalizeAccountSlug)\\s*\\(`
+    );
+    if (guardPattern.test(fromBinding)) return true;
+  }
 
   // The `slug` parameter carve-out described in the module doc comment,
   // narrowly matched on the exact name and a `slug: string` parameter
@@ -393,7 +577,7 @@ function findTemplateViolations(source: string): Violation[] {
       continue;
     }
     for (const { expr } of template.interpolations) {
-      if (isProvenSafe(masked, method, template.index, expr)) continue;
+      if (isProvenSafe(masked, method, template.index, expr, methodStarts)) continue;
       violations.push({
         line: template.line,
         method: method.name,
@@ -600,26 +784,39 @@ function splitTopLevelTernary(text: string): { branch1: string; branch2: string 
 }
 
 /**
- * Find `const name = <initializer>;`, the last such declaration textually
- * before `positionOfUse` in `method` — i.e. the one actually in scope at the
- * use — and return its initializer's text and start index. `let` never
- * matches: see "`let` is never a guard" in the module doc comment. Returns
- * null when no qualifying declaration exists in this method.
+ * Find `const name = <initializer>;`, the sole such declaration bound
+ * anywhere in `method` and sitting at the method body's own top level, and
+ * return its initializer's text and start index. Returns null when zero or
+ * more than one `const name` binding exists in the method (the
+ * duplicate-binding rule in the module doc comment), when the sole binding is
+ * nested rather than top-level, or when it does not textually precede
+ * `positionOfUse` — `const` is block-scoped, so a binding after the use point
+ * is not in scope there regardless of how many bindings exist. `let` never
+ * matches: see "`let` is never a guard" in the module doc comment.
+ *
+ * This used to take the *last* textual `const name = ...` before
+ * `positionOfUse`, with no regard for whether it sat in a block that had
+ * already closed — exactly the flaw the module doc comment's shadowing
+ * example describes, just for `path` instead of `board`. Requiring a single,
+ * top-level binding closes it the same way `isProvenSafe` closes it for a
+ * direct interpolation.
  */
 function resolveConstInitializer(
   masked: string,
   method: MethodStart,
   positionOfUse: number,
-  name: string
+  name: string,
+  methodStarts: MethodStart[]
 ): Span | null {
-  const window = masked.slice(method.index, positionOfUse);
-  const declPattern = new RegExp(`\\bconst\\s+${name}\\s*=\\s*`, "g");
-  let match: RegExpExecArray | null;
-  let last: RegExpExecArray | null = null;
-  while ((match = declPattern.exec(window))) last = match;
-  if (!last) return null;
+  const methodEnd = methodExtentEnd(methodStarts, method, masked.length);
+  const binding = findSoleConstBinding(masked, method, methodEnd, name);
+  if (!binding || binding.depth !== 1 || binding.index >= positionOfUse) return null;
 
-  const initStart = method.index + last.index + last[0].length;
+  const declPattern = new RegExp(`^const\\s+${name}\\s*=\\s*`);
+  const match = declPattern.exec(masked.slice(binding.index));
+  if (!match) return null; // e.g. a type annotation between the name and `=`
+
+  const initStart = binding.index + match[0].length;
   const semicolonIndex = findTopLevelSemicolon(masked, initStart);
   if (semicolonIndex === -1) return null;
   return sliceTrimmed(masked, initStart, semicolonIndex);
@@ -652,7 +849,8 @@ function classifyPathExpr(
   text: string,
   boundary: number,
   allowTernary: boolean,
-  allowIdentifier: boolean
+  allowIdentifier: boolean,
+  methodStarts: MethodStart[]
 ): Classification {
   if (text.length === 0) return { ok: false, reason: "empty path argument" };
 
@@ -662,7 +860,7 @@ function classifyPathExpr(
     }
     const interpolations = [...text.matchAll(/\$\{([^}]*)\}/g)].map((m) => m[1].trim());
     for (const expr of interpolations) {
-      if (!isProvenSafe(masked, method, boundary, expr)) {
+      if (!isProvenSafe(masked, method, boundary, expr, methodStarts)) {
         return {
           ok: false,
           reason: `interpolation \${${expr}} is not a locally-guarded value and not on the exemption list`,
@@ -682,23 +880,23 @@ function classifyPathExpr(
   if (allowTernary) {
     const split = splitTopLevelTernary(text);
     if (split) {
-      const left = classifyPathExpr(masked, method, split.branch1, boundary, false, false);
+      const left = classifyPathExpr(masked, method, split.branch1, boundary, false, false, methodStarts);
       if (!left.ok) return { ok: false, reason: `ternary "then" branch: ${left.reason}` };
-      const right = classifyPathExpr(masked, method, split.branch2, boundary, false, false);
+      const right = classifyPathExpr(masked, method, split.branch2, boundary, false, false, methodStarts);
       if (!right.ok) return { ok: false, reason: `ternary "else" branch: ${right.reason}` };
       return { ok: true };
     }
   }
 
   if (allowIdentifier && /^[A-Za-z_$][\w$]*$/.test(text)) {
-    const resolved = resolveConstInitializer(masked, method, boundary, text);
+    const resolved = resolveConstInitializer(masked, method, boundary, text, methodStarts);
     if (!resolved) {
       return {
         ok: false,
-        reason: `bare identifier "${text}" does not resolve to a \`const ${text} = ...\` bound earlier in this method`,
+        reason: `bare identifier "${text}" does not resolve to a \`const ${text} = ...\` bound exactly once, at top level, earlier in this method`,
       };
     }
-    return classifyPathExpr(masked, method, resolved.text, resolved.start, true, false);
+    return classifyPathExpr(masked, method, resolved.text, resolved.start, true, false, methodStarts);
   }
 
   return {
@@ -767,7 +965,15 @@ function findCallViolations(source: string): Violation[] {
       });
       continue;
     }
-    const result = classifyPathExpr(masked, site.method, site.pathArg.text, site.pathArg.start, true, true);
+    const result = classifyPathExpr(
+      masked,
+      site.method,
+      site.pathArg.text,
+      site.pathArg.start,
+      true,
+      true,
+      methodStarts
+    );
     if (!result.ok) {
       violations.push({
         line: site.line,
@@ -775,6 +981,125 @@ function findCallViolations(source: string): Violation[] {
         expr: site.pathArg.text,
         template: `this.${site.callee}(...)`,
         reason: result.reason ?? "not provably safe",
+      });
+    }
+  }
+  return violations;
+}
+
+// ============ The raw-fetch scan ============
+//
+// This file's request layer is not the only route to the network: a handful
+// of methods call the global `fetch` directly. Check 3 in the module doc
+// comment covers why those need their own check — the call-site and template
+// checks above only ever look at `this.request*` calls and path-shaped
+// templates, so a raw `fetch` fed a concatenated, unguarded id would sail
+// past both in silence.
+
+/**
+ * Every bare `fetch(` call in `masked` — not `this.request*`, not
+ * `something.fetch(` — with its first (URL) argument located. The negative
+ * lookbehind excludes a method call on some other object ending in `fetch`
+ * and a hypothetical `this.fetch(`, neither of which occurs in this file
+ * today; a plain identifier call is the only shape actually present at the
+ * three real sites.
+ */
+function findRawFetchCallSites(masked: string, methodStarts: MethodStart[]): FetchCallSite[] {
+  const sites: FetchCallSite[] = [];
+  const pattern = /(?<![.\w$])fetch\s*\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(masked))) {
+    const openParenIndex = m.index + m[0].length - 1;
+    const args = parseCallArguments(masked, openParenIndex);
+    const line = masked.slice(0, m.index).split("\n").length;
+    const method = findEnclosingMethod(methodStarts, m.index);
+
+    if (!method) {
+      sites.push({ index: m.index, line, method: { name: "(none)", index: -1 }, urlArg: undefined });
+      continue;
+    }
+    sites.push({ index: m.index, line, method, urlArg: args[0] });
+  }
+  return sites;
+}
+
+/**
+ * Every raw `fetch(` call this file is allowed to make, keyed by the
+ * enclosing method's name and the exact source text of the URL argument.
+ * Each entry is a human judgment call made once, with a `reason` recording
+ * why that specific call is safe — see "what neither check can see" in the
+ * module doc comment for the limits of what re-checking this list actually
+ * proves. A call whose method or URL expression doesn't match one of these
+ * exactly is a violation on its own; the pinned site count below additionally
+ * catches a call that coincidentally matches an entry it shouldn't (a second
+ * `fetch` added to an already-allowlisted method, reusing that method's own
+ * `url` local).
+ */
+const RAW_FETCH_ALLOWLIST: ReadonlyArray<{ method: string; urlExpr: string; reason: string }> = [
+  {
+    method: "executeRequestWithMeta",
+    urlExpr: "url",
+    reason:
+      "url is this method's own parameter; its only caller, requestWithMeta, " +
+      "builds it as `${this.baseUrl}${path}`, where path is the same argument " +
+      "the call-site check above proves safe at every call to requestWithMeta.",
+  },
+  {
+    method: "putBlobToStorage",
+    urlExpr: "url",
+    reason:
+      "url is a method parameter carrying the signed direct-upload URL " +
+      "Fizzy's own direct_uploads response returned — not a path this client " +
+      "builds or interpolates.",
+  },
+  {
+    method: "fetchAttachment",
+    urlExpr: "url",
+    reason:
+      "url starts from attachmentPath(), which the template check above " +
+      "proves, and is only ever replaced by resolveAttachmentRedirect's " +
+      "vetted http(s) Location — never by concatenating an unguarded id.",
+  },
+];
+
+/** Run the raw-fetch sweep over `source`, returning every violation found. */
+function findRawFetchViolations(source: string): Violation[] {
+  const masked = blankComments(source);
+  const methodStarts = findMethodStarts(masked, classBodyStartOf(masked));
+  const sites = findRawFetchCallSites(masked, methodStarts);
+
+  const violations: Violation[] = [];
+  for (const site of sites) {
+    if (site.method.index === -1) {
+      violations.push({
+        line: site.line,
+        method: "(none)",
+        expr: "(n/a)",
+        template: "fetch(...)",
+        reason: "raw fetch call could not be attributed to any method",
+      });
+      continue;
+    }
+    if (!site.urlArg) {
+      violations.push({
+        line: site.line,
+        method: site.method.name,
+        expr: "(n/a)",
+        template: "fetch(...)",
+        reason: "fetch call is missing its URL argument",
+      });
+      continue;
+    }
+    const allowed = RAW_FETCH_ALLOWLIST.some(
+      (entry) => entry.method === site.method.name && entry.urlExpr === site.urlArg!.text
+    );
+    if (!allowed) {
+      violations.push({
+        line: site.line,
+        method: site.method.name,
+        expr: site.urlArg.text,
+        template: "fetch(...)",
+        reason: `raw fetch in ${site.method.name} is not on the allowlist for URL expression \`${site.urlArg.text}\``,
       });
     }
   }
@@ -932,6 +1257,48 @@ describe("template scanner", () => {
   }`);
     expect(findTemplateViolations(source)).toEqual([]);
   });
+
+  it("rejects a name shadowed by an outer, unguarded binding of the same name", () => {
+    // Finding 1's exact shape: `board` is bound twice, once raw at the
+    // method's own top level and once guarded inside a block that has
+    // already closed by the time the template interpolates it. At the
+    // interpolation, `board` is lexically the outer, unguarded binding — a
+    // flat text search that just looks for "some `const board = ...`
+    // earlier in the method" finds the guarded one instead and wrongly
+    // passes it. Requiring the name be bound exactly once anywhere in the
+    // method closes that without tracking scope at all.
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    const board = boardId;
+    if (accountSlug.length > 0) {
+      const board = assertPathSegment(boardId, "board_id");
+    }
+    return this.request("GET", \`/\${slug}/boards/\${board}\`);
+  }`);
+    const violations = findTemplateViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ method: "getBoard", expr: "board" });
+  });
+
+  it("rejects a name bound twice at the method's own top level", () => {
+    // Two top-level `const board` declarations would not compile as real
+    // TypeScript (`Cannot redeclare block-scoped variable`), but the rule
+    // does not special-case nesting: it treats every duplicate the same way,
+    // guarded or not, nested or not, because a text scanner has no reliable
+    // way to tell "this duplicate is harmless" from "this duplicate is the
+    // attack" without doing real scope analysis.
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
+    const board = assertPathSegment(boardId, "board_id");
+    return this.request("GET", \`/\${slug}/boards/\${board}\`);
+  }`);
+    const violations = findTemplateViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ method: "getBoard", expr: "board" });
+  });
 });
 
 describe("call-site scanner", () => {
@@ -1001,6 +1368,30 @@ describe("call-site scanner", () => {
     expect(violations[0].reason).toMatch(/does not resolve/);
   });
 
+  it("rejects a shadowed const path resolved through a decoy declaration in a closed block", () => {
+    // resolveConstInitializer's version of Finding 1: `path` is bound twice —
+    // an outer one built straight from the unguarded boardId, and an inner,
+    // safe-looking one sitting in a block that has already closed by the
+    // time `path` is actually used. The old "last textual declaration wins"
+    // behavior picked the inner decoy and called `path` safe, even though
+    // the outer, unguarded binding is what is actually in scope at the
+    // `request` call.
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string): Promise<unknown> {
+    const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
+    const path = \`/\${slug}/boards/\${boardId}\`;
+    if (accountSlug.length > 0) {
+      const path = \`/\${slug}/boards/\${board}\`;
+    }
+    return this.request("GET", path);
+  }`);
+    const violations = findCallViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].method).toBe("getBoard");
+    expect(violations[0].reason).toMatch(/does not resolve/);
+  });
+
   it("accepts a const path bound to a ternary of two guarded templates", () => {
     // getNotifications's real shape: page 1 must stay page-less, so the path
     // is chosen by a ternary rather than always carrying a query string.
@@ -1055,6 +1446,67 @@ describe("call-site scanner", () => {
   });
 });
 
+describe("raw fetch scanner", () => {
+  // Check 3 in the module doc comment: a raw `fetch(` call reaches the
+  // network without ever going through `this.request*`, so it is invisible
+  // to both scanners above no matter how its URL was built. These fixtures
+  // exercise findRawFetchViolations directly, the same way the two describe
+  // blocks above exercise their own scanners.
+  const wrap = (body: string) => `class FizzyClient {\n${body}\n}\n`;
+
+  it("rejects a raw fetch whose URL is built by concatenating an unguarded id", () => {
+    // The exact shape from the module doc comment. The template's only
+    // interpolation is the guarded `slug`, so the template check sees
+    // nothing wrong with it in isolation — the danger is the `+ boardId`
+    // concatenation sitting outside the template entirely, reaching the
+    // network through a raw fetch that the call-site check never starts
+    // from (there is no `this.request*` call here at all).
+    const source = wrap(`
+  private async fetchWidget(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    const path = \`/\${slug}/boards/\` + boardId;
+    return fetch(this.baseUrl + path, { method: "GET" });
+  }`);
+    expect(findTemplateViolations(source)).toEqual([]);
+    expect(findCallViolations(source)).toEqual([]);
+    const violations = findRawFetchViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].method).toBe("fetchWidget");
+  });
+
+  it("rejects a raw fetch in a method that is not on the allowlist", () => {
+    // Even a `url` built exactly the way the three real, allowlisted call
+    // sites build theirs is not enough on its own — the method it's called
+    // from has to match too, since the allowlist is a (method, expression)
+    // pair, not a bare expression shape.
+    const source = wrap(`
+  private async fetchSomethingElse(url: string) {
+    return fetch(url, { method: "GET" });
+  }`);
+    const violations = findRawFetchViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].method).toBe("fetchSomethingElse");
+    expect(violations[0].reason).toMatch(/not on the allowlist/);
+  });
+
+  it("accepts the three real call sites' own (method, url) shape", () => {
+    const source = wrap(`
+  private async executeRequestWithMeta(method: string, url: string) {
+    return fetch(url, { method });
+  }
+
+  private async putBlobToStorage(url: string, headers: Record<string, string>) {
+    return fetch(url, { method: "PUT" });
+  }
+
+  async fetchAttachment(accountSlug: string, ref: unknown): Promise<unknown> {
+    let url = "https://storage.example.com/blob";
+    return fetch(url, { method: "GET" });
+  }`);
+    expect(findRawFetchViolations(source)).toEqual([]);
+  });
+});
+
 describe("path segment guards on FizzyClient", () => {
   const source = readFileSync(clientPath, "utf8");
 
@@ -1100,6 +1552,29 @@ describe("path segment guards on FizzyClient", () => {
         .map((v) => `  line ${v.line} (${v.method}): ${v.template} argument \`${v.expr}\` — ${v.reason}`)
         .join("\n");
       throw new Error(`Unproven request path argument(s) found:\n${details}`);
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("finds the raw fetch calls the real file actually has", () => {
+    // Guards the raw-fetch sweep the same way the two counts above guard
+    // their own scans: a pattern that stopped matching `fetch(` would make
+    // the allowlist assertion below pass vacuously over zero call sites. 3 is
+    // executeRequestWithMeta, putBlobToStorage and fetchAttachment — see
+    // check 3 in the module doc comment.
+    const masked = blankComments(source);
+    const methodStarts = findMethodStarts(masked, classBodyStartOf(masked));
+    const sites = findRawFetchCallSites(masked, methodStarts);
+    expect(sites.length).toBe(3);
+  });
+
+  it("proves every raw fetch call is on the allowlist", () => {
+    const violations = findRawFetchViolations(source);
+    if (violations.length > 0) {
+      const details = violations
+        .map((v) => `  line ${v.line} (${v.method}): ${v.template} argument \`${v.expr}\` — ${v.reason}`)
+        .join("\n");
+      throw new Error(`Unallowlisted raw fetch call(s) found:\n${details}`);
     }
     expect(violations).toEqual([]);
   });

--- a/tests/client/path-segments.test.ts
+++ b/tests/client/path-segments.test.ts
@@ -102,9 +102,9 @@
  *    So this check does not try to re-derive path safety for a raw `fetch` at
  *    all — that would mean tracing an arbitrary URL expression back through
  *    whatever built it, exactly the general-purpose data-flow analysis this
- *    whole sweep avoids. Instead it enumerates every bare `fetch(` call in the
- *    file, resolves its enclosing method and the exact source text of its URL
- *    argument, and requires that pair to match one of the hardcoded
+ *    whole sweep avoids. Instead it enumerates every `fetch` in the file,
+ *    resolves each one's enclosing method and the exact source text of its
+ *    URL argument, and requires that pair to match one of the hardcoded
  *    `RAW_FETCH_ALLOWLIST` entries — each one a human judgment call, made
  *    once, with a comment saying why that specific call is safe. A call in an
  *    unlisted method, or one whose URL expression no longer matches what the
@@ -114,6 +114,22 @@
  *    the file fails the suite even if it happens to reuse an
  *    already-allowlisted method and expression, which the allowlist match
  *    alone would not catch.
+ *
+ *    **Every `fetch`, not every `fetch(`.** This check first looked only for
+ *    a bare `fetch(` call, which made "the spellings someone thought to write
+ *    a pattern for" the working definition of a network sink. It is not one:
+ *    `globalThis.fetch(...)` reaches the network identically, and so does a
+ *    `fetch` stored in a variable and called through that name later, where
+ *    no pattern keyed on the call site can see it at all. Either one could
+ *    have carried the concatenated path above past all three checks with the
+ *    pinned count still reading 3. So the rule is inverted: every textual
+ *    occurrence of the identifier `fetch` is found, and anything that is not
+ *    one of the three reviewed bare calls is a violation on sight. The
+ *    allowlist is an inventory of approved *occurrences*, not of syntax.
+ *    `fetchAttachment` and other longer identifiers are unaffected, since
+ *    `\bfetch\b` does not match inside a word; string and template *text* is
+ *    blanked first (`blankStringLiterals`), because this client mentions
+ *    "fetch" in four ordinary strings and none of them is a network call.
  *
  * **Design is default-deny, and picks a direction to be wrong in.** Borrowed
  * directly from declared-dependencies.test.ts: a guard that quietly misses a
@@ -271,6 +287,8 @@ interface FetchCallSite {
   line: number;
   method: MethodStart;
   urlArg: Span | undefined;
+  /** False for any `fetch` that is not a bare `fetch(` call — see findRawFetchCallSites. */
+  isBareCall: boolean;
 }
 
 interface Violation {
@@ -997,28 +1015,132 @@ function findCallViolations(source: string): Violation[] {
 // past both in silence.
 
 /**
- * Every bare `fetch(` call in `masked` — not `this.request*`, not
- * `something.fetch(` — with its first (URL) argument located. The negative
- * lookbehind excludes a method call on some other object ending in `fetch`
- * and a hypothetical `this.fetch(`, neither of which occurs in this file
- * today; a plain identifier call is the only shape actually present at the
- * three real sites.
+ * Blank the *text* of every string and template literal in `masked`, keeping
+ * the quotes, the length and the newlines, so an index into the result still
+ * lines up with the same character in the input.
+ *
+ * Only the raw-fetch check below wants this. The other two checks read what
+ * is inside a template literal — that text is the request path — so they run
+ * on the comment-masked source with strings intact. The fetch check wants the
+ * opposite: `fetch` appears four times in this client inside ordinary strings
+ * (`error.message.includes("fetch")` three times and one timeout message),
+ * and none of those is a network sink.
+ *
+ * A `${...}` interpolation is copied through rather than blanked: the literal
+ * text around an expression is prose, but the expression itself is code and a
+ * call hiding there must stay visible. A nested template inside such an
+ * expression keeps its text visible too, which over-reports rather than
+ * under-reports — the direction this file always errs in.
  */
-function findRawFetchCallSites(masked: string, methodStarts: MethodStart[]): FetchCallSite[] {
-  const sites: FetchCallSite[] = [];
-  const pattern = /(?<![.\w$])fetch\s*\(/g;
-  let m: RegExpExecArray | null;
-  while ((m = pattern.exec(masked))) {
-    const openParenIndex = m.index + m[0].length - 1;
-    const args = parseCallArguments(masked, openParenIndex);
-    const line = masked.slice(0, m.index).split("\n").length;
-    const method = findEnclosingMethod(methodStarts, m.index);
+function blankStringLiterals(masked: string): string {
+  const out = masked.split("");
+  const blank = (i: number) => {
+    out[i] = masked[i] === "\n" ? "\n" : " ";
+  };
+  let i = 0;
+  while (i < masked.length) {
+    const ch = masked[i];
 
-    if (!method) {
-      sites.push({ index: m.index, line, method: { name: "(none)", index: -1 }, urlArg: undefined });
+    if (ch === '"' || ch === "'") {
+      i++;
+      while (i < masked.length && masked[i] !== ch) {
+        if (masked[i] === "\\") {
+          blank(i);
+          if (i + 1 < masked.length) blank(i + 1);
+          i += 2;
+          continue;
+        }
+        blank(i);
+        i++;
+      }
+      i++;
       continue;
     }
-    sites.push({ index: m.index, line, method, urlArg: args[0] });
+
+    if (ch === "`") {
+      i++;
+      while (i < masked.length && masked[i] !== "`") {
+        if (masked[i] === "\\") {
+          blank(i);
+          if (i + 1 < masked.length) blank(i + 1);
+          i += 2;
+          continue;
+        }
+        // `${` opens an expression: copy it through verbatim to the matching
+        // brace, so code inside an interpolation stays visible to the scan.
+        if (masked[i] === "$" && masked[i + 1] === "{") {
+          let depth = 0;
+          while (i < masked.length) {
+            if (masked[i] === "{") depth++;
+            else if (masked[i] === "}") {
+              depth--;
+              if (depth === 0) {
+                i++;
+                break;
+              }
+            }
+            i++;
+          }
+          continue;
+        }
+        blank(i);
+        i++;
+      }
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+  return out.join("");
+}
+
+/**
+ * Every occurrence of the identifier `fetch` in `masked` that is not inside a
+ * string literal, each classified as a bare `fetch(` call or not.
+ *
+ * The earlier version of this scan looked for a bare `fetch(` and nothing
+ * else, which quietly made "the shapes I thought to match" the definition of
+ * a network sink: `globalThis.fetch(...)`, `(0, fetch)(...)` and an aliased
+ * `const f = fetch` all reach the network and none of them matched, so a
+ * method using one could build a path by concatenating an unguarded id and
+ * pass all three checks. The pinned site count did not help either — an
+ * unmatched form leaves it unchanged.
+ *
+ * So the rule is inverted. Every textual `fetch` is found, and anything that
+ * is not one of the three reviewed bare calls is a violation on sight. That
+ * makes the allowlist an inventory of approved *occurrences* rather than of
+ * the syntax someone remembered to write a pattern for, and a new spelling
+ * fails loudly instead of passing silently. `fetchAttachment` and friends are
+ * untouched: `\bfetch\b` does not match inside a longer identifier.
+ */
+function findRawFetchCallSites(masked: string, methodStarts: MethodStart[]): FetchCallSite[] {
+  // Indices into codeOnly and masked agree: blankStringLiterals preserves
+  // length, so an argument span found here can be read back off masked, which
+  // still has the real text.
+  const codeOnly = blankStringLiterals(masked);
+  const sites: FetchCallSite[] = [];
+  const pattern = /\bfetch\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(codeOnly))) {
+    const line = codeOnly.slice(0, m.index).split("\n").length;
+    const method = findEnclosingMethod(methodStarts, m.index) ?? { name: "(none)", index: -1 };
+    const precededByDot = /[.?]\s*$/.test(codeOnly.slice(0, m.index));
+    const callAhead = /^\s*\(/.exec(codeOnly.slice(m.index + "fetch".length));
+
+    if (precededByDot || !callAhead) {
+      sites.push({ index: m.index, line, method, urlArg: undefined, isBareCall: false });
+      continue;
+    }
+
+    const openParenIndex = m.index + "fetch".length + callAhead[0].length - 1;
+    sites.push({
+      index: m.index,
+      line,
+      method,
+      urlArg: parseCallArguments(masked, openParenIndex)[0],
+      isBareCall: true,
+    });
   }
   return sites;
 }
@@ -1070,6 +1192,20 @@ function findRawFetchViolations(source: string): Violation[] {
 
   const violations: Violation[] = [];
   for (const site of sites) {
+    if (!site.isBareCall) {
+      violations.push({
+        line: site.line,
+        method: site.method.name,
+        expr: "(n/a)",
+        template: "fetch",
+        reason:
+          "an occurrence of `fetch` that is not one of the three reviewed bare calls — " +
+          "globalThis.fetch, a fetch stored in a variable, or any other spelling is not an " +
+          "approved network sink, and reaching the network through one would bypass every " +
+          "check in this file",
+      });
+      continue;
+    }
     if (site.method.index === -1) {
       violations.push({
         line: site.line,
@@ -1487,6 +1623,74 @@ describe("raw fetch scanner", () => {
     expect(violations).toHaveLength(1);
     expect(violations[0].method).toBe("fetchSomethingElse");
     expect(violations[0].reason).toMatch(/not on the allowlist/);
+  });
+
+  it("rejects globalThis.fetch, which the old bare-call pattern missed entirely", () => {
+    // The bypass this check was rewritten for. Every other control passes:
+    // the template's only interpolation is the guarded `slug`, there is no
+    // `this.request*` call to start a call-site check from, and the old
+    // `(?<![.\w$])fetch\s*\(` pattern refused to match a property access,
+    // so the dangerous concatenation reached the network unexamined.
+    const source = wrap(`
+  private async fetchWidget(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    const path = \`/\${slug}/boards/\` + boardId;
+    return globalThis.fetch(this.baseUrl + path);
+  }`);
+    expect(findTemplateViolations(source)).toEqual([]);
+    expect(findCallViolations(source)).toEqual([]);
+    const violations = findRawFetchViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].reason).toMatch(/not one of the three reviewed bare calls/);
+  });
+
+  it("rejects a fetch stored in a variable rather than called outright", () => {
+    // Aliasing separates the reference from the call, so no pattern keyed on
+    // `fetch(` can see the call site. Flagging the reference itself is what
+    // makes the shape of the call stop mattering.
+    const source = wrap(`
+  private async fetchWidget(url: string) {
+    const send = fetch;
+    return send(url);
+  }`);
+    const violations = findRawFetchViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].reason).toMatch(/not one of the three reviewed bare calls/);
+  });
+
+  it("ignores the word fetch inside a string or a template's literal text", () => {
+    // The real client says `error.message.includes("fetch")` three times and
+    // has a timeout message reading "Attachment fetch timed out". None is a
+    // network sink, and blanking string text is what keeps the inverted rule
+    // from flagging prose.
+    const source = wrap(`
+  private async request(url: string) {
+    try {
+      return await fetch(url);
+    } catch (error) {
+      if (error instanceof TypeError && error.message.includes("fetch")) {
+        throw new Error(\`fetch failed after \${this.timeout}ms\`);
+      }
+      throw error;
+    }
+  }`);
+    // The one real call is a bare call in an unlisted method, so exactly one
+    // violation — not four.
+    const violations = findRawFetchViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].reason).toMatch(/not on the allowlist/);
+  });
+
+  it("still sees a fetch inside a template interpolation", () => {
+    // Literal text in a template is prose and gets blanked; an expression
+    // inside `${...}` is code and must not be.
+    const source = wrap(`
+  private async fetchWidget(url: string) {
+    return \`result: \${globalThis.fetch(url)}\`;
+  }`);
+    const violations = findRawFetchViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].reason).toMatch(/not one of the three reviewed bare calls/);
   });
 
   it("accepts the three real call sites' own (method, url) shape", () => {

--- a/tests/client/path-segments.test.ts
+++ b/tests/client/path-segments.test.ts
@@ -1,7 +1,7 @@
 /**
- * A structural sweep of `src/client/fizzy-client.ts`: every request-path
- * template literal must interpolate only values this file can prove are safe
- * to drop into a URL path segment unguarded.
+ * A structural sweep of `src/client/fizzy-client.ts`: every request path this
+ * file can send to the Fizzy API must be provably built from values this
+ * scanner can prove are safe to drop into a URL path segment unguarded.
  *
  * This is what stops a method added later from silently skipping the guard —
  * without it, a new `getWidget(accountSlug, widgetId)` that forgets
@@ -10,24 +10,90 @@
  * `tests/tools/declared-dependencies.test.ts`: TypeScript 7 is the Go port and
  * ships no JavaScript compiler API, so this reads text rather than an AST.
  *
- * **Design is default-deny, and picks a direction to be wrong in.** For every
- * template that looks like a request path (a backtick string starting with
- * `` /${ ``), every one of its `${...}` interpolations must be provably either:
+ * **Two independent, additive checks, because each has a blind spot the other
+ * covers.**
  *
- *   (a) a name bound earlier in the *same* method by
- *       `const NAME = assertPathSegment(...)`, `this.normalizeSlug(...)` or
- *       `normalizeAccountSlug(...)` — or the method's own parameter named
- *       exactly `slug` (see "the `slug` parameter" below) — or
- *   (b) one of the small, explicitly listed exemptions: `ref.signedId`,
- *       `ref.variation`, `filename`, `queryString`, `requestedPage` — each
- *       justified at its call site in fizzy-client.ts.
+ * 1. **The call-site check** (`findCallViolations`) is the primary one, and it
+ *    inverts the sweep's original design: instead of looking for template
+ *    literals shaped like a path and hoping every path-issuing call happens to
+ *    use one, it starts at every call in this file to `this.request<...>(`,
+ *    `this.requestAllPages<...>(` and `this.requestWithMeta<...>(` — the only
+ *    three ways this file reaches the network — and demands the argument that
+ *    supplies the path be provably one of:
  *
- * Anything else — an expression this scanner does not recognise, or a
- * template it cannot attribute to any method — fails the test. It is never
- * silently skipped. Borrowed directly from declared-dependencies.test.ts: a
- * guard that quietly misses a case stops guarding and nobody finds out; a
- * guard that flags one case too many fails loudly and is fixed in a minute.
- * This scanner is built to make the second mistake, never the first.
+ *      (a) a template literal whose every `${...}` interpolation is one of the
+ *          exemptions below, or a name bound earlier in the *same* method by
+ *          `const NAME = assertPathSegment(...)`, `this.normalizeSlug(...)` or
+ *          `normalizeAccountSlug(...)` (or the method's own `slug` parameter —
+ *          see "the `slug` parameter" below);
+ *      (b) a plain string literal with no interpolation at all (`"/my/identity"`);
+ *      (c) a `const` local, bound in the same method, whose initializer is
+ *          itself (a) or (b) — including a ternary whose *both* branches are.
+ *          `getNotifications` is the real instance of this: it binds
+ *          `const path = <cond> ? \`/${slug}/notifications\` : \`/${slug}/notifications?page=${requestedPage}\``
+ *          and passes `path`.
+ *
+ *    Anything else — string concatenation, a call to a path-building helper, a
+ *    bare identifier the scanner cannot resolve to a qualifying `const`, a
+ *    `let` (guarded or not: see below) — is a violation. There is no escape
+ *    hatch for an unrecognised shape; the point is that it fails loudly and a
+ *    human looks, rather than the sweep silently deciding it is fine.
+ *
+ *    This is the check that closes what the template-only design originally
+ *    missed: a path built by `` `/${slug}/boards/` + boardId ``, or by
+ *    `this.request("GET", this.buildPath(boardId))`, builds no template that
+ *    starts where the old scan looked, so the old scan never saw it — the
+ *    unguarded `boardId` shipped and the pinned template *count* didn't even
+ *    move, because concatenation and a helper call are not templates at all.
+ *    Starting from the request call instead of the template closes that by
+ *    construction: every path-issuing call is found *because* it is a call to
+ *    one of the three request methods, not because its argument happens to
+ *    look like a path.
+ *
+ *    **What this check does not scan.** `request()` and `requestWithMeta()`
+ *    call each other (`request` forwards straight to `requestWithMeta`), and
+ *    `requestAllPages()` builds its own paginated URL from the `basePath` its
+ *    caller already supplied and calls `requestWithMeta` in turn. Those three
+ *    calls are the plumbing that *implements* the boundary this check inspects,
+ *    not new path construction — the value they forward was already proved at
+ *    its own call site, checked here like any other. Scanning them too would
+ *    require proving a bare function parameter safe with no local `const` to
+ *    point to, which is exactly the escape hatch this design refuses to add.
+ *    So a call site is only in scope for this check when it sits in a method
+ *    other than `request`, `requestWithMeta` or `requestAllPages` themselves.
+ *
+ * 2. **The template check** (`findTemplateViolations`) is additive and kept
+ *    for what the call-site check cannot see: a path-building method that is
+ *    not itself a call to `request`/`requestAllPages`/`requestWithMeta`.
+ *    `attachmentPath` is the live example — it returns a template consumed by
+ *    `fetchAttachment`, which reaches the network through a raw `fetch`, not
+ *    through this file's request layer, so no call-site scan would ever look
+ *    at it. This check instead sweeps every backtick template in the file
+ *    that looks path-shaped — contains both a `/` and a `${` — regardless of
+ *    where it starts, and proves its interpolations the same way. It used to
+ *    require the template to start with exactly `` /${ ``, which missed a
+ *    template with a literal prefix like `` `/accounts/${slug}/...` ``;
+ *    broadening the shape to "contains `/` and `${` anywhere" closes that
+ *    without narrowing anything it already caught — every template that
+ *    matched the old, narrower rule still starts with `/${` and so still
+ *    contains both markers.
+ *
+ * **Design is default-deny, and picks a direction to be wrong in.** Borrowed
+ * directly from declared-dependencies.test.ts: a guard that quietly misses a
+ * case stops guarding and nobody finds out; a guard that flags one case too
+ * many fails loudly and is fixed in a minute. Both checks here are built to
+ * make the second mistake, never the first — an expression shape neither
+ * recognises is a violation, not a pass.
+ *
+ * **Two independent counts are pinned**, not just the "no violations" result:
+ * the number of path-shaped templates (54) and the number of in-scope
+ * request-issuing call sites (52). A silent scanning regression — a shape
+ * that stops matching — would otherwise still report zero violations over
+ * fewer things checked. Pinning the *count* each scan actually walked is what
+ * turns "found nothing wrong" into "found nothing wrong in the right number of
+ * places"; a new call site or template changes one of these numbers no matter
+ * which construction shape it uses, and the count assertion is what catches
+ * that even before the safety assertion would.
  *
  * **The `slug` parameter.** `attachmentPath` takes an already-normalized slug
  * as a parameter literally named `slug` (never `accountSlug`) rather than
@@ -40,6 +106,34 @@
  * without requiring a fresh local assignment — this is a narrow, named
  * exception to rule (a), not a blanket one: a parameter named anything else,
  * `accountSlug` included, still needs a real local binding.
+ *
+ * **`let` is never a guard, reassigned or not.** A value guarded into a `let`
+ * (`let board = assertPathSegment(...)`) and never touched again is
+ * indistinguishable, to a text scanner, from one reassigned to something
+ * unguarded one line later — proving "never reassigned" would need real
+ * data-flow analysis, which a regex has no way to do. Rather than attempt
+ * that and risk getting it wrong, every guard pattern below requires `const`
+ * outright. `fizzy-client.ts` already binds every guarded value with `const`;
+ * if a future change genuinely needs a reassignable guarded local, that is a
+ * real gap in this scanner's design, not something to paper over by adding
+ * `let` back into the pattern.
+ *
+ * **What neither check can see.** Both read text, not an AST, so a shape
+ * outside what is enumerated above is a violation rather than a considered
+ * "no" — that is deliberate, but it also means a genuinely new *safe* shape
+ * (a third kind of guard function, a `switch` instead of a ternary, two levels
+ * of `const` chaining) will fail here and need this file extended, not just
+ * the production code. Neither check follows a value across methods or files:
+ * a guard applied in one method never covers a use in another, and a path
+ * built by something other than `fizzy-client.ts` — a caller of this client,
+ * or Fizzy's own server-side routing — is out of scope entirely. The
+ * interpolation regex (`\$\{([^}]*)\}`) stops at the first `}`, so an
+ * interpolation containing its own object literal would be split wrong; no
+ * such interpolation exists in this file today. And neither check re-verifies
+ * that `assertPathSegment`, `normalizeSlug` or `normalizeAccountSlug`
+ * themselves reject what they claim to — only that they were called; their
+ * own correctness is `src/utils/path-segment.ts`'s tests to own, not this
+ * file's.
  */
 
 import { describe, it, expect } from "vitest";
@@ -59,6 +153,10 @@ const EXEMPT_NAMES = new Set([
   "requestedPage",
 ]);
 
+/** The three methods a request path can reach the network through. */
+const REQUEST_METHOD_NAMES = ["requestAllPages", "requestWithMeta", "request"] as const;
+type RequestMethodName = (typeof REQUEST_METHOD_NAMES)[number];
+
 /** A `${...}` interpolation lifted out of a path template, still in raw text form. */
 interface Interpolation {
   expr: string;
@@ -75,6 +173,29 @@ interface PathTemplate {
 interface MethodStart {
   name: string;
   index: number;
+}
+
+/** A source-text span with its own start index, for guard-window lookups on whatever it contains. */
+interface Span {
+  text: string;
+  start: number;
+}
+
+/** One call in fizzy-client.ts to a request-issuing method, with its path argument (if found). */
+interface RequestCallSite {
+  index: number;
+  line: number;
+  callee: RequestMethodName;
+  method: MethodStart;
+  pathArg: Span | undefined;
+}
+
+interface Violation {
+  line: number;
+  method: string;
+  expr: string;
+  template: string;
+  reason: string;
 }
 
 /**
@@ -148,10 +269,10 @@ function blankComments(source: string): string {
  * spaces or more and never matches.
  *
  * This is deliberately *only* a start position, not a full body range: a
- * template is attributed to the closest preceding method-start, and the
- * guard search for a template runs from that method's start to the
- * template's own position. Finding a method's *end* would require reasoning
- * about TypeScript's grammar (a return-type object literal like
+ * template or call site is attributed to the closest preceding method-start,
+ * and any guard search runs from that method's start to the use's own
+ * position. Finding a method's *end* would require reasoning about
+ * TypeScript's grammar (a return-type object literal like
  * `(): { x: number } | null {` opens and closes a brace before the real body
  * does), which a text scanner cannot do reliably — and does not need to, since
  * "closest preceding start" is well-defined without it.
@@ -177,16 +298,30 @@ function findEnclosingMethod(methodStarts: MethodStart[], index: number): Method
   return best;
 }
 
+/** The index right after `class FizzyClient { ... {`'s opening brace, in `masked`. */
+function classBodyStartOf(masked: string): number {
+  const classMatch = /class\s+FizzyClient\b[^{]*\{/.exec(masked);
+  if (!classMatch) {
+    throw new Error("path-segments sweep: could not find `class FizzyClient { ... }`");
+  }
+  return classMatch.index + classMatch[0].length;
+}
+
 /**
- * Every backtick template in `masked` whose content starts with `` /${ `` —
- * the shape every request-path template in this file has, and no
- * non-path template (log lines, request ids, error messages) happens to
- * share. Templates in this file are single-line with no nested backtick, so a
- * plain "next backtick" scan delimits them correctly; a future template that
- * violated either assumption would either fail to match `` /${ `` (and so be
- * silently outside this sweep) or be caught by the total-count assertion
- * below, which cross-checks this function's count against one written
- * independently against the live class.
+ * Every backtick template in `masked` that looks path-shaped: its content
+ * contains both a `/` and a `${`. Templates in this file are single-line with
+ * no nested backtick, so a plain "next backtick" scan delimits them
+ * correctly; a future template that violated either assumption would either
+ * fail to match (and so be silently outside this sweep) or be caught by the
+ * total-count assertion below, which cross-checks this function's count
+ * against one written independently against the live class.
+ *
+ * Broadened from an earlier version that required the content to *start*
+ * with `` /${ ``: that missed a template with a literal prefix, like
+ * `` `/accounts/${slug}/boards/${boardId}` ``, which is exactly the shape a
+ * new endpoint might use. Every template that matched the old rule still
+ * starts with `/${` and so still contains both markers, so this is a strict
+ * widening — nothing previously caught stops being caught.
  */
 function findPathTemplates(masked: string): PathTemplate[] {
   const templates: PathTemplate[] = [];
@@ -194,7 +329,7 @@ function findPathTemplates(masked: string): PathTemplate[] {
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(masked))) {
     const raw = match[1];
-    if (!raw.startsWith("/${")) continue;
+    if (!(raw.includes("/") && raw.includes("${"))) continue;
     const interpolations = [...raw.matchAll(/\$\{([^}]*)\}/g)].map((m) => ({
       expr: m[1].trim(),
     }));
@@ -204,24 +339,15 @@ function findPathTemplates(masked: string): PathTemplate[] {
   return templates;
 }
 
-interface Violation {
-  line: number;
-  method: string;
-  expr: string;
-  template: string;
-  reason: string;
-}
-
 /**
- * Whether `expr`, interpolated inside `method` at `templateIndex`, is
- * provably safe — rule (a) or (b) from the module doc comment above.
+ * Whether `expr`, interpolated inside `method` at `boundary`, is provably
+ * safe — rule (a) or (b) from the module doc comment above. `boundary` is the
+ * position `expr`'s guard must textually precede — the start of the template
+ * or call argument it appears in, not necessarily the position of `${expr}`
+ * itself, matching how a `const` guard must precede the whole statement that
+ * uses it, not just the one interpolation.
  */
-function isProvenSafe(
-  masked: string,
-  method: MethodStart,
-  templateIndex: number,
-  expr: string
-): boolean {
+function isProvenSafe(masked: string, method: MethodStart, boundary: number, expr: string): boolean {
   if (EXEMPT_NAMES.has(expr)) return true;
 
   // Only a bare identifier can be traced to a local binding; a property
@@ -229,9 +355,10 @@ function isProvenSafe(
   // fails outright.
   if (!/^[A-Za-z_$][\w$]*$/.test(expr)) return false;
 
-  const window = masked.slice(method.index, templateIndex);
+  const window = masked.slice(method.index, boundary);
+  // `const` only — see "let is never a guard" in the module doc comment.
   const guardPattern = new RegExp(
-    `\\b(?:const|let)\\s+${expr}\\s*=\\s*(?:assertPathSegment|this\\.normalizeSlug|normalizeAccountSlug)\\s*\\(`
+    `\\bconst\\s+${expr}\\s*=\\s*(?:assertPathSegment|this\\.normalizeSlug|normalizeAccountSlug)\\s*\\(`
   );
   if (guardPattern.test(window)) return true;
 
@@ -246,15 +373,10 @@ function isProvenSafe(
   return false;
 }
 
-/** Run the sweep over `source` (the file content), returning every violation found. */
-function findGuardViolations(source: string): Violation[] {
+/** Run the template sweep over `source`, returning every violation found. */
+function findTemplateViolations(source: string): Violation[] {
   const masked = blankComments(source);
-  const classMatch = /class\s+FizzyClient\b[^{]*\{/.exec(masked);
-  if (!classMatch) {
-    throw new Error("path-segments sweep: could not find `class FizzyClient { ... }`");
-  }
-  const classBodyStart = classMatch.index + classMatch[0].length;
-  const methodStarts = findMethodStarts(masked, classBodyStart);
+  const methodStarts = findMethodStarts(masked, classBodyStartOf(masked));
   const templates = findPathTemplates(masked);
 
   const violations: Violation[] = [];
@@ -284,7 +406,382 @@ function findGuardViolations(source: string): Violation[] {
   return violations;
 }
 
-describe("scanner", () => {
+// ============ The call-site scan ============
+//
+// The functions below implement the primary check described at the top of
+// this file: find every call to `this.request(...)` / `this.requestAllPages(...)`
+// / `this.requestWithMeta(...)`, extract the argument that supplies the path,
+// and require it to be a template, a string literal, or a `const` bound to
+// one of those (directly, or via a ternary of both branches).
+
+/**
+ * Advance past a single- or double-quoted string, or a backtick template,
+ * starting at `s[start]` (one of `"`, `'`, `` ` ``). Returns the index just
+ * past the matching closing quote. Backslash escapes are honoured; a
+ * template's `${...}` interior is not parsed here — templates this scanner
+ * deals with are single-line with no nested backtick (see `blankComments`),
+ * so a "next matching quote" scan closes them correctly.
+ */
+function skipQuoted(s: string, start: number): number {
+  const quote = s[start];
+  let i = start + 1;
+  while (i < s.length && s[i] !== quote) {
+    if (s[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    i++;
+  }
+  return Math.min(i + 1, s.length);
+}
+
+/** `source.slice(start, end)` with surrounding whitespace trimmed, keeping the trimmed start index. */
+function sliceTrimmed(source: string, start: number, end: number): Span {
+  let s = start;
+  let e = end;
+  while (s < e && /\s/.test(source[s])) s++;
+  while (e > s && /\s/.test(source[e - 1])) e--;
+  return { text: source.slice(s, e), start: s };
+}
+
+/**
+ * Split a call's argument list into top-level, comma-separated arguments,
+ * given the index of its opening `(`. Tracks nesting depth across
+ * `()`/`[]`/`{}` and skips over string/template literals wholesale (via
+ * `skipQuoted`), so a comma inside an object-literal argument — `{ card: data }`
+ * — or inside a template's own text never splits an argument in two.
+ */
+function parseCallArguments(masked: string, openParenIndex: number): Span[] {
+  let i = openParenIndex + 1;
+  let depth = 0;
+  let currentStart = i;
+  const args: Span[] = [];
+  while (i < masked.length) {
+    const ch = masked[i];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      i = skipQuoted(masked, i);
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === ")" && depth === 0) {
+      args.push(sliceTrimmed(masked, currentStart, i));
+      return args;
+    }
+    if (ch === ")" || ch === "]" || ch === "}") {
+      depth--;
+      i++;
+      continue;
+    }
+    if (ch === "," && depth === 0) {
+      args.push(sliceTrimmed(masked, currentStart, i));
+      currentStart = i + 1;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  throw new Error("path-segments sweep: unterminated call (unbalanced parens)");
+}
+
+/**
+ * From `index`, skip whitespace, then an optional generic clause (`<T>`,
+ * depth-aware so `<FizzyCard[]>` closes correctly), then whitespace again.
+ * Returns the index of what should be the call's opening `(`.
+ */
+function skipOptionalGenericAndWhitespace(masked: string, index: number): number {
+  let i = index;
+  while (i < masked.length && /\s/.test(masked[i])) i++;
+  if (masked[i] === "<") {
+    let depth = 0;
+    while (i < masked.length) {
+      if (masked[i] === "<") depth++;
+      else if (masked[i] === ">") {
+        depth--;
+        i++;
+        if (depth === 0) break;
+        continue;
+      }
+      i++;
+    }
+  }
+  while (i < masked.length && /\s/.test(masked[i])) i++;
+  return i;
+}
+
+/** The index of the first top-level `;` at or after `start` (depth 0, outside any string/template), or -1. */
+function findTopLevelSemicolon(masked: string, start: number): number {
+  let i = start;
+  let depth = 0;
+  while (i < masked.length) {
+    const ch = masked[i];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      i = skipQuoted(masked, i);
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === ")" || ch === "]" || ch === "}") {
+      depth--;
+      i++;
+      continue;
+    }
+    if (ch === ";" && depth === 0) return i;
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Split `text` on its own top-level `? ... : ...`, if it has one at depth 0
+ * outside any string/template — e.g. `cond ? a : b`, but not `a?.b` or `a ?? b`.
+ * Only a single, unnested ternary is recognised: a branch that is itself
+ * another ternary is not split further and will fail `classifyPathExpr`'s
+ * literal/string check on the next call, which is the intended over-report —
+ * rule (c) in the module doc comment describes exactly one ternary level.
+ */
+function splitTopLevelTernary(text: string): { branch1: string; branch2: string } | null {
+  let depth = 0;
+  let qIndex = -1;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      i = skipQuoted(text, i) - 1;
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") {
+      depth++;
+      continue;
+    }
+    if (ch === ")" || ch === "]" || ch === "}") {
+      depth--;
+      continue;
+    }
+    if (depth === 0 && ch === "?" && text[i + 1] !== "." && text[i + 1] !== "?" && text[i - 1] !== "?") {
+      qIndex = i;
+      break;
+    }
+  }
+  if (qIndex === -1) return null;
+
+  let depth2 = 0;
+  let colonIndex = -1;
+  for (let i = qIndex + 1; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      i = skipQuoted(text, i) - 1;
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") {
+      depth2++;
+      continue;
+    }
+    if (ch === ")" || ch === "]" || ch === "}") {
+      depth2--;
+      continue;
+    }
+    if (depth2 === 0 && ch === ":") {
+      colonIndex = i;
+      break;
+    }
+  }
+  if (colonIndex === -1) return null;
+
+  return {
+    branch1: text.slice(qIndex + 1, colonIndex).trim(),
+    branch2: text.slice(colonIndex + 1).trim(),
+  };
+}
+
+/**
+ * Find `const name = <initializer>;`, the last such declaration textually
+ * before `positionOfUse` in `method` — i.e. the one actually in scope at the
+ * use — and return its initializer's text and start index. `let` never
+ * matches: see "`let` is never a guard" in the module doc comment. Returns
+ * null when no qualifying declaration exists in this method.
+ */
+function resolveConstInitializer(
+  masked: string,
+  method: MethodStart,
+  positionOfUse: number,
+  name: string
+): Span | null {
+  const window = masked.slice(method.index, positionOfUse);
+  const declPattern = new RegExp(`\\bconst\\s+${name}\\s*=\\s*`, "g");
+  let match: RegExpExecArray | null;
+  let last: RegExpExecArray | null = null;
+  while ((match = declPattern.exec(window))) last = match;
+  if (!last) return null;
+
+  const initStart = method.index + last.index + last[0].length;
+  const semicolonIndex = findTopLevelSemicolon(masked, initStart);
+  if (semicolonIndex === -1) return null;
+  return sliceTrimmed(masked, initStart, semicolonIndex);
+}
+
+interface Classification {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Whether `text` — the source text of a request call's path argument, a
+ * ternary branch, or a resolved `const` initializer — is one of the provably
+ * safe shapes from rule (a)/(b)/(c) in the module doc comment.
+ *
+ * `boundary` is passed through unchanged into ternary-branch recursion (both
+ * branches belong to the same statement, so the same guard window applies),
+ * and updated to the initializer's own start when resolving a `const` — a
+ * guard must precede the `const` statement that uses it, not merely the
+ * request call that eventually consumes the resolved value.
+ *
+ * `allowIdentifier` is true only for the top-level call argument: rule (c)
+ * resolves one `const` hop, not a chain, so a ternary branch or a resolved
+ * initializer that is itself a bare identifier is a violation, not a further
+ * lookup.
+ */
+function classifyPathExpr(
+  masked: string,
+  method: MethodStart,
+  text: string,
+  boundary: number,
+  allowTernary: boolean,
+  allowIdentifier: boolean
+): Classification {
+  if (text.length === 0) return { ok: false, reason: "empty path argument" };
+
+  if (text[0] === "`") {
+    if (skipQuoted(text, 0) !== text.length) {
+      return { ok: false, reason: "not a single template literal — likely string concatenation" };
+    }
+    const interpolations = [...text.matchAll(/\$\{([^}]*)\}/g)].map((m) => m[1].trim());
+    for (const expr of interpolations) {
+      if (!isProvenSafe(masked, method, boundary, expr)) {
+        return {
+          ok: false,
+          reason: `interpolation \${${expr}} is not a locally-guarded value and not on the exemption list`,
+        };
+      }
+    }
+    return { ok: true };
+  }
+
+  if (text[0] === '"' || text[0] === "'") {
+    if (skipQuoted(text, 0) !== text.length) {
+      return { ok: false, reason: "not a single string literal — likely string concatenation" };
+    }
+    return { ok: true };
+  }
+
+  if (allowTernary) {
+    const split = splitTopLevelTernary(text);
+    if (split) {
+      const left = classifyPathExpr(masked, method, split.branch1, boundary, false, false);
+      if (!left.ok) return { ok: false, reason: `ternary "then" branch: ${left.reason}` };
+      const right = classifyPathExpr(masked, method, split.branch2, boundary, false, false);
+      if (!right.ok) return { ok: false, reason: `ternary "else" branch: ${right.reason}` };
+      return { ok: true };
+    }
+  }
+
+  if (allowIdentifier && /^[A-Za-z_$][\w$]*$/.test(text)) {
+    const resolved = resolveConstInitializer(masked, method, boundary, text);
+    if (!resolved) {
+      return {
+        ok: false,
+        reason: `bare identifier "${text}" does not resolve to a \`const ${text} = ...\` bound earlier in this method`,
+      };
+    }
+    return classifyPathExpr(masked, method, resolved.text, resolved.start, true, false);
+  }
+
+  return {
+    ok: false,
+    reason: "not a template literal, a string literal, or a resolvable const — construction not recognised",
+  };
+}
+
+/**
+ * Every call in `masked` to `this.request<...>(`, `this.requestAllPages<...>(`
+ * or `this.requestWithMeta<...>(`, with its path argument located — arg 0 for
+ * `requestAllPages` (its only parameter), arg 1 for the other two (arg 0 is
+ * the HTTP method string). Excludes calls whose enclosing method is one of
+ * those same three names: see "what this check does not scan" in the module
+ * doc comment.
+ */
+function findRequestCallSites(masked: string, methodStarts: MethodStart[]): RequestCallSite[] {
+  const sites: RequestCallSite[] = [];
+  const pattern = /this\.(requestAllPages|requestWithMeta|request)\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(masked))) {
+    const callee = m[1] as RequestMethodName;
+    const openParenIndex = skipOptionalGenericAndWhitespace(masked, m.index + m[0].length);
+    if (masked[openParenIndex] !== "(") continue; // not actually a call — does not occur in this file today
+    const args = parseCallArguments(masked, openParenIndex);
+    const line = masked.slice(0, m.index).split("\n").length;
+    const method = findEnclosingMethod(methodStarts, m.index);
+
+    if (!method) {
+      sites.push({ index: m.index, line, callee, method: { name: "(none)", index: -1 }, pathArg: undefined });
+      continue;
+    }
+    if ((REQUEST_METHOD_NAMES as readonly string[]).includes(method.name)) continue;
+
+    const pathArgIndex = callee === "requestAllPages" ? 0 : 1;
+    sites.push({ index: m.index, line, callee, method, pathArg: args[pathArgIndex] });
+  }
+  return sites;
+}
+
+/** Run the call-site sweep over `source`, returning every violation found. */
+function findCallViolations(source: string): Violation[] {
+  const masked = blankComments(source);
+  const methodStarts = findMethodStarts(masked, classBodyStartOf(masked));
+  const sites = findRequestCallSites(masked, methodStarts);
+
+  const violations: Violation[] = [];
+  for (const site of sites) {
+    if (site.method.index === -1) {
+      violations.push({
+        line: site.line,
+        method: "(none)",
+        expr: "(n/a)",
+        template: `this.${site.callee}(...)`,
+        reason: "call could not be attributed to any method",
+      });
+      continue;
+    }
+    if (!site.pathArg) {
+      violations.push({
+        line: site.line,
+        method: site.method.name,
+        expr: "(n/a)",
+        template: `this.${site.callee}(...)`,
+        reason: `this.${site.callee} call is missing its path argument`,
+      });
+      continue;
+    }
+    const result = classifyPathExpr(masked, site.method, site.pathArg.text, site.pathArg.start, true, true);
+    if (!result.ok) {
+      violations.push({
+        line: site.line,
+        method: site.method.name,
+        expr: site.pathArg.text,
+        template: `this.${site.callee}(...)`,
+        reason: result.reason ?? "not provably safe",
+      });
+    }
+  }
+  return violations;
+}
+
+describe("template scanner", () => {
   // Each case below is a minimal class shaped like FizzyClient, so the
   // scanner is exercised the same way it will be against the real file: find
   // the class, find its methods, find its path templates, judge each
@@ -299,7 +796,7 @@ describe("scanner", () => {
     const board = assertPathSegment(boardId, "board_id");
     return this.request("GET", \`/\${slug}/boards/\${board}\`);
   }`);
-    expect(findGuardViolations(source)).toEqual([]);
+    expect(findTemplateViolations(source)).toEqual([]);
   });
 
   it("accepts a value guarded by a direct normalizeAccountSlug(...) call", () => {
@@ -308,7 +805,7 @@ describe("scanner", () => {
     const slug = normalizeAccountSlug(accountSlug);
     return this.request("GET", \`/\${slug}/boards\`);
   }`);
-    expect(findGuardViolations(source)).toEqual([]);
+    expect(findTemplateViolations(source)).toEqual([]);
   });
 
   it("rejects a value interpolated with no local guard at all", () => {
@@ -317,7 +814,7 @@ describe("scanner", () => {
     const slug = this.normalizeSlug(accountSlug);
     return this.request("GET", \`/\${slug}/boards/\${boardId}\`);
   }`);
-    const violations = findGuardViolations(source);
+    const violations = findTemplateViolations(source);
     expect(violations).toHaveLength(1);
     expect(violations[0]).toMatchObject({ method: "getBoard", expr: "boardId" });
   });
@@ -334,7 +831,7 @@ describe("scanner", () => {
     const slug = this.normalizeSlug(accountSlug);
     return this.request("DELETE", \`/\${slug}/boards/\${board}\`);
   }`);
-    const violations = findGuardViolations(source);
+    const violations = findTemplateViolations(source);
     expect(violations).toHaveLength(1);
     expect(violations[0]).toMatchObject({ method: "deleteBoard", expr: "board" });
   });
@@ -345,7 +842,7 @@ describe("scanner", () => {
     const slug = this.normalizeSlug(accountSlug);
     return this.request("GET", \`/\${slug}/things/\${${name}}\`);
   }`);
-    expect(findGuardViolations(source)).toEqual([]);
+    expect(findTemplateViolations(source)).toEqual([]);
   });
 
   it("accepts a method's own parameter literally named slug", () => {
@@ -354,7 +851,7 @@ describe("scanner", () => {
     const filename = encodeURIComponent(ref.filename);
     return \`/\${slug}/rails/active_storage/blobs/redirect/\${ref.signedId}/\${filename}\`;
   }`);
-    expect(findGuardViolations(source)).toEqual([]);
+    expect(findTemplateViolations(source)).toEqual([]);
   });
 
   it("does not extend the slug carve-out to a parameter named accountSlug", () => {
@@ -362,12 +859,12 @@ describe("scanner", () => {
   async getBoards(accountSlug: string) {
     return this.request("GET", \`/\${accountSlug}/boards\`);
   }`);
-    const violations = findGuardViolations(source);
+    const violations = findTemplateViolations(source);
     expect(violations).toHaveLength(1);
     expect(violations[0]).toMatchObject({ method: "getBoards", expr: "accountSlug" });
   });
 
-  it("ignores a template that does not start with /${ even if it interpolates a raw value", () => {
+  it("ignores a template with an interpolation but no / at all", () => {
     const source = wrap(`
   async getBoard(accountSlug: string, boardId: string) {
     this.log.debug(\`Fetching board \${boardId}\`);
@@ -375,7 +872,32 @@ describe("scanner", () => {
     const board = assertPathSegment(boardId, "board_id");
     return this.request("GET", \`/\${slug}/boards/\${board}\`);
   }`);
-    expect(findGuardViolations(source)).toEqual([]);
+    expect(findTemplateViolations(source)).toEqual([]);
+  });
+
+  it("ignores a template with a / but no interpolation at all", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    this.log.debug(\`GET /boards request starting\`);
+    const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
+    return this.request("GET", \`/\${slug}/boards/\${board}\`);
+  }`);
+    expect(findTemplateViolations(source)).toEqual([]);
+  });
+
+  it("catches a path-shaped template with a literal prefix, not only /${ ", () => {
+    // The shape the /${ -only rule used to miss entirely: a literal segment
+    // before the first interpolation. Broadening the match condition is what
+    // makes this template visible to the sweep at all.
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    return this.request("GET", \`/accounts/\${slug}/boards/\${boardId}\`);
+  }`);
+    const violations = findTemplateViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ method: "getBoard", expr: "boardId" });
   });
 
   it("fails a template it cannot attribute to any method, rather than skipping it", () => {
@@ -388,7 +910,7 @@ describe("scanner", () => {
   }
 }
 `;
-    const violations = findGuardViolations(source);
+    const violations = findTemplateViolations(source);
     expect(violations).toHaveLength(1);
     expect(violations[0].reason).toMatch(/could not be attributed/);
   });
@@ -408,7 +930,128 @@ describe("scanner", () => {
     const board = assertPathSegment(boardId, "board_id");
     return this.request("GET", \`/\${slug}/boards/\${board}\`);
   }`);
-    expect(findGuardViolations(source)).toEqual([]);
+    expect(findTemplateViolations(source)).toEqual([]);
+  });
+});
+
+describe("call-site scanner", () => {
+  // Same fixture shape as the template-scanner suite above, exercising
+  // findCallViolations instead: find the class, find its request calls,
+  // classify each one's path argument.
+  const wrap = (body: string) => `class FizzyClient {\n${body}\n}\n`;
+
+  it("rejects a path built by string concatenation", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    return this.request("GET", \`/\${slug}/boards/\` + boardId);
+  }`);
+    const violations = findCallViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].method).toBe("getBoard");
+    expect(violations[0].reason).toMatch(/concatenation/);
+  });
+
+  it("rejects a template with a literal prefix that interpolates an unguarded id", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    return this.request("GET", \`/accounts/\${slug}/boards/\${boardId}\`);
+  }`);
+    const violations = findCallViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].method).toBe("getBoard");
+    expect(violations[0].reason).toContain("boardId");
+  });
+
+  it("rejects a path routed through an intermediate helper call", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    const board = assertPathSegment(boardId, "board_id");
+    return this.request("GET", this.buildPath(board));
+  }`);
+    const violations = findCallViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].method).toBe("getBoard");
+    expect(violations[0].reason).toMatch(/not recognised/);
+  });
+
+  it("rejects a value guarded into a let and reassigned before use", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    let board = assertPathSegment(boardId, "board_id");
+    board = boardId;
+    return this.request("GET", \`/\${slug}/boards/\${board}\`);
+  }`);
+    const violations = findCallViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].method).toBe("getBoard");
+    expect(violations[0].reason).toContain("board");
+  });
+
+  it("rejects a request call whose path argument is a bare unresolvable identifier", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string): Promise<unknown> {
+    return this.request("GET", somePath);
+  }`);
+    const violations = findCallViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].method).toBe("getBoard");
+    expect(violations[0].reason).toMatch(/does not resolve/);
+  });
+
+  it("accepts a const path bound to a ternary of two guarded templates", () => {
+    // getNotifications's real shape: page 1 must stay page-less, so the path
+    // is chosen by a ternary rather than always carrying a query string.
+    const source = wrap(`
+  async getNotifications(accountSlug: string, requestedPage: number): Promise<unknown> {
+    const slug = this.normalizeSlug(accountSlug);
+    const path =
+      requestedPage === 1
+        ? \`/\${slug}/notifications\`
+        : \`/\${slug}/notifications?page=\${requestedPage}\`;
+    return this.request("GET", path);
+  }`);
+    expect(findCallViolations(source)).toEqual([]);
+  });
+
+  it("accepts a plain string-literal path with no interpolation", () => {
+    const source = wrap(`
+  async getIdentity(): Promise<unknown> {
+    return this.request("GET", "/my/identity");
+  }`);
+    expect(findCallViolations(source)).toEqual([]);
+  });
+
+  it("accepts requestAllPages's single basePath argument directly", () => {
+    const source = wrap(`
+  async getBoards(accountSlug: string): Promise<unknown[]> {
+    const slug = this.normalizeSlug(accountSlug);
+    return this.requestAllPages(\`/\${slug}/boards\`);
+  }`);
+    expect(findCallViolations(source)).toEqual([]);
+  });
+
+  it("does not require request()/requestWithMeta()'s own mutual forwarding to prove a const", () => {
+    // request() forwards its own `path` parameter straight to
+    // requestWithMeta() — plumbing underneath the boundary this check
+    // inspects, not new construction. See "what this check does not scan" in
+    // the module doc comment.
+    const source = wrap(`
+  private async request(method: string, path: string, body?: unknown) {
+    const { data } = await this.requestWithMeta(method, path, body);
+    return data;
+  }
+
+  private async requestWithMeta(method: string, path: string, body?: unknown) {
+    return { data: null, meta: undefined };
+  }
+
+  async getIdentity(): Promise<unknown> {
+    return this.request("GET", "/my/identity");
+  }`);
+    expect(findCallViolations(source)).toEqual([]);
   });
 });
 
@@ -416,24 +1059,47 @@ describe("path segment guards on FizzyClient", () => {
   const source = readFileSync(clientPath, "utf8");
 
   it("finds the path-like templates the real file actually has", () => {
-    // Guards the sweep itself: a scanner that matched nothing would make the
-    // assertion below pass vacuously. 54 templates carry the 55 guarded
-    // interpolations (plus account_slug and the five exemptions): a template
-    // can hold more than one, so the template count and the guarded-value
-    // count are not the same number — e.g. removeReaction's single template
-    // interpolates card, comment and reaction together.
+    // Guards the template sweep itself: a scanner that matched nothing would
+    // make the assertion below pass vacuously. 54 templates carry the 55
+    // guarded interpolations (plus account_slug and the five exemptions): a
+    // template can hold more than one, so the template count and the
+    // guarded-value count are not the same number — e.g. removeReaction's
+    // single template interpolates card, comment and reaction together.
     const masked = blankComments(source);
     const templates = findPathTemplates(masked);
     expect(templates.length).toBe(54);
   });
 
-  it("proves every interpolation in every request-path template safe", () => {
-    const violations = findGuardViolations(source);
+  it("finds the request-issuing call sites the real file actually has", () => {
+    // Guards the call-site sweep the same way: a scanner that stopped
+    // matching request calls would make the assertion below pass vacuously.
+    // 52 is every call to request()/requestAllPages()/requestWithMeta() in a
+    // method other than those three themselves — see "what this check does
+    // not scan" in the module doc comment for the two calls this excludes.
+    const masked = blankComments(source);
+    const methodStarts = findMethodStarts(masked, classBodyStartOf(masked));
+    const sites = findRequestCallSites(masked, methodStarts);
+    expect(sites.length).toBe(52);
+  });
+
+  it("proves every interpolation in every path-shaped template safe", () => {
+    const violations = findTemplateViolations(source);
     if (violations.length > 0) {
       const details = violations
         .map((v) => `  line ${v.line} (${v.method}): \${${v.expr}} in ${v.template} — ${v.reason}`)
         .join("\n");
       throw new Error(`Unguarded path-segment interpolation(s) found:\n${details}`);
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("proves every request call's path argument safe", () => {
+    const violations = findCallViolations(source);
+    if (violations.length > 0) {
+      const details = violations
+        .map((v) => `  line ${v.line} (${v.method}): ${v.template} argument \`${v.expr}\` — ${v.reason}`)
+        .join("\n");
+      throw new Error(`Unproven request path argument(s) found:\n${details}`);
     }
     expect(violations).toEqual([]);
   });

--- a/tests/client/path-segments.test.ts
+++ b/tests/client/path-segments.test.ts
@@ -120,16 +120,28 @@
  *    a pattern for" the working definition of a network sink. It is not one:
  *    `globalThis.fetch(...)` reaches the network identically, and so does a
  *    `fetch` stored in a variable and called through that name later, where
- *    no pattern keyed on the call site can see it at all. Either one could
- *    have carried the concatenated path above past all three checks with the
- *    pinned count still reading 3. So the rule is inverted: every textual
- *    occurrence of the identifier `fetch` is found, and anything that is not
- *    one of the three reviewed bare calls is a violation on sight. The
- *    allowlist is an inventory of approved *occurrences*, not of syntax.
- *    `fetchAttachment` and other longer identifiers are unaffected, since
- *    `\bfetch\b` does not match inside a word; string and template *text* is
- *    blanked first (`blankStringLiterals`), because this client mentions
- *    "fetch" in four ordinary strings and none of them is a network call.
+ *    no pattern keyed on the call site can see it at all. Either could have
+ *    carried the concatenated path above past all three checks with the
+ *    pinned count still reading 3.
+ *
+ *    The first attempt at a fix kept the call-shape idea and added a literal
+ *    parser, so string text could be blanked before scanning. That was the
+ *    wrong move twice over: `globalThis["fetch"](url)` hid the identifier
+ *    inside a string the parser then erased, and a `}` inside a string inside
+ *    a `${...}` expression closed the interpolation early and blanked real
+ *    code — a blind spot, which is the direction that actually hurts. The
+ *    lesson is that a text scanner cannot out-parse source written to evade
+ *    it, so it should not try.
+ *
+ *    So the rule is inverted and the parser is gone. Every textual occurrence
+ *    of `fetch` is found — prose included — and each one must be accounted
+ *    for by name: the three reviewed calls in `RAW_FETCH_ALLOWLIST`, the four
+ *    prose mentions in `FETCH_MENTIONS`. The allowlist is an inventory of
+ *    approved *occurrences*, not of syntax. That is simpler and stricter at
+ *    once: `globalThis["fetch"]` now fails on the unlisted string it hides
+ *    in, and there is no parser left to have a blind spot. `fetchAttachment`
+ *    and other longer identifiers are unaffected, since `\bfetch\b` does not
+ *    match inside a word.
  *
  * **Design is default-deny, and picks a direction to be wrong in.** Borrowed
  * directly from declared-dependencies.test.ts: a guard that quietly misses a
@@ -225,6 +237,18 @@
  * reviewed, so a rewritten (but still textually matching) implementation of
  * an allowlisted method could in principle drift unsafe without tripping this
  * check at all.
+ *
+ * **And none of it survives a contributor who is actively evading it.** These
+ * checks read the same source the contributor writes, so anything that hides
+ * the identifier from a regex — a Unicode escape (`\u0066etch`), a name
+ * assembled at runtime, an import aliased to something else — defeats them,
+ * and so does deleting this file. That is not a gap to be closed by a
+ * cleverer pattern; it is what a static text check over attacker-controlled
+ * source fundamentally is. The threat this file actually defends against is
+ * the realistic one: a contributor adding an endpoint who does not know the
+ * guard exists, or a refactor that quietly drops it. Against that it is
+ * strong, and it should not be described — in a review, a PR, or a later
+ * commit message — as more than that.
  */
 
 import { describe, it, expect } from "vitest";
@@ -1015,118 +1039,36 @@ function findCallViolations(source: string): Violation[] {
 // past both in silence.
 
 /**
- * Blank the *text* of every string and template literal in `masked`, keeping
- * the quotes, the length and the newlines, so an index into the result still
- * lines up with the same character in the input.
+ * Every occurrence of the identifier `fetch` in `masked`, each classified as
+ * a bare `fetch(` call or not.
  *
- * Only the raw-fetch check below wants this. The other two checks read what
- * is inside a template literal — that text is the request path — so they run
- * on the comment-masked source with strings intact. The fetch check wants the
- * opposite: `fetch` appears four times in this client inside ordinary strings
- * (`error.message.includes("fetch")` three times and one timeout message),
- * and none of those is a network sink.
+ * There is no attempt to tell code from string text here, and that is
+ * deliberate. An earlier version blanked string and template literals first
+ * so the scan would not trip over the four places this client legitimately
+ * says "fetch" in prose — but a hand-written literal parser is exactly the
+ * wrong tool: `globalThis["fetch"](url)` hid the identifier inside a string
+ * the parser then erased, and a `}` inside a string inside a `${...}`
+ * expression ended the interpolation early and blanked real code. Each fix
+ * revealed another spelling, because a text scanner cannot out-parse source
+ * that is trying to evade it.
  *
- * A `${...}` interpolation is copied through rather than blanked: the literal
- * text around an expression is prose, but the expression itself is code and a
- * call hiding there must stay visible. A nested template inside such an
- * expression keeps its text visible too, which over-reports rather than
- * under-reports — the direction this file always errs in.
- */
-function blankStringLiterals(masked: string): string {
-  const out = masked.split("");
-  const blank = (i: number) => {
-    out[i] = masked[i] === "\n" ? "\n" : " ";
-  };
-  let i = 0;
-  while (i < masked.length) {
-    const ch = masked[i];
-
-    if (ch === '"' || ch === "'") {
-      i++;
-      while (i < masked.length && masked[i] !== ch) {
-        if (masked[i] === "\\") {
-          blank(i);
-          if (i + 1 < masked.length) blank(i + 1);
-          i += 2;
-          continue;
-        }
-        blank(i);
-        i++;
-      }
-      i++;
-      continue;
-    }
-
-    if (ch === "`") {
-      i++;
-      while (i < masked.length && masked[i] !== "`") {
-        if (masked[i] === "\\") {
-          blank(i);
-          if (i + 1 < masked.length) blank(i + 1);
-          i += 2;
-          continue;
-        }
-        // `${` opens an expression: copy it through verbatim to the matching
-        // brace, so code inside an interpolation stays visible to the scan.
-        if (masked[i] === "$" && masked[i + 1] === "{") {
-          let depth = 0;
-          while (i < masked.length) {
-            if (masked[i] === "{") depth++;
-            else if (masked[i] === "}") {
-              depth--;
-              if (depth === 0) {
-                i++;
-                break;
-              }
-            }
-            i++;
-          }
-          continue;
-        }
-        blank(i);
-        i++;
-      }
-      i++;
-      continue;
-    }
-
-    i++;
-  }
-  return out.join("");
-}
-
-/**
- * Every occurrence of the identifier `fetch` in `masked` that is not inside a
- * string literal, each classified as a bare `fetch(` call or not.
- *
- * The earlier version of this scan looked for a bare `fetch(` and nothing
- * else, which quietly made "the shapes I thought to match" the definition of
- * a network sink: `globalThis.fetch(...)`, `(0, fetch)(...)` and an aliased
- * `const f = fetch` all reach the network and none of them matched, so a
- * method using one could build a path by concatenating an unguarded id and
- * pass all three checks. The pinned site count did not help either — an
- * unmatched form leaves it unchanged.
- *
- * So the rule is inverted. Every textual `fetch` is found, and anything that
- * is not one of the three reviewed bare calls is a violation on sight. That
- * makes the allowlist an inventory of approved *occurrences* rather than of
- * the syntax someone remembered to write a pattern for, and a new spelling
- * fails loudly instead of passing silently. `fetchAttachment` and friends are
- * untouched: `\bfetch\b` does not match inside a longer identifier.
+ * So the parser is gone. Every textual `fetch` is an occurrence, prose
+ * included, and every occurrence has to be accounted for by name — the three
+ * reviewed calls in `RAW_FETCH_ALLOWLIST`, the four prose mentions in
+ * `FETCH_MENTIONS`. That is simpler *and* stricter: `globalThis["fetch"]`
+ * now fails on the string `"fetch"` nobody listed, and there is no parser
+ * left to have a blind spot. `fetchAttachment` and other longer identifiers
+ * are unaffected, since `\bfetch\b` does not match inside a word.
  */
 function findRawFetchCallSites(masked: string, methodStarts: MethodStart[]): FetchCallSite[] {
-  // Indices into codeOnly and masked agree: blankStringLiterals preserves
-  // length, so an argument span found here can be read back off masked, which
-  // still has the real text.
-  const codeOnly = blankStringLiterals(masked);
   const sites: FetchCallSite[] = [];
   const pattern = /\bfetch\b/g;
   let m: RegExpExecArray | null;
-  while ((m = pattern.exec(codeOnly))) {
-    const line = codeOnly.slice(0, m.index).split("\n").length;
+  while ((m = pattern.exec(masked))) {
+    const line = masked.slice(0, m.index).split("\n").length;
     const method = findEnclosingMethod(methodStarts, m.index) ?? { name: "(none)", index: -1 };
-    const precededByDot = /[.?]\s*$/.test(codeOnly.slice(0, m.index));
-    const callAhead = /^\s*\(/.exec(codeOnly.slice(m.index + "fetch".length));
+    const precededByDot = /[.?]\s*$/.test(masked.slice(0, m.index));
+    const callAhead = /^\s*\(/.exec(masked.slice(m.index + "fetch".length));
 
     if (precededByDot || !callAhead) {
       sites.push({ index: m.index, line, method, urlArg: undefined, isBareCall: false });
@@ -1144,6 +1086,36 @@ function findRawFetchCallSites(masked: string, methodStarts: MethodStart[]): Fet
   }
   return sites;
 }
+
+/**
+ * The occurrences of `fetch` in this client that are not calls at all: three
+ * `error.message.includes("fetch")` guards and one timeout message. Keyed by
+ * method with a count, so a new mention in an already-listed method still
+ * moves a number and fails.
+ *
+ * Listing prose alongside calls is the price of having no literal parser, and
+ * it is a low one: four entries, each obviously not a network call, against a
+ * scan with nowhere left to be blind.
+ */
+const FETCH_MENTIONS: ReadonlyArray<{ method: string; count: number; reason: string }> = [
+  {
+    method: "executeRequestWithMeta",
+    count: 1,
+    reason: 'error.message.includes("fetch") — classifying a TypeError as a network failure.',
+  },
+  {
+    method: "putBlobToStorage",
+    count: 1,
+    reason: 'error.message.includes("fetch") — the same classification on the upload path.',
+  },
+  {
+    method: "fetchAttachment",
+    count: 2,
+    reason:
+      'the same includes("fetch") classification, plus the "Attachment fetch timed out" ' +
+      "message in the template literal above it.",
+  },
+];
 
 /**
  * Every raw `fetch(` call this file is allowed to make, keyed by the
@@ -1190,19 +1162,32 @@ function findRawFetchViolations(source: string): Violation[] {
   const methodStarts = findMethodStarts(masked, classBodyStartOf(masked));
   const sites = findRawFetchCallSites(masked, methodStarts);
 
+  // Spent down as each listed prose mention is matched, so an extra mention
+  // in an already-listed method is a violation rather than a free pass.
+  const mentionBudget = new Map(FETCH_MENTIONS.map((e) => [e.method, e.count]));
+
   const violations: Violation[] = [];
   for (const site of sites) {
     if (!site.isBareCall) {
+      // Not a call: either prose accounted for in FETCH_MENTIONS, or a
+      // spelling nobody reviewed — globalThis.fetch, globalThis["fetch"], a
+      // fetch stored in a variable. The budget is spent per method below, so
+      // a mention beyond the listed count lands here too.
+      const budget = mentionBudget.get(site.method.name);
+      if (budget !== undefined && budget > 0) {
+        mentionBudget.set(site.method.name, budget - 1);
+        continue;
+      }
       violations.push({
         line: site.line,
         method: site.method.name,
         expr: "(n/a)",
         template: "fetch",
         reason:
-          "an occurrence of `fetch` that is not one of the three reviewed bare calls — " +
-          "globalThis.fetch, a fetch stored in a variable, or any other spelling is not an " +
-          "approved network sink, and reaching the network through one would bypass every " +
-          "check in this file",
+          "an occurrence of `fetch` that is neither one of the three reviewed bare calls " +
+          "nor a listed prose mention — globalThis.fetch, globalThis[\"fetch\"], a fetch " +
+          "stored in a variable and any other spelling reach the network without being " +
+          "seen by any other check in this file",
       });
       continue;
     }
@@ -1641,7 +1626,7 @@ describe("raw fetch scanner", () => {
     expect(findCallViolations(source)).toEqual([]);
     const violations = findRawFetchViolations(source);
     expect(violations).toHaveLength(1);
-    expect(violations[0].reason).toMatch(/not one of the three reviewed bare calls/);
+    expect(violations[0].reason).toMatch(/neither one of the three reviewed bare calls nor a listed prose mention/);
   });
 
   it("rejects a fetch stored in a variable rather than called outright", () => {
@@ -1655,30 +1640,48 @@ describe("raw fetch scanner", () => {
   }`);
     const violations = findRawFetchViolations(source);
     expect(violations).toHaveLength(1);
-    expect(violations[0].reason).toMatch(/not one of the three reviewed bare calls/);
+    expect(violations[0].reason).toMatch(/neither one of the three reviewed bare calls nor a listed prose mention/);
   });
 
-  it("ignores the word fetch inside a string or a template's literal text", () => {
+  it("counts prose as an occurrence, so an unlisted mention is a violation", () => {
     // The real client says `error.message.includes("fetch")` three times and
-    // has a timeout message reading "Attachment fetch timed out". None is a
-    // network sink, and blanking string text is what keeps the inverted rule
-    // from flagging prose.
+    // has an "Attachment fetch timed out" message; those are accounted for by
+    // name in FETCH_MENTIONS. In a method nobody listed, the same prose is a
+    // violation — which is exactly what makes globalThis["fetch"] fail, since
+    // it hides the identifier in a string too.
     const source = wrap(`
-  private async request(url: string) {
+  private async sendWidget(url: string) {
     try {
       return await fetch(url);
     } catch (error) {
       if (error instanceof TypeError && error.message.includes("fetch")) {
-        throw new Error(\`fetch failed after \${this.timeout}ms\`);
+        throw new Error("request failed");
       }
       throw error;
     }
   }`);
-    // The one real call is a bare call in an unlisted method, so exactly one
-    // violation — not four.
+    const violations = findRawFetchViolations(source);
+    // Two: the unlisted bare call, and the unlisted prose mention.
+    expect(violations).toHaveLength(2);
+    expect(violations.map((v) => v.method)).toEqual(["sendWidget", "sendWidget"]);
+  });
+
+  it("rejects a computed-property fetch, which hides the identifier in a string", () => {
+    // globalThis["fetch"](url) reaches the network with no bare `fetch(`
+    // anywhere. An earlier version of this check blanked string text before
+    // scanning and so erased the only evidence; counting prose is what closes
+    // it, with no parser to get wrong.
+    const source = wrap(`
+  private async fetchWidget(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    const path = \`/\${slug}/boards/\` + boardId;
+    return globalThis["fetch"](this.baseUrl + path);
+  }`);
+    expect(findTemplateViolations(source)).toEqual([]);
+    expect(findCallViolations(source)).toEqual([]);
     const violations = findRawFetchViolations(source);
     expect(violations).toHaveLength(1);
-    expect(violations[0].reason).toMatch(/not on the allowlist/);
+    expect(violations[0].reason).toMatch(/neither one of the three reviewed bare calls nor a listed prose mention/);
   });
 
   it("still sees a fetch inside a template interpolation", () => {
@@ -1690,7 +1693,7 @@ describe("raw fetch scanner", () => {
   }`);
     const violations = findRawFetchViolations(source);
     expect(violations).toHaveLength(1);
-    expect(violations[0].reason).toMatch(/not one of the three reviewed bare calls/);
+    expect(violations[0].reason).toMatch(/neither one of the three reviewed bare calls nor a listed prose mention/);
   });
 
   it("accepts the three real call sites' own (method, url) shape", () => {
@@ -1760,16 +1763,20 @@ describe("path segment guards on FizzyClient", () => {
     expect(violations).toEqual([]);
   });
 
-  it("finds the raw fetch calls the real file actually has", () => {
+  it("finds every fetch occurrence the real file actually has", () => {
     // Guards the raw-fetch sweep the same way the two counts above guard
-    // their own scans: a pattern that stopped matching `fetch(` would make
-    // the allowlist assertion below pass vacuously over zero call sites. 3 is
-    // executeRequestWithMeta, putBlobToStorage and fetchAttachment — see
-    // check 3 in the module doc comment.
+    // their own scans: a pattern that stopped matching would make the
+    // allowlist assertion below pass vacuously over zero occurrences. 7 is
+    // every `fetch` outside a comment — the three calls in
+    // executeRequestWithMeta, putBlobToStorage and fetchAttachment, plus the
+    // four prose mentions listed in FETCH_MENTIONS. Prose is counted because
+    // there is no literal parser to exclude it; see check 3 in the module doc
+    // comment for why that is the point rather than a shortcoming.
     const masked = blankComments(source);
     const methodStarts = findMethodStarts(masked, classBodyStartOf(masked));
     const sites = findRawFetchCallSites(masked, methodStarts);
-    expect(sites.length).toBe(3);
+    expect(sites.length).toBe(7);
+    expect(sites.filter((site) => site.isBareCall)).toHaveLength(3);
   });
 
   it("proves every raw fetch call is on the allowlist", () => {

--- a/tests/client/path-segments.test.ts
+++ b/tests/client/path-segments.test.ts
@@ -1,0 +1,440 @@
+/**
+ * A structural sweep of `src/client/fizzy-client.ts`: every request-path
+ * template literal must interpolate only values this file can prove are safe
+ * to drop into a URL path segment unguarded.
+ *
+ * This is what stops a method added later from silently skipping the guard —
+ * without it, a new `getWidget(accountSlug, widgetId)` that forgets
+ * `assertPathSegment` would compile, pass every other test, and reopen the
+ * exact traversal this file exists to close. Follows the precedent of
+ * `tests/tools/declared-dependencies.test.ts`: TypeScript 7 is the Go port and
+ * ships no JavaScript compiler API, so this reads text rather than an AST.
+ *
+ * **Design is default-deny, and picks a direction to be wrong in.** For every
+ * template that looks like a request path (a backtick string starting with
+ * `` /${ ``), every one of its `${...}` interpolations must be provably either:
+ *
+ *   (a) a name bound earlier in the *same* method by
+ *       `const NAME = assertPathSegment(...)`, `this.normalizeSlug(...)` or
+ *       `normalizeAccountSlug(...)` — or the method's own parameter named
+ *       exactly `slug` (see "the `slug` parameter" below) — or
+ *   (b) one of the small, explicitly listed exemptions: `ref.signedId`,
+ *       `ref.variation`, `filename`, `queryString`, `requestedPage` — each
+ *       justified at its call site in fizzy-client.ts.
+ *
+ * Anything else — an expression this scanner does not recognise, or a
+ * template it cannot attribute to any method — fails the test. It is never
+ * silently skipped. Borrowed directly from declared-dependencies.test.ts: a
+ * guard that quietly misses a case stops guarding and nobody finds out; a
+ * guard that flags one case too many fails loudly and is fixed in a minute.
+ * This scanner is built to make the second mistake, never the first.
+ *
+ * **The `slug` parameter.** `attachmentPath` takes an already-normalized slug
+ * as a parameter literally named `slug` (never `accountSlug`) rather than
+ * normalizing it itself — its one call site, `fetchAttachment`, computes it
+ * via `this.normalizeSlug` first. This file's convention is to spell an
+ * already-normalized value `slug` and a raw one `accountSlug`; grepping the
+ * file for `slug:` as a parameter type turns up exactly these two spots
+ * (`normalizeSlug` itself, which does the normalizing, and `attachmentPath`).
+ * So a method's own parameter named exactly `slug` is recognised as safe
+ * without requiring a fresh local assignment — this is a narrow, named
+ * exception to rule (a), not a blanket one: a parameter named anything else,
+ * `accountSlug` included, still needs a real local binding.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const clientPath = join(repoRoot, "src", "client", "fizzy-client.ts");
+
+/** Names that need no local guard — each justified where it appears in fizzy-client.ts. */
+const EXEMPT_NAMES = new Set([
+  "ref.signedId",
+  "ref.variation",
+  "filename",
+  "queryString",
+  "requestedPage",
+]);
+
+/** A `${...}` interpolation lifted out of a path template, still in raw text form. */
+interface Interpolation {
+  expr: string;
+}
+
+/** A path-shaped template literal and where it sits in the (comment-blanked) source. */
+interface PathTemplate {
+  index: number;
+  line: number;
+  raw: string;
+  interpolations: Interpolation[];
+}
+
+interface MethodStart {
+  name: string;
+  index: number;
+}
+
+/**
+ * Blank `//` and `/* *‍/` comments to spaces (newlines kept, so line numbers
+ * stay meaningful), leaving every string and template literal untouched.
+ *
+ * Reused verbatim from the reasoning in declared-dependencies.test.ts's own
+ * `maskSource`: comments have to go before anything structural is counted, or
+ * a JSDoc `{@link Foo}` reads as a brace and a doc comment mentioning a URL
+ * reads as the start of a real one. Strings and templates are copied through
+ * rather than masked, because the next pass needs to read what is actually
+ * inside them.
+ */
+function blankComments(source: string): string {
+  let out = "";
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+
+    if (ch === "/" && next === "/") {
+      while (i < source.length && source[i] !== "\n") {
+        out += " ";
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === "/" && next === "*") {
+      out += "  ";
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) {
+        out += source[i] === "\n" ? "\n" : " ";
+        i++;
+      }
+      out += "  ";
+      i += 2;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      out += ch;
+      i++;
+      while (i < source.length && source[i] !== quote) {
+        if (source[i] === "\\") {
+          out += source[i] + (source[i + 1] ?? "");
+          i += 2;
+          continue;
+        }
+        out += source[i];
+        i++;
+      }
+      out += source[i] ?? "";
+      i++;
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+/**
+ * Every top-level class-member declaration in `masked`, from `searchFrom`
+ * onward: `identifier(`, optionally preceded by `private`/`static`/`async`/…
+ * and followed by an optional single generic parameter (`<T>`), anchored to
+ * exactly two leading spaces of indentation — the class's own member
+ * indentation in this file. A statement inside a method body is indented four
+ * spaces or more and never matches.
+ *
+ * This is deliberately *only* a start position, not a full body range: a
+ * template is attributed to the closest preceding method-start, and the
+ * guard search for a template runs from that method's start to the
+ * template's own position. Finding a method's *end* would require reasoning
+ * about TypeScript's grammar (a return-type object literal like
+ * `(): { x: number } | null {` opens and closes a brace before the real body
+ * does), which a text scanner cannot do reliably — and does not need to, since
+ * "closest preceding start" is well-defined without it.
+ */
+function findMethodStarts(masked: string, searchFrom: number): MethodStart[] {
+  const pattern =
+    /^ {2}(?:(?:private|public|protected|static|async|readonly)\s+)*([A-Za-z_$][\w$]*)\s*(?:<[^>]*>)?\s*\(/gm;
+  pattern.lastIndex = searchFrom;
+  const starts: MethodStart[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(masked))) {
+    starts.push({ name: match[1], index: match.index });
+  }
+  return starts;
+}
+
+/** The method whose declaration most closely precedes `index`, or undefined if none does. */
+function findEnclosingMethod(methodStarts: MethodStart[], index: number): MethodStart | undefined {
+  let best: MethodStart | undefined;
+  for (const start of methodStarts) {
+    if (start.index <= index && (!best || start.index > best.index)) best = start;
+  }
+  return best;
+}
+
+/**
+ * Every backtick template in `masked` whose content starts with `` /${ `` —
+ * the shape every request-path template in this file has, and no
+ * non-path template (log lines, request ids, error messages) happens to
+ * share. Templates in this file are single-line with no nested backtick, so a
+ * plain "next backtick" scan delimits them correctly; a future template that
+ * violated either assumption would either fail to match `` /${ `` (and so be
+ * silently outside this sweep) or be caught by the total-count assertion
+ * below, which cross-checks this function's count against one written
+ * independently against the live class.
+ */
+function findPathTemplates(masked: string): PathTemplate[] {
+  const templates: PathTemplate[] = [];
+  const pattern = /`([^`]*)`/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(masked))) {
+    const raw = match[1];
+    if (!raw.startsWith("/${")) continue;
+    const interpolations = [...raw.matchAll(/\$\{([^}]*)\}/g)].map((m) => ({
+      expr: m[1].trim(),
+    }));
+    const line = masked.slice(0, match.index).split("\n").length;
+    templates.push({ index: match.index, line, raw, interpolations });
+  }
+  return templates;
+}
+
+interface Violation {
+  line: number;
+  method: string;
+  expr: string;
+  template: string;
+  reason: string;
+}
+
+/**
+ * Whether `expr`, interpolated inside `method` at `templateIndex`, is
+ * provably safe — rule (a) or (b) from the module doc comment above.
+ */
+function isProvenSafe(
+  masked: string,
+  method: MethodStart,
+  templateIndex: number,
+  expr: string
+): boolean {
+  if (EXEMPT_NAMES.has(expr)) return true;
+
+  // Only a bare identifier can be traced to a local binding; a property
+  // access or anything more complex either matches an exemption above or
+  // fails outright.
+  if (!/^[A-Za-z_$][\w$]*$/.test(expr)) return false;
+
+  const window = masked.slice(method.index, templateIndex);
+  const guardPattern = new RegExp(
+    `\\b(?:const|let)\\s+${expr}\\s*=\\s*(?:assertPathSegment|this\\.normalizeSlug|normalizeAccountSlug)\\s*\\(`
+  );
+  if (guardPattern.test(window)) return true;
+
+  // The `slug` parameter carve-out described in the module doc comment,
+  // narrowly matched on the exact name and a `slug: string` parameter
+  // declaration in this method's own signature.
+  if (expr === "slug") {
+    const signatureWindow = masked.slice(method.index, method.index + 400);
+    if (/\bslug\s*:\s*string\b/.test(signatureWindow)) return true;
+  }
+
+  return false;
+}
+
+/** Run the sweep over `source` (the file content), returning every violation found. */
+function findGuardViolations(source: string): Violation[] {
+  const masked = blankComments(source);
+  const classMatch = /class\s+FizzyClient\b[^{]*\{/.exec(masked);
+  if (!classMatch) {
+    throw new Error("path-segments sweep: could not find `class FizzyClient { ... }`");
+  }
+  const classBodyStart = classMatch.index + classMatch[0].length;
+  const methodStarts = findMethodStarts(masked, classBodyStart);
+  const templates = findPathTemplates(masked);
+
+  const violations: Violation[] = [];
+  for (const template of templates) {
+    const method = findEnclosingMethod(methodStarts, template.index);
+    if (!method) {
+      violations.push({
+        line: template.line,
+        method: "(none)",
+        expr: "(n/a)",
+        template: template.raw,
+        reason: "template could not be attributed to any method",
+      });
+      continue;
+    }
+    for (const { expr } of template.interpolations) {
+      if (isProvenSafe(masked, method, template.index, expr)) continue;
+      violations.push({
+        line: template.line,
+        method: method.name,
+        expr,
+        template: template.raw,
+        reason: "not a locally-guarded value and not on the exemption list",
+      });
+    }
+  }
+  return violations;
+}
+
+describe("scanner", () => {
+  // Each case below is a minimal class shaped like FizzyClient, so the
+  // scanner is exercised the same way it will be against the real file: find
+  // the class, find its methods, find its path templates, judge each
+  // interpolation. A scanner nobody has tested against known-good and
+  // known-bad input is a scanner that can silently stop scanning.
+  const wrap = (body: string) => `class FizzyClient {\n${body}\n}\n`;
+
+  it("accepts a value guarded by assertPathSegment in the same method", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
+    return this.request("GET", \`/\${slug}/boards/\${board}\`);
+  }`);
+    expect(findGuardViolations(source)).toEqual([]);
+  });
+
+  it("accepts a value guarded by a direct normalizeAccountSlug(...) call", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string) {
+    const slug = normalizeAccountSlug(accountSlug);
+    return this.request("GET", \`/\${slug}/boards\`);
+  }`);
+    expect(findGuardViolations(source)).toEqual([]);
+  });
+
+  it("rejects a value interpolated with no local guard at all", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    return this.request("GET", \`/\${slug}/boards/\${boardId}\`);
+  }`);
+    const violations = findGuardViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ method: "getBoard", expr: "boardId" });
+  });
+
+  it("does not let a guard in one method cover an interpolation in another", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
+    return this.request("GET", \`/\${slug}/boards/\${board}\`);
+  }
+
+  async deleteBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    return this.request("DELETE", \`/\${slug}/boards/\${board}\`);
+  }`);
+    const violations = findGuardViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ method: "deleteBoard", expr: "board" });
+  });
+
+  it.each([...EXEMPT_NAMES])("accepts the exempt name %s with no local guard", (name) => {
+    const source = wrap(`
+  async getThing(accountSlug: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    return this.request("GET", \`/\${slug}/things/\${${name}}\`);
+  }`);
+    expect(findGuardViolations(source)).toEqual([]);
+  });
+
+  it("accepts a method's own parameter literally named slug", () => {
+    const source = wrap(`
+  private attachmentPath(slug: string, ref: AttachmentRef) {
+    const filename = encodeURIComponent(ref.filename);
+    return \`/\${slug}/rails/active_storage/blobs/redirect/\${ref.signedId}/\${filename}\`;
+  }`);
+    expect(findGuardViolations(source)).toEqual([]);
+  });
+
+  it("does not extend the slug carve-out to a parameter named accountSlug", () => {
+    const source = wrap(`
+  async getBoards(accountSlug: string) {
+    return this.request("GET", \`/\${accountSlug}/boards\`);
+  }`);
+    const violations = findGuardViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ method: "getBoards", expr: "accountSlug" });
+  });
+
+  it("ignores a template that does not start with /${ even if it interpolates a raw value", () => {
+    const source = wrap(`
+  async getBoard(accountSlug: string, boardId: string) {
+    this.log.debug(\`Fetching board \${boardId}\`);
+    const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
+    return this.request("GET", \`/\${slug}/boards/\${board}\`);
+  }`);
+    expect(findGuardViolations(source)).toEqual([]);
+  });
+
+  it("fails a template it cannot attribute to any method, rather than skipping it", () => {
+    const source = `class FizzyClient {
+  static readonly BASE = \`/\${badGlobal}/boards\`;
+
+  async getBoard(accountSlug: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    return this.request("GET", \`/\${slug}/boards\`);
+  }
+}
+`;
+    const violations = findGuardViolations(source);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].reason).toMatch(/could not be attributed/);
+  });
+
+  it("does not get confused by a return-type object literal before the real body", () => {
+    // getCacheStats()/parsePaginationMeta() in the real file have this shape:
+    // a `{ ... }` object type in the return position, before the body's own
+    // `{`. The scanner only needs each method's *start*, never its end, so
+    // this shape cannot desynchronise it the way finding a body's end would.
+    const source = wrap(`
+  getStats(): { count: number } | null {
+    return null;
+  }
+
+  async getBoard(accountSlug: string, boardId: string) {
+    const slug = this.normalizeSlug(accountSlug);
+    const board = assertPathSegment(boardId, "board_id");
+    return this.request("GET", \`/\${slug}/boards/\${board}\`);
+  }`);
+    expect(findGuardViolations(source)).toEqual([]);
+  });
+});
+
+describe("path segment guards on FizzyClient", () => {
+  const source = readFileSync(clientPath, "utf8");
+
+  it("finds the path-like templates the real file actually has", () => {
+    // Guards the sweep itself: a scanner that matched nothing would make the
+    // assertion below pass vacuously. 54 templates carry the 55 guarded
+    // interpolations (plus account_slug and the five exemptions): a template
+    // can hold more than one, so the template count and the guarded-value
+    // count are not the same number — e.g. removeReaction's single template
+    // interpolates card, comment and reaction together.
+    const masked = blankComments(source);
+    const templates = findPathTemplates(masked);
+    expect(templates.length).toBe(54);
+  });
+
+  it("proves every interpolation in every request-path template safe", () => {
+    const violations = findGuardViolations(source);
+    if (violations.length > 0) {
+      const details = violations
+        .map((v) => `  line ${v.line} (${v.method}): \${${v.expr}} in ${v.template} — ${v.reason}`)
+        .join("\n");
+      throw new Error(`Unguarded path-segment interpolation(s) found:\n${details}`);
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/utils/path-segment.test.ts
+++ b/tests/utils/path-segment.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The path-segment containment guard every non-slug id in fizzy-client.ts is
+ * checked with.
+ *
+ * Mirrors tests/utils/account-slug.test.ts: this is the shared rule, so its
+ * own behaviour is asserted here once, and tests/client/fizzy-client.test.ts
+ * and tests/client/path-segments.test.ts assert that the client actually
+ * calls it everywhere it needs to.
+ */
+
+import { describe, it, expect } from "vitest";
+import { assertPathSegment } from "../../src/utils/path-segment.js";
+
+describe("assertPathSegment", () => {
+  it("returns a bare value unchanged", () => {
+    expect(assertPathSegment("123456", "board_id")).toBe("123456");
+  });
+
+  it("accepts a 25-character base36 id — the shape every real Fizzy id has", () => {
+    // Fabricated, not a real id: base36-encoded UUIDv7, 25 characters from
+    // [0-9a-z]. See utils/path-segment.ts for where this shape is confirmed.
+    const id = "0000000000000000000000abc";
+    expect(id).toHaveLength(25);
+    expect(assertPathSegment(id, "board_id")).toBe(id);
+  });
+
+  it("accepts a plain card number", () => {
+    // Card paths resolve by number, not by id — a small plain integer.
+    expect(assertPathSegment("42", "card_number")).toBe("42");
+  });
+
+  it("accepts the full character set a path segment may legitimately use", () => {
+    expect(assertPathSegment("abc-DEF_123.456~789", "board_id")).toBe(
+      "abc-DEF_123.456~789"
+    );
+  });
+
+  it.each([
+    ["empty", ""],
+    ["the current directory", "."],
+    ["a parent traversal", ".."],
+  ])("rejects %s", (_label, value) => {
+    expect(() => assertPathSegment(value, "board_id")).toThrow(/board_id/);
+  });
+
+  it.each([
+    ["extra path segments", "123456/cards"],
+    ["an embedded traversal", "123456/../999999"],
+    ["a query string", "123456?admin=1"],
+    ["a fragment", "123456#x"],
+    ["an encoded separator", "123456%2Fcards"],
+    ["a backslash", "123456\\cards"],
+    ["whitespace", "123 456"],
+    ["a newline", "123456\ncards"],
+  ])("rejects %s", (_label, value) => {
+    expect(() => assertPathSegment(value, "board_id")).toThrow(/board_id/);
+  });
+
+  it("rejects a value over the length cap", () => {
+    expect(() => assertPathSegment("a".repeat(257), "board_id")).toThrow(/board_id/);
+  });
+
+  it("accepts a value at exactly the length cap", () => {
+    const value = "a".repeat(256);
+    expect(assertPathSegment(value, "board_id")).toBe(value);
+  });
+
+  it("names the MCP-facing argument in the message, not the value", () => {
+    expect(() => assertPathSegment("../cards/42", "card_number")).toThrow(/card_number/);
+  });
+
+  it("does not leak the rejected value back to the caller", () => {
+    // The message is returned to the model verbatim; echoing the input would
+    // reflect whatever the caller sent into the tool result.
+    const secret = "https://evil.example/x?leaked=1";
+    try {
+      assertPathSegment(secret, "board_id");
+      throw new Error("expected assertPathSegment to throw");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).not.toContain(secret);
+      expect(message).not.toContain("evil.example");
+    }
+  });
+});

--- a/tsconfig.cloudflare.json
+++ b/tsconfig.cloudflare.json
@@ -31,6 +31,7 @@
     "src/utils/file-source.ts",
     "src/utils/md5.ts",
     "src/utils/origin.ts",
+    "src/utils/path-segment.ts",
     "src/utils/projections.ts",
     "src/utils/search-terms.ts"
   ],


### PR DESCRIPTION
Every `FizzyClient` method builds its request path by interpolating caller-supplied ids
straight into a template:

```ts
return this.request<FizzyBoard>("GET", `/${slug}/boards/${boardId}`);
```

`account_slug` was pinned to a single path segment in #85. The 55 other interpolations —
`board_id`, `card_number`, `card_id`, `comment_id`, `step_id`, `reaction_id`, `user_id`,
`column_id`, `notification_id` — were not. An id that escapes its segment retargets the
request: `getBoard("123456", "../cards/42")` builds `/123456/boards/../cards/42`, and
`fetch` resolves the dot segments before sending, so the request that actually goes out is
`/123456/cards/42` and nothing downstream sees the traversal. An id containing `/` grafts
extra segments on; `?` or `#` truncates the rest of the path into a query or fragment.

These values arrive as MCP tool arguments, so they are model-supplied. The Cloudflare
transport dispatches tool arguments without running Zod at all, so the client is the only
enforcement point on that path.

## A containment guard, not a shape pin

The issue assumed no single pattern could work — card numbers being integers while other
ids are ULID-like — and proposed confirming each id's shape and pinning it. Checking
upstream showed the premise doesn't hold:

- Every resource id is a base36-encoded UUIDv7, **exactly 25 characters of `[0-9a-z]`**
  (`lib/rails_ext/active_record_uuid_type.rb`: `hex.to_i(16).to_s(36).rjust(25, "0")`,
  with `BASE36_LENGTH = 25 # 36^25 > 2^128`). Confirmed at each controller's
  `.find(params[:id])`.
- Card routes resolve by **number**, an integer: `cards_controller.rb` does
  `find_by!(number: params[:id])`, and `Card#to_param` returns `number.to_s`.

Both shapes sit strictly inside `[0-9a-z]`, so one conservative guard covers them. Pinning
exact shapes was rejected deliberately: it would hard-code upstream's current id encoding
into this client, and `card_id` has no unambiguous shape to pin anyway (see #87).

`assertPathSegment` therefore rejects `""`, `"."`, `".."` and anything outside
`[A-Za-z0-9._~-]`, with a length cap. What matters is what it excludes — `/` and `\` cannot
introduce a segment, `%` cannot smuggle an encoded one, `?` and `#` cannot truncate the
path — which is the same reasoning `SIGNED_TOKEN_PATTERN` already uses for signed ids. It
never echoes the rejected value, and names the MCP-facing argument, since these messages
reach the model verbatim.

## Keeping it applied

55 call sites is enough that a method added later could quietly skip the guard, so
`tests/client/path-segments.test.ts` checks that it hasn't. Three default-deny scans:

1. **Call sites** — every `request` / `requestAllPages` / `requestWithMeta` call must pass a
   path that is a guarded template, a plain string literal, or a `const` bound to one.
   Concatenation, helper calls and unresolvable identifiers are violations, so a new path
   is covered whatever syntax it uses.
2. **Templates** — for the one path a call-site scan structurally cannot see:
   `attachmentPath` returns a path consumed by a raw `fetch`.
3. **`fetch` occurrences** — every textual `fetch` must be an approved occurrence, three
   reviewed calls plus four prose mentions. Counting prose is why no literal parser is
   needed, and why `globalThis["fetch"]` fails on the unlisted string it hides in.

Counts are pinned alongside the violation assertions, so a scan that silently stopped
matching can't pass by checking nothing.

The file documents what these checks *cannot* do, which matters more than what they can:
they read the same source a contributor writes, so a Unicode-escaped identifier or a
runtime-assembled name defeats them, as does deleting the file. They defend against the
realistic case — someone adding an endpoint who doesn't know the guard exists — and are
described as no more than that.

## Also here

- `account_slug.ts`'s doc comment no longer describes the other ids as unguarded.
- Seven id descriptions in `schemas.ts` said "numeric string, e.g. '12345'". They're
  25-character base36 ids, and these descriptions ship to every client in `tools/list`, so
  the inaccuracy actively misleads the model. `card_id` and `card_number` are left alone —
  that's #87.

## Verification

`npm test` 1031 passing, `typecheck`, `typecheck:cf`, `test:cloudflare` (124) and `build`
all clean. The 5 failures in `sse-multi-user` / `security-warnings` are the known
port-3100 collision with a foreign process, unrelated to this change.

Also run against the live API using this branch's own build: real board ids, column and
card lookups and comment fetches all still work, while `../cards/42`, `..`, `42/comments`
and `a?b=c` are refused before any request is issued — the failures are the guard's
messages, not upstream 404s.

Fixes #86. Related: #87, which this deliberately does not address.
